### PR TITLE
feat: deploy SSH key to host via ssh-copy-id (FLE-65)

### DIFF
--- a/internal/app/deploy_key_test.go
+++ b/internal/app/deploy_key_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDeployKeyKeybind(t *testing.T) {
-	t.Run("K on online host returns exec command", func(t *testing.T) {
+	t.Run("K on online host shows confirm prompt", func(t *testing.T) {
 		m := newTestModel()
 		m.view = viewHostList
 		m.hosts = []config.Host{{
@@ -19,9 +19,68 @@ func TestDeployKeyKeybind(t *testing.T) {
 		m.hostCursor = 0
 
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}}
-		_, cmd := m.handleHostListKeys(msg)
+		result, cmd := m.handleHostListKeys(msg)
+		m2 := result.(Model)
+		if cmd != nil {
+			t.Error("expected nil cmd — confirm prompt should not fire command yet")
+		}
+		if !m2.showConfirm {
+			t.Error("expected showConfirm = true")
+		}
+		if m2.pendingHandover == nil {
+			t.Error("expected pendingHandover to be set")
+		}
+	})
+
+	t.Run("K confirm yes executes handover", func(t *testing.T) {
+		m := newTestModel()
+		m.view = viewHostList
+		m.hosts = []config.Host{{
+			Entry:  config.HostEntry{Name: "host1", Hostname: "10.0.0.1", User: "ansible", Port: 22},
+			Status: config.HostOnline,
+		}}
+		m.hostCursor = 0
+		m.selectedHost = 0
+		m.showConfirm = true
+		m.confirmMessage = "Deploy SSH key to ansible@host1? [Y/n]"
+		m.pendingHandover = func() tea.Msg { return nil } // stub
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+		result, cmd := m.handleKey(msg)
+		m2 := result.(Model)
 		if cmd == nil {
-			t.Error("expected non-nil cmd for K on online host")
+			t.Error("expected non-nil cmd after confirming deploy key")
+		}
+		if m2.showConfirm {
+			t.Error("expected showConfirm = false after confirm")
+		}
+		if m2.pendingHandover != nil {
+			t.Error("expected pendingHandover to be cleared after confirm")
+		}
+	})
+
+	t.Run("K confirm no cancels", func(t *testing.T) {
+		m := newTestModel()
+		m.view = viewHostList
+		m.hosts = []config.Host{{
+			Entry:  config.HostEntry{Name: "host1", Hostname: "10.0.0.1", User: "ansible", Port: 22},
+			Status: config.HostOnline,
+		}}
+		m.hostCursor = 0
+		m.showConfirm = true
+		m.pendingHandover = func() tea.Msg { return nil } // stub
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+		result, cmd := m.handleKey(msg)
+		m2 := result.(Model)
+		if cmd != nil {
+			t.Error("expected nil cmd after cancelling")
+		}
+		if m2.flash != "Cancelled" {
+			t.Errorf("flash = %q, want %q", m2.flash, "Cancelled")
+		}
+		if m2.pendingHandover != nil {
+			t.Error("expected pendingHandover to be cleared after cancel")
 		}
 	})
 

--- a/internal/app/deploy_key_test.go
+++ b/internal/app/deploy_key_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+func TestDeployKeyKeybind(t *testing.T) {
+	t.Run("K on online host returns exec command", func(t *testing.T) {
+		m := newTestModel()
+		m.view = viewHostList
+		m.hosts = []config.Host{{
+			Entry:  config.HostEntry{Name: "host1", Hostname: "10.0.0.1", User: "ansible", Port: 22},
+			Status: config.HostOnline,
+		}}
+		m.hostCursor = 0
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}}
+		_, cmd := m.handleHostListKeys(msg)
+		if cmd == nil {
+			t.Error("expected non-nil cmd for K on online host")
+		}
+	})
+
+	t.Run("K on offline host shows flash error", func(t *testing.T) {
+		m := newTestModel()
+		m.view = viewHostList
+		m.hosts = []config.Host{{
+			Entry:  config.HostEntry{Name: "host1", Hostname: "10.0.0.1", User: "ansible", Port: 22},
+			Status: config.HostUnreachable,
+		}}
+		m.hostCursor = 0
+
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}}
+		result, cmd := m.handleHostListKeys(msg)
+		m2 := result.(Model)
+		if cmd != nil {
+			t.Error("expected nil cmd for K on offline host")
+		}
+		if m2.flash != "Host is not reachable" {
+			t.Errorf("flash = %q, want %q", m2.flash, "Host is not reachable")
+		}
+		if !m2.flashError {
+			t.Error("expected flashError = true")
+		}
+	})
+}

--- a/internal/app/handover.go
+++ b/internal/app/handover.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 )
 
-// sshHandoverFinishedMsg is sent when a terminal handover SSH command completes.
+// sshHandoverFinishedMsg is sent when a terminal handover command completes.
 type sshHandoverFinishedMsg struct {
 	Err error
 }
@@ -99,6 +99,47 @@ func (m Model) editFleetFile() tea.Cmd {
 	e := &editorExec{path: f.Path}
 	return tea.Exec(e, func(err error) tea.Msg {
 		return editFinishedMsg{Err: e.err}
+	})
+}
+
+// cmdExec wraps an arbitrary command with terminal handover.
+type cmdExec struct {
+	name   string
+	args   []string
+	banner string
+	err    error
+}
+
+func (c *cmdExec) Run() error {
+	sep := strings.Repeat("\u2501", 50)
+	fmt.Printf("\n%s\n\u25b6 %s\n%s\n\n", sep, c.banner, sep)
+
+	cmd := exec.Command(c.name, c.args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	c.err = cmd.Run()
+
+	status := "\u2713 done"
+	if c.err != nil {
+		status = fmt.Sprintf("\u2717 %v", c.err)
+	}
+	fmt.Printf("\n%s\n%s\nPress Enter to return to fleetdesk...", sep, status)
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+
+	return nil
+}
+
+func (c *cmdExec) SetStdin(_ io.Reader)  {}
+func (c *cmdExec) SetStdout(_ io.Writer) {}
+func (c *cmdExec) SetStderr(_ io.Writer) {}
+
+// cmdHandover creates a tea.Cmd for terminal handover to an arbitrary command.
+func cmdHandover(name string, args []string, banner string) tea.Cmd {
+	e := &cmdExec{name: name, args: args, banner: banner}
+	return tea.Exec(e, func(err error) tea.Msg {
+		return sshHandoverFinishedMsg{Err: e.err}
 	})
 }
 

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -452,6 +452,18 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, sshHandover(h, []string{}, fmt.Sprintf("shell %s@%s", h.Entry.User, h.Entry.Name))
 		}
+	case "K":
+		if len(m.hosts) > 0 {
+			h := m.hosts[m.hostCursor]
+			if h.Status != config.HostOnline {
+				m.flash = "Host is not reachable"
+				m.flashError = true
+				return m, nil
+			}
+			return m, cmdHandover("ssh-copy-id",
+				[]string{"-o", "StrictHostKeyChecking=no", "-p", fmt.Sprintf("%d", h.Entry.Port), fmt.Sprintf("%s@%s", h.Entry.User, h.Entry.Hostname)},
+				fmt.Sprintf("deploy key to %s@%s", h.Entry.User, h.Entry.Name))
+		}
 	case "R":
 		if len(m.hosts) > 0 {
 			h := m.hosts[m.hostCursor]

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -150,6 +150,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.showConfirm = false
 			m.confirmCmd = ""
 			m.confirmBanner = ""
+			m.pendingHandover = nil
 			m.flash = "Cancelled"
 			return m, nil
 		default:
@@ -178,6 +179,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(execCmd, m.startPoll())
 			}
 			return m, execCmd
+		}
+
+		if m.pendingHandover != nil {
+			c := m.pendingHandover
+			m.pendingHandover = nil
+			m.flash = ""
+			return m, c
 		}
 
 		h := m.hosts[m.selectedHost]
@@ -460,7 +468,10 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.flashError = true
 				return m, nil
 			}
-			return m, cmdHandover("ssh-copy-id",
+			m.selectedHost = m.hostCursor
+			m.showConfirm = true
+			m.confirmMessage = fmt.Sprintf("Deploy SSH key to %s@%s? [Y/n]", h.Entry.User, h.Entry.Name)
+			m.pendingHandover = cmdHandover("ssh-copy-id",
 				[]string{"-o", "StrictHostKeyChecking=no", "-p", fmt.Sprintf("%d", h.Entry.Port), fmt.Sprintf("%s@%s", h.Entry.User, h.Entry.Hostname)},
 				fmt.Sprintf("deploy key to %s@%s", h.Entry.User, h.Entry.Name))
 		}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -407,8 +407,9 @@ type Model struct {
 	// confirmation prompt
 	showConfirm    bool
 	confirmMessage string
-	confirmCmd     string
-	confirmBanner  string
+	confirmCmd      string
+	confirmBanner   string
+	pendingHandover tea.Cmd
 
 	// SSH
 	ssh   *ssh.Manager

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -128,6 +128,7 @@ func (m Model) renderHostList() string {
 			{"↑↓", "Navigate"},
 			{"Enter", "Drill In"},
 			{"x", "Shell"},
+			{"K", "Deploy Key"},
 			{"d", "Metrics"},
 			{"R", "Reboot"},
 			{"r", "Refresh"},


### PR DESCRIPTION
## Summary

- Add generic `cmdExec`/`cmdHandover` pattern for non-SSH terminal handovers (reusable for future commands)
- Add `K` keybind on Host List to run `ssh-copy-id` to the selected host, eliminating SSH password prompts permanently
- Reachability guard, hint bar entry, and 2 UI test cases

Closes FLE-65