### PR TITLE
feat(fle-64): support sudo password for SSH commands

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,57 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            /code-review --comment ${{ github.event.pull_request.number }}
+            Perform a code review for PR ${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Follow these steps precisely:
+
+            1. Use a Haiku agent to check if the PR is (a) closed, (b) a draft, (c) an automated PR that does not need review, or (d) already reviewed by you. If so, stop.
+            2. Use a Haiku agent to list relevant CLAUDE.md file paths (root + directories touched by the PR).
+            3. Use a Haiku agent to view the PR and return a summary of the change.
+            4. Launch 5 parallel Sonnet agents to independently review the change:
+               a. Agent 1: Audit compliance with CLAUDE.md (only instructions applicable to written code, not to Claude workflow).
+               b. Agent 2: Scan the diff for obvious bugs. Focus on large bugs; ignore nitpicks and false positives.
+               c. Agent 3: Read git blame and history of modified code; identify bugs in that historical context.
+               d. Agent 4: Read previous PRs that touched these files; check if prior review comments apply here too.
+               e. Agent 5: Read code comments in modified files; verify changes comply with any guidance in those comments.
+               Each agent returns a list of issues with the reason each was flagged.
+            5. For each issue from step 4, launch a parallel Haiku agent to score confidence (0-100):
+               - 0: False positive, does not survive light scrutiny, or pre-existing issue.
+               - 25: Might be real but unverified; or stylistic and not called out in CLAUDE.md.
+               - 50: Real but minor; unlikely to matter in practice.
+               - 75: Verified, will be hit in practice, important — or directly mentioned in CLAUDE.md.
+               - 100: Certain, frequent, directly evidenced.
+            6. Discard issues with score below 80. If none remain, post "No issues found." and stop.
+            7. Re-run the eligibility check from step 1.
+            8. Post ONE consolidated comment on the PR using "gh pr comment". Use exactly this format:
+
+            ---
+            ## Code Review: <PR title>
+
+            ### 🔴 Must Fix
+            <numbered list — security issues, data loss, crashes, or CLAUDE.md hard requirements. Omit section if empty.>
+
+            ### 🟡 Should Fix
+            <numbered list — bugs, correctness issues, important design problems. Omit section if empty.>
+
+            ### 💡 Suggestions (non-blocking)
+            <numbered list — design improvements, minor inconsistencies. Omit section if empty.>
+
+            ### ✅ What Looks Good
+            - <bullet per notable strength or well-implemented area>
+
+            ### Test Coverage Gaps
+            - <bullet per missing test case worth adding. Omit section if none.>
+
+            Generated with Claude Code
+            ---
+
+            Rules for the comment:
+            - Each finding: bold short title, dash, one-sentence description. See filename:line with full-SHA link.
+            - Full SHA links only (no HEAD refs): https://github.com/OWNER/REPO/blob/SHA/path/to/file#L10-L15
+            - Do NOT post separate inline comments as the primary output. Inline comments are permitted only as supplementary references after the consolidated comment is posted.
+            - Assign severity: 🔴 for security/data loss/CLAUDE.md hard requirements, 🟡 for bugs/correctness, 💡 for design suggestions.
+            - False positives to exclude: pre-existing issues, linter/compiler catches, missing imports, type errors, issues on unmodified lines.
+
           claude_args: |
-            --model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model claude-opus-4-6 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh search:*)"

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -241,10 +241,15 @@ func (m Model) fetchServiceDetail(unit string) func() tea.Msg {
 			"(%s show '%s' --property=Id,Description,LoadState,ActiveState,SubState,MainPID,MemoryCurrent,TasksCurrent,ActiveEnterTimestamp,UnitFileState --no-pager; echo '---LOGS---'; %s '%s' --no-pager -n 50 -q --reverse 2>/dev/null) | cat",
 			sysctl, shellQuote(unit), journal, shellQuote(unit),
 		)
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "service_detail", "host_idx", idx, "unit", unit, "err", err)
-			return fetchServiceDetailMsg{err: fmt.Errorf("service detail: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchServiceDetailMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "service_detail", "host_idx", idx, "unit", unit, "err", err)
+				return fetchServiceDetailMsg{err: fmt.Errorf("service detail: %w", err)}
+			}
 		}
 
 		parts := strings.SplitN(out, "---LOGS---", 2)
@@ -371,8 +376,11 @@ func (m Model) fetchLogLevels() func() tea.Msg {
 			`sudo journalctl --since '%s' --no-pager -q -o json --output-fields=PRIORITY 2>/dev/null | awk -F'"' '/PRIORITY/{a[$4]++} END{for(i=0;i<=6;i++) print a[i]+0}'`,
 			since,
 		)
-		out, err := sm.RunCommand(idx, cmd)
+		out, err := sm.RunSudoCommand(idx, cmd)
 		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchLogLevelsMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
 			logger.Error("fetch failed", "view", "log_levels", "host_idx", idx, "err", err)
 			return fetchLogLevelsMsg{err: fmt.Errorf("log levels: %w", err)}
 		}
@@ -428,8 +436,11 @@ func (m Model) fetchErrorLogs() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "error_logs", "host_idx", idx, "level", level)
 		cmd := fmt.Sprintf("(sudo journalctl -p %s --since '%s' --no-pager -q -o short --no-hostname --reverse 2>/dev/null | head -500) | cat", level, since)
-		out, err := sm.RunCommand(idx, cmd)
+		out, err := sm.RunSudoCommand(idx, cmd)
 		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchErrorLogsMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
 			logger.Error("fetch failed", "view", "error_logs", "host_idx", idx, "err", err)
 			return fetchErrorLogsMsg{err: fmt.Errorf("error logs: %w", err)}
 		}
@@ -586,10 +597,15 @@ func (m Model) fetchSubscription() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "subscription", "host_idx", idx)
 		cmd := `echo '===IDENTITY===' && sudo subscription-manager identity 2>&1 && echo '===STATUS===' && sudo subscription-manager status 2>&1 && echo '===SERVER===' && sudo subscription-manager config --list 2>&1 | grep 'hostname' | head -1 && echo '===REPOS===' && dnf repolist --enabled 2>&1 && echo '===REPOCHECK===' && for repo in $(dnf repolist --enabled -q 2>/dev/null | tail -n+2 | awk '{print $1}'); do (echo "REPO:$repo:$(dnf repoinfo --disablerepo='*' --enablerepo=$repo 2>&1 | grep -c 'Error:')") & done; wait`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && !strings.Contains(out, "===IDENTITY===") {
-			logger.Error("fetch failed", "view", "subscription", "host_idx", idx, "err", err)
-			return fetchSubscriptionMsg{err: fmt.Errorf("subscription: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchSubscriptionMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if !strings.Contains(out, "===IDENTITY===") {
+				logger.Error("fetch failed", "view", "subscription", "host_idx", idx, "err", err)
+				return fetchSubscriptionMsg{err: fmt.Errorf("subscription: %w", err)}
+			}
 		}
 
 		var subs []config.Subscription
@@ -788,10 +804,15 @@ func (m Model) fetchAccountDetail(user string) func() tea.Msg {
 			`echo '===IDENTITY===' && id '%s' 2>&1 && echo '===PASSWORD===' && (sudo chage -l '%s' 2>/dev/null || echo 'Managed by IPA') && echo '===LOGIN===' && (lastlog -u '%s' 2>/dev/null | tail -1 || echo 'N/A') && echo '===SUDO===' && sudo -l -U '%s' 2>/dev/null`,
 			u, u, u, u,
 		)
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "account_detail", "host_idx", idx, "user", user, "err", err)
-			return fetchAccountDetailMsg{err: fmt.Errorf("account detail: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchAccountDetailMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "account_detail", "host_idx", idx, "user", user, "err", err)
+				return fetchAccountDetailMsg{err: fmt.Errorf("account detail: %w", err)}
+			}
 		}
 
 		var sections []accountDetailSection
@@ -902,10 +923,15 @@ func (m Model) fetchNetworkInfo() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "network_info", "host_idx", idx)
 		cmd := `ip route 2>/dev/null | wc -l && if systemctl is-active firewalld >/dev/null 2>&1; then echo "firewalld"; (firewall-cmd --list-all-zones 2>/dev/null | grep -cE 'services:|ports:' || echo 0); elif command -v nft >/dev/null 2>&1 && nft list ruleset 2>/dev/null | grep -q 'chain'; then echo "nftables"; (nft list ruleset 2>/dev/null | grep -c 'rule' || echo 0); else echo "iptables"; (sudo iptables -L -n 2>/dev/null | tail -n+3 | grep -cv '^$' || echo 0); fi`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "network_info", "host_idx", idx, "err", err)
-			return fetchNetworkInfoMsg{err: fmt.Errorf("network info: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchNetworkInfoMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "network_info", "host_idx", idx, "err", err)
+				return fetchNetworkInfoMsg{err: fmt.Errorf("network info: %w", err)}
+			}
 		}
 
 		lines := strings.Split(strings.TrimSpace(out), "\n")
@@ -1121,10 +1147,15 @@ func (m Model) fetchFirewall() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "firewall", "host_idx", idx)
 		cmd := `if systemctl is-active firewalld >/dev/null 2>&1; then echo '---FIREWALLD---'; sudo firewall-cmd --list-all-zones 2>/dev/null; elif command -v nft >/dev/null 2>&1; then _nft=$(sudo nft list ruleset 2>/dev/null); if echo "$_nft" | grep -q 'chain'; then echo '---NFTABLES---'; echo "$_nft"; else echo '---IPTABLES---'; sudo iptables -L -n --line-numbers 2>/dev/null; fi; else echo '---IPTABLES---'; sudo iptables -L -n --line-numbers 2>/dev/null; fi`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "firewall", "host_idx", idx, "err", err)
-			return fetchFirewallMsg{err: fmt.Errorf("firewall: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchFirewallMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "firewall", "host_idx", idx, "err", err)
+				return fetchFirewallMsg{err: fmt.Errorf("firewall: %w", err)}
+			}
 		}
 
 		backend := ssh.DetectFirewallBackend(out)
@@ -1217,10 +1248,15 @@ func (m Model) fetchFailedLogins() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "failed_logins", "host_idx", idx)
 		cmd := `sudo journalctl -u sshd --no-pager -q --no-hostname -o short -n 500 2>/dev/null | grep -iE 'Failed|Invalid user' | tac; true`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "failed_logins", "host_idx", idx, "err", err)
-			return fetchFailedLoginsMsg{err: fmt.Errorf("failed logins: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchFailedLoginsMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "failed_logins", "host_idx", idx, "err", err)
+				return fetchFailedLoginsMsg{err: fmt.Errorf("failed logins: %w", err)}
+			}
 		}
 
 		var logins []config.FailedLogin
@@ -1254,10 +1290,15 @@ func (m Model) fetchSudoActivity() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "sudo_activity", "host_idx", idx)
 		cmd := `sudo journalctl _COMM=sudo --no-pager -q --no-hostname -o short -n 500 2>/dev/null | tac; true`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "sudo_activity", "host_idx", idx, "err", err)
-			return fetchSudoActivityMsg{err: fmt.Errorf("sudo activity: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchSudoActivityMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "sudo_activity", "host_idx", idx, "err", err)
+				return fetchSudoActivityMsg{err: fmt.Errorf("sudo activity: %w", err)}
+			}
 		}
 
 		var entries []config.SudoEntry
@@ -1291,10 +1332,15 @@ func (m Model) fetchSELinuxDenials() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "selinux_denials", "host_idx", idx)
 		cmd := `sudo journalctl _TRANSPORT=audit --no-pager -q --no-hostname -o short -n 500 2>/dev/null | grep 'avc:' | tac; true`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "selinux_denials", "host_idx", idx, "err", err)
-			return fetchSELinuxMsg{err: fmt.Errorf("selinux: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchSELinuxMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "selinux_denials", "host_idx", idx, "err", err)
+				return fetchSELinuxMsg{err: fmt.Errorf("selinux: %w", err)}
+			}
 		}
 
 		var denials []config.SELinuxDenial
@@ -1328,10 +1374,15 @@ func (m Model) fetchAuditSummary() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "audit_summary", "host_idx", idx)
 		cmd := `sudo aureport --auth -i 2>/dev/null | grep -E '^\s*[0-9]+\.' | tac; true`
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "audit_summary", "host_idx", idx, "err", err)
-			return fetchAuditSummaryMsg{err: fmt.Errorf("audit: %w", err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchAuditSummaryMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "audit_summary", "host_idx", idx, "err", err)
+				return fetchAuditSummaryMsg{err: fmt.Errorf("audit: %w", err)}
+			}
 		}
 
 		var events []config.AuditEvent
@@ -1395,10 +1446,15 @@ func (m Model) fetchDiskDetail(mount string) func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "disk_detail", "host_idx", idx, "mount", mount)
 		cmd := fmt.Sprintf("df -h '%s' 2>/dev/null && echo '---' && (sudo tune2fs -l $(findmnt -n -o SOURCE '%s') 2>/dev/null || lsblk -f $(findmnt -n -o SOURCE '%s') 2>/dev/null || echo 'No additional details available')", shellQuote(mount), shellQuote(mount), shellQuote(mount))
-		out, err := sm.RunCommand(idx, cmd)
-		if err != nil && out == "" {
-			logger.Error("fetch failed", "view", "disk_detail", "host_idx", idx, "mount", mount, "err", err)
-			return fetchDiskDetailMsg{err: fmt.Errorf("disk detail %s: %w", mount, err)}
+		out, err := sm.RunSudoCommand(idx, cmd)
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchDiskDetailMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if out == "" {
+				logger.Error("fetch failed", "view", "disk_detail", "host_idx", idx, "mount", mount, "err", err)
+				return fetchDiskDetailMsg{err: fmt.Errorf("disk detail %s: %w", mount, err)}
+			}
 		}
 		var lines []string
 		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -230,6 +230,36 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// sudo password prompt mode -- capture input on any SSH view
+	if m.showSudoPrompt {
+		switch msg.Type {
+		case tea.KeyEnter:
+			m.showSudoPrompt = false
+			password := m.sudoInput
+			m.sudoInput = ""
+			m.ssh.SetSudoPassword(m.selectedHost, password)
+			retry := m.pendingSudoRetry
+			m.pendingSudoRetry = nil
+			return m, retry
+		case tea.KeyEsc:
+			m.showSudoPrompt = false
+			m.sudoInput = ""
+			m.pendingSudoRetry = nil
+			m.flash = "Sudo password prompt cancelled"
+			m.flashError = true
+			return m, nil
+		case tea.KeyBackspace:
+			if len(m.sudoInput) > 0 {
+				m.sudoInput = m.sudoInput[:len(m.sudoInput)-1]
+			}
+		default:
+			if msg.Type == tea.KeyRunes {
+				m.sudoInput += string(msg.Runes)
+			}
+		}
+		return m, nil
+	}
+
 	m.flash = ""
 	m.flashError = false
 

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -234,6 +234,9 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.showSudoPrompt {
 		switch msg.Type {
 		case tea.KeyEnter:
+			if m.sudoInput == "" {
+				return m, nil
+			}
 			m.showSudoPrompt = false
 			password := m.sudoInput
 			m.sudoInput = ""
@@ -250,7 +253,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyBackspace:
 			if len(m.sudoInput) > 0 {
-				m.sudoInput = m.sudoInput[:len(m.sudoInput)-1]
+				runes := []rune(m.sudoInput)
+				m.sudoInput = string(runes[:len(runes)-1])
 			}
 		default:
 			if msg.Type == tea.KeyRunes {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -476,9 +476,10 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 	sshPw := m.ssh.GetCachedPassword()
 	if sshPw != "" {
 		sm := m.ssh
-		escaped := strings.ReplaceAll(sshPw, "'", `'\''`)
 		testCmd := func() tea.Msg {
-			out, runErr := sm.RunCommand(idx, "echo '"+escaped+"' | sudo -S true 2>&1")
+			sm.SetSudoPassword(idx, sshPw)
+			out, runErr := sm.RunSudoCommand(idx, "sudo true")
+			sm.SetSudoPassword(idx, "") // always clear — model Update sets it on success
 			success := runErr == nil && !ssh.IsSudoOutput(out)
 			return sudoTestMsg{Password: sshPw, Success: success}
 		}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -154,6 +154,12 @@ type fetchAzureActivityLogMsg struct {
 	err     error
 }
 
+// sudoTestMsg is sent after silently testing whether the SSH password works for sudo.
+type sudoTestMsg struct {
+	Password string
+	Success  bool
+}
+
 func (m Model) tickCmd() tea.Cmd {
 	interval, err := time.ParseDuration(m.fleets[m.selectedFleet].Defaults.RefreshInterval)
 	if err != nil {
@@ -414,6 +420,11 @@ type Model struct {
 	passwordHostIdx    int
 	showPasswordPrompt bool
 
+	// sudo password prompt
+	showSudoPrompt   bool
+	sudoInput        string
+	pendingSudoRetry tea.Cmd // fetch closure to re-run after sudo password is obtained
+
 	// flash message
 	flash      string
 	flashError bool
@@ -440,6 +451,44 @@ func NewModel(fleets []config.Fleet, logger *slog.Logger, version string) Model 
 
 func (m Model) Init() tea.Cmd {
 	return nil
+}
+
+// handleSudoOrFlash checks if err is a sudo password error.
+// If yes: stores the retry closure, then either silently tests the SSH cached password
+// or shows the sudo prompt. Returns the updated model, an optional tea.Cmd, and true.
+// If no: returns the original model, nil, and false — caller should set flash.
+func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool) {
+	if !ssh.IsSudoError(err) {
+		return m, nil, false
+	}
+	idx := m.selectedHost
+	m.pendingSudoRetry = retry
+
+	// Wrong cached password: it was tried and failed — clear and re-prompt.
+	if m.ssh.GetSudoPassword(idx) != "" {
+		m.ssh.SetSudoPassword(idx, "")
+		m.showSudoPrompt = true
+		m.sudoInput = ""
+		return m, nil, true
+	}
+
+	// Try the SSH connection password silently if available.
+	sshPw := m.ssh.GetCachedPassword()
+	if sshPw != "" {
+		sm := m.ssh
+		escaped := strings.ReplaceAll(sshPw, "'", `'\''`)
+		testCmd := func() tea.Msg {
+			out, runErr := sm.RunCommand(idx, "echo '"+escaped+"' | sudo -S true 2>&1")
+			success := runErr == nil && !ssh.IsSudoOutput(out)
+			return sudoTestMsg{Password: sshPw, Success: success}
+		}
+		return m, testCmd, true
+	}
+
+	// No SSH password cached (key auth): show prompt directly.
+	m.showSudoPrompt = true
+	m.sudoInput = ""
+	return m, nil, true
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -867,6 +916,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case sudoTestMsg:
+		if msg.Success {
+			m.ssh.SetSudoPassword(m.selectedHost, msg.Password)
+			retry := m.pendingSudoRetry
+			m.pendingSudoRetry = nil
+			return m, retry
+		}
+		// SSH password didn't work as sudo password — show prompt.
+		m.showSudoPrompt = true
+		m.sudoInput = ""
+		return m, nil
+
 	case fetchMetricsMsg:
 		if msg.err != nil {
 			if m.metricErrors == nil {
@@ -897,6 +958,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchServiceDetailMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchServiceDetail(m.serviceDetailUnit)); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -938,6 +1002,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchLogLevelsMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchLogLevels()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -947,6 +1014,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchErrorLogsMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchErrorLogs()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -980,6 +1050,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchSubscriptionMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSubscription()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -989,6 +1062,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchAccountDetailMsg:
 		if msg.err != nil {
+			user := ""
+			if m.accountCursor < len(m.accounts) {
+				user = m.accounts[m.accountCursor].User
+			}
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchAccountDetail(user)); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1053,6 +1133,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchNetworkInfoMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchNetworkInfo()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1064,6 +1147,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchFirewallMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFirewall()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1074,6 +1160,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchFailedLoginsMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFailedLogins()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1087,6 +1176,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchSudoActivityMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSudoActivity()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1100,6 +1192,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchSELinuxMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSELinuxDenials()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1113,6 +1208,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchAuditSummaryMsg:
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchAuditSummary()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {
@@ -1135,6 +1233,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fetchDiskDetailMsg:
 		if msg.err != nil {
+			mount := ""
+			if m.diskCursor < len(m.disks) {
+				mount = m.disks[m.diskCursor].Mount
+			}
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchDiskDetail(mount)); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {

--- a/internal/app/sudo_test.go
+++ b/internal/app/sudo_test.go
@@ -1,0 +1,203 @@
+package app
+
+import (
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
+)
+
+func newTestModel() Model {
+	logger := slog.Default()
+	return Model{
+		ssh:    ssh.NewManager(logger),
+		logger: logger,
+		width:  80,
+		height: 24,
+	}
+}
+
+// TestSudoPromptKeyCapture verifies keyboard handling when showSudoPrompt is active.
+func TestSudoPromptKeyCapture(t *testing.T) {
+	t.Run("rune appended", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if m2.sudoInput != "a" {
+			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "a")
+		}
+	})
+
+	t.Run("backspace single byte", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = "abc"
+		msg := tea.KeyMsg{Type: tea.KeyBackspace}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if m2.sudoInput != "ab" {
+			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "ab")
+		}
+	})
+
+	t.Run("backspace multi-byte rune", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = "pàss" // à is 2 bytes in UTF-8
+		msg := tea.KeyMsg{Type: tea.KeyBackspace}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if m2.sudoInput != "pàs" {
+			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "pàs")
+		}
+	})
+
+	t.Run("enter with empty input is no-op", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = ""
+		msg := tea.KeyMsg{Type: tea.KeyEnter}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if !m2.showSudoPrompt {
+			t.Error("showSudoPrompt should remain true on empty enter")
+		}
+	})
+
+	t.Run("enter with password clears prompt", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = "mypassword"
+		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
+		m.selectedHost = 0
+		msg := tea.KeyMsg{Type: tea.KeyEnter}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if m2.showSudoPrompt {
+			t.Error("showSudoPrompt should be false after entering password")
+		}
+		if m2.sudoInput != "" {
+			t.Errorf("sudoInput should be cleared, got %q", m2.sudoInput)
+		}
+	})
+
+	t.Run("esc cancels prompt", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = "typing"
+		msg := tea.KeyMsg{Type: tea.KeyEsc}
+		result, _ := m.handleKey(msg)
+		m2 := result.(Model)
+		if m2.showSudoPrompt {
+			t.Error("showSudoPrompt should be false after Esc")
+		}
+		if m2.flash == "" {
+			t.Error("flash should be set after Esc")
+		}
+	})
+}
+
+// TestHandleSudoOrFlash verifies the sudo error detection and branching logic.
+func TestHandleSudoOrFlash(t *testing.T) {
+	retryCmd := func() tea.Msg { return nil }
+
+	t.Run("non-sudo error returns false", func(t *testing.T) {
+		m := newTestModel()
+		err := errors.New("connection refused")
+		_, cmd, ok := m.handleSudoOrFlash(err, retryCmd)
+		if ok {
+			t.Error("expected ok=false for non-sudo error")
+		}
+		if cmd != nil {
+			t.Error("expected cmd=nil for non-sudo error")
+		}
+	})
+
+	t.Run("sudo error with no cached passwords shows prompt", func(t *testing.T) {
+		m := newTestModel()
+		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
+		err := ssh.ErrSudoRequired
+		m2, cmd, ok := m.handleSudoOrFlash(err, retryCmd)
+		if !ok {
+			t.Error("expected ok=true for sudo error")
+		}
+		if !m2.showSudoPrompt {
+			t.Error("expected showSudoPrompt=true when no passwords cached")
+		}
+		if cmd != nil {
+			t.Error("expected cmd=nil when showing prompt directly")
+		}
+	})
+
+	t.Run("sudo error with cached SSH password returns test cmd", func(t *testing.T) {
+		m := newTestModel()
+		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
+		m.ssh.SetCachedPassword("sshpw")
+		err := ssh.ErrSudoRequired
+		m2, cmd, ok := m.handleSudoOrFlash(err, retryCmd)
+		if !ok {
+			t.Error("expected ok=true for sudo error")
+		}
+		if m2.showSudoPrompt {
+			t.Error("expected showSudoPrompt=false when silently testing SSH password")
+		}
+		if cmd == nil {
+			t.Error("expected non-nil cmd for silent sudo test")
+		}
+	})
+
+	t.Run("sudo error with wrong cached sudo password clears and prompts", func(t *testing.T) {
+		m := newTestModel()
+		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
+		m.ssh.SetSudoPassword(0, "wrongpw")
+		err := ssh.ErrSudoRequired
+		m2, cmd, ok := m.handleSudoOrFlash(err, retryCmd)
+		if !ok {
+			t.Error("expected ok=true for sudo error")
+		}
+		if !m2.showSudoPrompt {
+			t.Error("expected showSudoPrompt=true after clearing wrong sudo password")
+		}
+		if cmd != nil {
+			t.Error("expected cmd=nil when showing prompt")
+		}
+		if m2.ssh.GetSudoPassword(0) != "" {
+			t.Error("expected sudo password to be cleared")
+		}
+	})
+}
+
+// TestRenderSudoPromptOrHintBar verifies the hint bar rendering with and without sudo prompt.
+func TestRenderSudoPromptOrHintBar(t *testing.T) {
+	t.Run("sudo prompt active shows masked password and username", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = true
+		m.sudoInput = "pw"
+		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1", User: "alice"}}}
+		m.selectedHost = 0
+		out := m.renderSudoPromptOrHintBar(nil)
+		if !strings.Contains(out, "alice") {
+			t.Errorf("expected username 'alice' in output, got: %q", out)
+		}
+		if !strings.Contains(out, "**") {
+			t.Errorf("expected masked password '**' in output, got: %q", out)
+		}
+	})
+
+	t.Run("no sudo prompt delegates to hint bar", func(t *testing.T) {
+		m := newTestModel()
+		m.showSudoPrompt = false
+		hints := [][]string{{"Enter", "Confirm"}}
+		out := m.renderSudoPromptOrHintBar(hints)
+		if !strings.Contains(out, "<") {
+			t.Errorf("expected hint bar key brackets in output, got: %q", out)
+		}
+	})
+}

--- a/internal/app/view_account.go
+++ b/internal/app/view_account.go
@@ -162,7 +162,7 @@ func (m Model) renderAccountList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 {"Enter", "Detail"},

--- a/internal/app/view_common.go
+++ b/internal/app/view_common.go
@@ -28,6 +28,21 @@ func (m Model) renderHeader(breadcrumb string, current, total int) string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
+// renderSudoPromptOrHintBar renders the sudo password prompt if active,
+// otherwise delegates to renderHintBar. Use in all SSH-based VM views.
+func (m Model) renderSudoPromptOrHintBar(hints [][]string) string {
+	if m.showSudoPrompt {
+		user := ""
+		if m.selectedHost < len(m.hosts) {
+			user = m.hosts[m.selectedHost].Entry.User
+		}
+		masked := strings.Repeat("*", len(m.sudoInput))
+		prompt := fmt.Sprintf("  Sudo password for %s: %s\u2588", user, masked)
+		return hintBarStyle.Width(m.width).Render(prompt)
+	}
+	return m.renderHintBar(hints)
+}
+
 func (m Model) renderHintBar(hints [][]string) string {
 	var parts []string
 	for _, h := range hints {

--- a/internal/app/view_common.go
+++ b/internal/app/view_common.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
@@ -36,7 +37,7 @@ func (m Model) renderSudoPromptOrHintBar(hints [][]string) string {
 		if m.selectedHost < len(m.hosts) {
 			user = m.hosts[m.selectedHost].Entry.User
 		}
-		masked := strings.Repeat("*", len(m.sudoInput))
+		masked := strings.Repeat("*", utf8.RuneCountInString(m.sudoInput))
 		prompt := fmt.Sprintf("  Sudo password for %s: %s\u2588", user, masked)
 		return hintBarStyle.Width(m.width).Render(prompt)
 	}

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -64,7 +64,7 @@ func (m Model) renderContainerList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -147,7 +147,7 @@ func (m Model) renderContainerList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-3", "Sort"},

--- a/internal/app/view_cron.go
+++ b/internal/app/view_cron.go
@@ -101,7 +101,7 @@ func (m Model) renderCronList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"1-3", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_disk.go
+++ b/internal/app/view_disk.go
@@ -59,7 +59,7 @@ func (m Model) renderDiskList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -148,7 +148,7 @@ func (m Model) renderDiskList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-6", "Sort"},

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -102,7 +102,7 @@ func (m Model) renderFleetPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"Enter", "Select"},
 		{"e", "Edit"},
 		{"r", "Reload"},

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -119,6 +119,8 @@ func (m Model) renderHostList() string {
 		masked := strings.Repeat("*", len(m.passwordInput))
 		prompt := fmt.Sprintf("  Password for %s: %s\u2588", user, masked)
 		s += hintBarStyle.Width(m.width).Render(prompt)
+	} else if m.showSudoPrompt {
+		s += m.renderSudoPromptOrHintBar(nil)
 	} else if m.showConfirm {
 		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
 	} else {

--- a/internal/app/view_logs.go
+++ b/internal/app/view_logs.go
@@ -50,7 +50,7 @@ func (m Model) renderLogLevelPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "View Logs"},
 		{"r", "Refresh"},
@@ -214,7 +214,7 @@ func (m Model) renderErrorLogList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"↑↓", "Navigate"},
 			{"1-3", "Sort"},
 			{"Enter", "Detail"},

--- a/internal/app/view_metrics.go
+++ b/internal/app/view_metrics.go
@@ -156,7 +156,7 @@ func (m Model) renderMetrics() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"r", "Refresh"},

--- a/internal/app/view_network.go
+++ b/internal/app/view_network.go
@@ -64,7 +64,7 @@ func (m Model) renderNetworkPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},

--- a/internal/app/view_network_firewall.go
+++ b/internal/app/view_network_firewall.go
@@ -133,7 +133,7 @@ func (m Model) renderNetworkFirewall() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_interfaces.go
+++ b/internal/app/view_network_interfaces.go
@@ -116,7 +116,7 @@ func (m Model) renderNetworkInterfaces() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_ports.go
+++ b/internal/app/view_network_ports.go
@@ -109,7 +109,7 @@ func (m Model) renderNetworkPorts() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_routes.go
+++ b/internal/app/view_network_routes.go
@@ -118,7 +118,7 @@ func (m Model) renderNetworkRoutes() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_resource.go
+++ b/internal/app/view_resource.go
@@ -101,7 +101,7 @@ func (m Model) renderResourcePicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},

--- a/internal/app/view_security_audit.go
+++ b/internal/app/view_security_audit.go
@@ -102,7 +102,7 @@ func (m Model) renderAuditSummary() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_failed_logins.go
+++ b/internal/app/view_security_failed_logins.go
@@ -95,7 +95,7 @@ func (m Model) renderFailedLogins() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_selinux.go
+++ b/internal/app/view_security_selinux.go
@@ -99,7 +99,7 @@ func (m Model) renderSELinuxDenials() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_sudo.go
+++ b/internal/app/view_security_sudo.go
@@ -102,7 +102,7 @@ func (m Model) renderSudoActivity() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderSudoPromptOrHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -141,7 +141,7 @@ func (m Model) renderServiceList() string {
 		if m.showConfirm {
 			s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
 		} else {
-			s += m.renderHintBar([][]string{
+			s += m.renderSudoPromptOrHintBar([][]string{
 				{"\u2191\u2193", "Scroll"},
 				{"/", "Search"},
 				{"s", "Start"},
@@ -238,7 +238,7 @@ func (m Model) renderServiceList() string {
 	} else if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"1-4", "Sort"},
 			{"Enter", "Detail"},

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -76,7 +76,7 @@ func (m Model) renderSubscription() string {
 	if m.showConfirm {
 		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"↑↓", "Navigate"},
 			{"d", "Disable Repo"},
 			{"r", "Refresh"},

--- a/internal/app/view_updates.go
+++ b/internal/app/view_updates.go
@@ -59,7 +59,7 @@ func (m Model) renderUpdateList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -152,7 +152,7 @@ func (m Model) renderUpdateList() string {
 	if m.showConfirm {
 		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderSudoPromptOrHintBar([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
 			{"1-3", "Sort"},

--- a/internal/ssh/fetch.go
+++ b/internal/ssh/fetch.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,22 @@ import (
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 )
+
+// ErrSudoRequired is returned when a command fails because sudo requires a password.
+var ErrSudoRequired = errors.New("sudo password required")
+
+// IsSudoOutput returns true if the command output indicates sudo needs a password.
+func IsSudoOutput(output string) bool {
+	return strings.Contains(output, "sudo: a password is required") ||
+		strings.Contains(output, "sudo: no tty present") ||
+		strings.Contains(output, "[sudo] password for") ||
+		strings.Contains(output, "sudo: no password supplied")
+}
+
+// IsSudoError returns true if err wraps ErrSudoRequired.
+func IsSudoError(err error) bool {
+	return errors.Is(err, ErrSudoRequired)
+}
 
 // ServiceStateOrder returns a sort priority for service states.
 // Lower = shown first.

--- a/internal/ssh/fetch.go
+++ b/internal/ssh/fetch.go
@@ -28,6 +28,11 @@ func IsSudoError(err error) bool {
 	return errors.Is(err, ErrSudoRequired)
 }
 
+// EscapeSingleQuotes escapes single quotes in s for safe embedding in a single-quoted shell string.
+func EscapeSingleQuotes(s string) string {
+	return strings.ReplaceAll(s, "'", `'\''`)
+}
+
 // ServiceStateOrder returns a sort priority for service states.
 // Lower = shown first.
 func ServiceStateOrder(state string) int {

--- a/internal/ssh/fetch_test.go
+++ b/internal/ssh/fetch_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -1034,3 +1035,45 @@ func TestParseMetricsOutput(t *testing.T) {
 type errString string
 
 func (e errString) Error() string { return string(e) }
+
+func TestIsSudoOutput(t *testing.T) {
+	tests := []struct {
+		output string
+		want   bool
+	}{
+		{"sudo: a password is required", true},
+		{"sudo: no tty present and no askpass program specified", true},
+		{"[sudo] password for gaetan:", true},
+		{"sudo: no password supplied", true},
+		{"", false},
+		{"permission denied", false},
+		{"exit status 1", false},
+		// partial match
+		{"some output\nsudo: a password is required\nmore output", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.output, func(t *testing.T) {
+			got := IsSudoOutput(tt.output)
+			if got != tt.want {
+				t.Errorf("IsSudoOutput(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSudoError(t *testing.T) {
+	if IsSudoError(nil) {
+		t.Error("IsSudoError(nil) = true, want false")
+	}
+	if IsSudoError(errString("some other error")) {
+		t.Error("IsSudoError(non-sudo error) = true, want false")
+	}
+	if !IsSudoError(ErrSudoRequired) {
+		t.Error("IsSudoError(ErrSudoRequired) = false, want true")
+	}
+	// wrapped
+	wrapped := fmt.Errorf("fetch failed: %w", ErrSudoRequired)
+	if !IsSudoError(wrapped) {
+		t.Error("IsSudoError(wrapped ErrSudoRequired) = false, want true")
+	}
+}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,14 +22,16 @@ type Manager struct {
 	mu             sync.Mutex
 	conns          map[int]*gossh.Client
 	cachedPassword string
+	sudoPasswords  map[int]string // per-host sudo password cache, cleared on Close
 	logger         *slog.Logger
 }
 
 // NewManager creates a new SSH manager.
 func NewManager(logger *slog.Logger) *Manager {
 	return &Manager{
-		conns:  make(map[int]*gossh.Client),
-		logger: logger,
+		conns:         make(map[int]*gossh.Client),
+		sudoPasswords: make(map[int]string),
+		logger:        logger,
 	}
 }
 
@@ -92,6 +95,50 @@ func (sm *Manager) ConnectAndProbe(idx int, h config.Host) HostProbeResult {
 
 	sm.logger.Debug("probe complete", "host", h.Entry.Name, "reused", false, "elapsed", time.Since(start))
 	return HostProbeResult{Index: idx, Info: info}
+}
+
+// GetCachedPassword returns the SSH connection password, if the user authenticated via password.
+func (sm *Manager) GetCachedPassword() string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.cachedPassword
+}
+
+// SetSudoPassword caches a sudo password for a specific host index.
+// Pass an empty string to clear the cached password for that host.
+func (sm *Manager) SetSudoPassword(idx int, password string) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if password == "" {
+		delete(sm.sudoPasswords, idx)
+	} else {
+		sm.sudoPasswords[idx] = password
+	}
+}
+
+// GetSudoPassword returns the cached sudo password for a host (empty if none).
+func (sm *Manager) GetSudoPassword(idx int) string {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.sudoPasswords[idx]
+}
+
+// RunSudoCommand executes a command on the given host, wrapping sudo invocations
+// with password piping if a sudo password is cached for this host.
+// If no sudo password is cached, delegates to RunCommand unchanged.
+func (sm *Manager) RunSudoCommand(idx int, cmd string) (string, error) {
+	pw := sm.GetSudoPassword(idx)
+	if pw != "" {
+		cmd = rewriteSudoCmd(cmd, pw)
+	}
+	return sm.RunCommand(idx, cmd)
+}
+
+// rewriteSudoCmd rewrites every "sudo " occurrence in cmd to pipe the password
+// via stdin. Single quotes in the password are escaped to prevent shell injection.
+func rewriteSudoCmd(cmd string, password string) string {
+	escaped := strings.ReplaceAll(password, "'", `'\''`)
+	return strings.ReplaceAll(cmd, "sudo ", "echo '"+escaped+"' | sudo -S 2>/dev/null ")
 }
 
 // RunCommand executes a command on the given host index and returns stdout.
@@ -204,7 +251,7 @@ func (sm *Manager) HasConnection(idx int) bool {
 	return sm.conns[idx] != nil
 }
 
-// Close shuts down all SSH connections.
+// Close shuts down all SSH connections and clears all cached credentials.
 func (sm *Manager) Close() {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
@@ -215,6 +262,7 @@ func (sm *Manager) Close() {
 	}
 	sm.conns = make(map[int]*gossh.Client)
 	sm.cachedPassword = ""
+	sm.sudoPasswords = make(map[int]string)
 }
 
 // Probe runs a single SSH command to gather all host info in one roundtrip.

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -137,7 +137,7 @@ func (sm *Manager) RunSudoCommand(idx int, cmd string) (string, error) {
 // rewriteSudoCmd rewrites every "sudo " occurrence in cmd to pipe the password
 // via stdin. Single quotes in the password are escaped to prevent shell injection.
 func rewriteSudoCmd(cmd string, password string) string {
-	escaped := strings.ReplaceAll(password, "'", `'\''`)
+	escaped := EscapeSingleQuotes(password)
 	return strings.ReplaceAll(cmd, "sudo ", "echo '"+escaped+"' | sudo -S 2>/dev/null ")
 }
 

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -143,7 +143,11 @@ func rewriteSudoCmd(cmd string, password string) string {
 
 // RunCommand executes a command on the given host index and returns stdout.
 func (sm *Manager) RunCommand(idx int, cmd string) (string, error) {
-	sm.logger.Debug("runCommand", "idx", idx, "cmd_prefix", cmd[:min(len(cmd), 60)])
+	logPrefix := cmd[:min(len(cmd), 60)]
+	if strings.Contains(cmd, "| sudo -S") {
+		logPrefix = "[sudo-rewritten]"
+	}
+	sm.logger.Debug("runCommand", "idx", idx, "cmd_prefix", logPrefix)
 
 	sm.mu.Lock()
 	client, ok := sm.conns[idx]

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -1,0 +1,104 @@
+package ssh
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestSudoPasswordCache(t *testing.T) {
+	sm := NewManager(slog.Default())
+
+	// Initially empty
+	if got := sm.GetSudoPassword(0); got != "" {
+		t.Errorf("GetSudoPassword(0) = %q, want empty", got)
+	}
+
+	// Set and retrieve
+	sm.SetSudoPassword(0, "secret")
+	if got := sm.GetSudoPassword(0); got != "secret" {
+		t.Errorf("GetSudoPassword(0) = %q, want %q", got, "secret")
+	}
+
+	// Per-host isolation
+	if got := sm.GetSudoPassword(1); got != "" {
+		t.Errorf("GetSudoPassword(1) = %q, want empty (different host)", got)
+	}
+	sm.SetSudoPassword(1, "other")
+	if got := sm.GetSudoPassword(0); got != "secret" {
+		t.Errorf("GetSudoPassword(0) = %q, want %q after setting host 1", got, "secret")
+	}
+
+	// Clear with empty string
+	sm.SetSudoPassword(0, "")
+	if got := sm.GetSudoPassword(0); got != "" {
+		t.Errorf("GetSudoPassword(0) = %q, want empty after clear", got)
+	}
+
+	// Close clears all
+	sm.SetSudoPassword(1, "stillset")
+	sm.Close()
+	if got := sm.GetSudoPassword(1); got != "" {
+		t.Errorf("GetSudoPassword(1) = %q, want empty after Close()", got)
+	}
+}
+
+func TestGetCachedPassword(t *testing.T) {
+	sm := NewManager(slog.Default())
+
+	if got := sm.GetCachedPassword(); got != "" {
+		t.Errorf("GetCachedPassword() = %q, want empty initially", got)
+	}
+
+	sm.SetCachedPassword("mypassword")
+	if got := sm.GetCachedPassword(); got != "mypassword" {
+		t.Errorf("GetCachedPassword() = %q, want %q", got, "mypassword")
+	}
+
+	sm.ClearPassword()
+	if got := sm.GetCachedPassword(); got != "" {
+		t.Errorf("GetCachedPassword() = %q, want empty after ClearPassword", got)
+	}
+}
+
+func TestRewriteSudoCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		password string
+		want     string
+	}{
+		{
+			name:     "simple sudo",
+			cmd:      "sudo journalctl -u sshd",
+			password: "secret",
+			want:     "echo 'secret' | sudo -S 2>/dev/null journalctl -u sshd",
+		},
+		{
+			name:     "multiple sudo",
+			cmd:      "sudo systemctl status && sudo journalctl",
+			password: "pass",
+			want:     "echo 'pass' | sudo -S 2>/dev/null systemctl status && echo 'pass' | sudo -S 2>/dev/null journalctl",
+		},
+		{
+			name:     "password with single quote",
+			cmd:      "sudo true",
+			password: "it's a secret",
+			want:     `echo 'it'\''s a secret' | sudo -S 2>/dev/null true`,
+		},
+		{
+			name:     "no sudo in command",
+			cmd:      "systemctl status",
+			password: "irrelevant",
+			want:     "systemctl status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteSudoCmd(tt.cmd, tt.password)
+			if got != tt.want {
+				t.Errorf("rewriteSudoCmd(%q, %q)\n  got  %q\n  want %q", tt.cmd, tt.password, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add fail-then-retry sudo password escalation to `RunSudoCommand` — when a privileged SSH command fails because sudo requires a password, FleetDesk prompts the user inline (same hint bar) and retries automatically
- Silent SSH-password test: if the user connected via password auth, FleetDesk tries it as the sudo password first — no prompt shown on success (common LDAP/AD case)
- Sudo password cached per host in `ssh.Manager`, cleared on `Close()` (fleet switch / quit)

Closes FLE-64