### PR TITLE
fix: satellite detection, config delegation, registration from config (FLE-61)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -629,23 +629,7 @@ func (m Model) fetchSubscription() func() tea.Msg {
 		}
 
 		// detect registration type from server hostname
-		regType := "Unknown"
-		serverHost := ""
-		for _, line := range strings.Split(serverSection, "\n") {
-			line = strings.TrimSpace(line)
-			if strings.Contains(line, "hostname") {
-				if idx := strings.Index(line, "["); idx > 0 {
-					serverHost = strings.Trim(line[idx:], "[]")
-				}
-			}
-		}
-		if strings.Contains(serverHost, "rhsm.redhat.com") {
-			regType = "Red Hat CDN"
-		} else if strings.Contains(serverHost, "satellite") || strings.Contains(serverHost, "katello") {
-			regType = "Satellite"
-		} else if serverHost != "" {
-			regType = "Custom (" + serverHost + ")"
-		}
+		regType, serverHost := detectRegistrationType(serverSection)
 		subs = append(subs, config.Subscription{Field: "Registration", Value: regType})
 		if serverHost != "" {
 			subs = append(subs, config.Subscription{Field: "Server", Value: serverHost})
@@ -727,6 +711,31 @@ func (m Model) fetchSubscription() func() tea.Msg {
 		logger.Debug("fetch complete", "view", "subscription", "host_idx", idx, "count", len(subs), "elapsed", time.Since(start))
 		return fetchSubscriptionMsg{subs: subs}
 	}
+}
+
+// detectRegistrationType parses the [server] section of subscription-manager config
+// and returns the registration type ("Red Hat CDN", "Satellite", or "Unknown") and the server hostname.
+func detectRegistrationType(serverSection string) (regType, serverHost string) {
+	for _, line := range strings.Split(serverSection, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "hostname") {
+			if idx := strings.Index(line, "="); idx > 0 {
+				val := strings.TrimSpace(line[idx+1:])
+				val = strings.Trim(val, "[]")
+				if val != "" {
+					serverHost = val
+				}
+			}
+		}
+	}
+	if strings.HasSuffix(serverHost, "rhsm.redhat.com") {
+		regType = "Red Hat CDN"
+	} else if serverHost != "" {
+		regType = "Satellite"
+	} else {
+		regType = "Unknown"
+	}
+	return
 }
 
 // --- Accounts ---

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1129,10 +1129,28 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.confirmBanner = fmt.Sprintf("unregister from %s on %s", regType, h.Entry.Name)
 	case "g":
 		h := m.hosts[m.selectedHost]
+		orgID := h.Entry.RHOrgID
+		actKey := h.Entry.RHActivationKey
+		satURL := h.Entry.SatelliteURL
+		if orgID == "" || actKey == "" {
+			m.flash = "rh_org_id and rh_activation_key required in config"
+			m.flashError = true
+			return m, nil
+		}
+		var cmd, target string
+		if satURL != "" {
+			target = "Satellite"
+			cmd = fmt.Sprintf("sudo dnf install -y http://%s/pub/katello-ca-consumer-latest.noarch.rpm --disablerepo='*' && sudo subscription-manager register --org=%s --activationkey=%s --force",
+				shellQuote(satURL), shellQuote(orgID), shellQuote(actKey))
+		} else {
+			target = "Red Hat CDN"
+			cmd = fmt.Sprintf("sudo subscription-manager register --org=%s --activationkey=%s",
+				shellQuote(orgID), shellQuote(actKey))
+		}
 		m.showConfirm = true
-		m.confirmMessage = "Register to Red Hat CDN? [Y/n]"
-		m.pendingHandover = sshHandover(h, []string{"sudo subscription-manager register"},
-			fmt.Sprintf("register to Red Hat CDN on %s", h.Entry.Name))
+		m.confirmMessage = fmt.Sprintf("Register to %s? [Y/n]", target)
+		m.confirmCmd = cmd
+		m.confirmBanner = fmt.Sprintf("register to %s on %s", target, h.Entry.Name)
 	case "d":
 		if len(m.subscriptions) > 0 {
 			sub := m.subscriptions[m.subscriptionCursor]

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1140,11 +1140,11 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		var cmd, target string
 		if satURL != "" {
 			target = "Satellite"
-			cmd = fmt.Sprintf("sudo subscription-manager clean && sudo dnf install -y http://%s/pub/katello-ca-consumer-latest.noarch.rpm --disablerepo='*' && sudo subscription-manager register --org=%s --activationkey=%s --force",
+			cmd = fmt.Sprintf("sudo subscription-manager clean && sudo dnf install -y 'http://%s/pub/katello-ca-consumer-latest.noarch.rpm' --disablerepo='*' && sudo subscription-manager register --org='%s' --activationkey='%s' --force",
 				shellQuote(satURL), shellQuote(orgID), shellQuote(actKey))
 		} else {
 			target = "Red Hat CDN"
-			cmd = fmt.Sprintf("sudo subscription-manager register --org=%s --activationkey=%s",
+			cmd = fmt.Sprintf("sudo subscription-manager register --org='%s' --activationkey='%s'",
 				shellQuote(orgID), shellQuote(actKey))
 		}
 		m.showConfirm = true

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1140,7 +1140,7 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		var cmd, target string
 		if satURL != "" {
 			target = "Satellite"
-			cmd = fmt.Sprintf("sudo dnf install -y http://%s/pub/katello-ca-consumer-latest.noarch.rpm --disablerepo='*' && sudo subscription-manager register --org=%s --activationkey=%s --force",
+			cmd = fmt.Sprintf("sudo subscription-manager clean && sudo dnf install -y http://%s/pub/katello-ca-consumer-latest.noarch.rpm --disablerepo='*' && sudo subscription-manager register --org=%s --activationkey=%s --force",
 				shellQuote(satURL), shellQuote(orgID), shellQuote(actKey))
 		} else {
 			target = "Red Hat CDN"

--- a/internal/app/subscription_actions_test.go
+++ b/internal/app/subscription_actions_test.go
@@ -146,8 +146,26 @@ func TestUnregisterAction(t *testing.T) {
 // --- Register CDN (g key) ---
 
 func TestRegisterCDNAction(t *testing.T) {
-	t.Run("g shows confirm with pendingHandover set", func(t *testing.T) {
+	t.Run("g without config shows flash error", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+		result, cmd := m.handleSubscriptionKeys(msg)
+		m2 := result.(Model)
+		if cmd != nil {
+			t.Error("expected nil cmd")
+		}
+		if m2.showConfirm {
+			t.Error("expected showConfirm = false without config")
+		}
+		if !m2.flashError {
+			t.Error("expected flashError = true")
+		}
+	})
+
+	t.Run("g with CDN config registers to CDN", func(t *testing.T) {
+		m := subscriptionModel("Unknown")
+		m.hosts[0].Entry.RHOrgID = "12345"
+		m.hosts[0].Entry.RHActivationKey = "ak-cdn"
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 		result, cmd := m.handleSubscriptionKeys(msg)
 		m2 := result.(Model)
@@ -157,17 +175,38 @@ func TestRegisterCDNAction(t *testing.T) {
 		if !m2.showConfirm {
 			t.Error("expected showConfirm = true")
 		}
-		if m2.pendingHandover == nil {
-			t.Error("expected pendingHandover to be set")
+		if !strings.Contains(m2.confirmMessage, "Red Hat CDN") {
+			t.Errorf("confirmMessage = %q, should mention Red Hat CDN", m2.confirmMessage)
 		}
-		if !strings.Contains(m2.confirmMessage, "CDN") {
-			t.Errorf("confirmMessage = %q, should mention CDN", m2.confirmMessage)
+		if strings.Contains(m2.confirmCmd, "katello") {
+			t.Errorf("CDN register should not install katello, got: %s", m2.confirmCmd)
 		}
 	})
 
-	t.Run("g is always available (no guard)", func(t *testing.T) {
+	t.Run("g with satellite_url registers to Satellite", func(t *testing.T) {
+		m := subscriptionModel("Unknown")
+		m.hosts[0].Entry.RHOrgID = "Fluxys"
+		m.hosts[0].Entry.RHActivationKey = "ak-sat"
+		m.hosts[0].Entry.SatelliteURL = "flxsatprd01.central.fluxys.int"
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
+		result, _ := m.handleSubscriptionKeys(msg)
+		m2 := result.(Model)
+		if !strings.Contains(m2.confirmMessage, "Satellite") {
+			t.Errorf("confirmMessage = %q, should mention Satellite", m2.confirmMessage)
+		}
+		if !strings.Contains(m2.confirmCmd, "katello-ca-consumer") {
+			t.Errorf("Satellite register should install katello, got: %s", m2.confirmCmd)
+		}
+		if !strings.Contains(m2.confirmCmd, "--force") {
+			t.Errorf("Satellite register should use --force, got: %s", m2.confirmCmd)
+		}
+	})
+
+	t.Run("g is always available regardless of registration state", func(t *testing.T) {
 		for _, regType := range []string{"", "Unknown", "Red Hat CDN", "Satellite"} {
 			m := subscriptionModel(regType)
+			m.hosts[0].Entry.RHOrgID = "12345"
+			m.hosts[0].Entry.RHActivationKey = "ak-test"
 			msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 			result, _ := m.handleSubscriptionKeys(msg)
 			m2 := result.(Model)
@@ -181,7 +220,8 @@ func TestRegisterCDNAction(t *testing.T) {
 		m := subscriptionModel("Unknown")
 		m.showConfirm = true
 		m.confirmMessage = "Register to Red Hat CDN? [Y/n]"
-		m.pendingHandover = func() tea.Msg { return nil } // stub
+		m.confirmCmd = "sudo subscription-manager register --org=12345 --activationkey=ak-test"
+		m.confirmBanner = "register to Red Hat CDN on host1"
 
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
 		result, cmd := m.handleKey(msg)
@@ -192,15 +232,12 @@ func TestRegisterCDNAction(t *testing.T) {
 		if m2.showConfirm {
 			t.Error("expected showConfirm = false after confirm")
 		}
-		if m2.pendingHandover != nil {
-			t.Error("expected pendingHandover to be cleared")
-		}
 	})
 
 	t.Run("g confirm no cancels", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
 		m.showConfirm = true
-		m.pendingHandover = func() tea.Msg { return nil } // stub
+		m.confirmCmd = "sudo subscription-manager register --org=12345 --activationkey=ak-test"
 
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
 		result, cmd := m.handleKey(msg)
@@ -217,11 +254,23 @@ func TestRegisterCDNAction(t *testing.T) {
 // --- Hint bar ---
 
 func TestSubscriptionHintBar(t *testing.T) {
-	m := subscriptionModel("Red Hat CDN")
-	rendered := m.renderSubscription()
-	for _, hint := range []string{"u", "Unregister", "g", "Register"} {
-		if !strings.Contains(rendered, hint) {
-			t.Errorf("hint bar missing %q", hint)
+	t.Run("CDN host shows Register CDN", func(t *testing.T) {
+		m := subscriptionModel("Red Hat CDN")
+		rendered := m.renderSubscription()
+		if !strings.Contains(rendered, "Unregister") {
+			t.Error("hint bar missing Unregister")
 		}
-	}
+		if !strings.Contains(rendered, "Register CDN") {
+			t.Error("hint bar missing Register CDN")
+		}
+	})
+
+	t.Run("Satellite host shows Register Satellite", func(t *testing.T) {
+		m := subscriptionModel("Satellite")
+		m.hosts[0].Entry.SatelliteURL = "sat.example.com"
+		rendered := m.renderSubscription()
+		if !strings.Contains(rendered, "Register Satellite") {
+			t.Error("hint bar missing Register Satellite")
+		}
+	})
 }

--- a/internal/app/subscription_detection_test.go
+++ b/internal/app/subscription_detection_test.go
@@ -1,0 +1,72 @@
+package app
+
+import "testing"
+
+func TestDetectRegistrationType(t *testing.T) {
+	tests := []struct {
+		name       string
+		section    string
+		wantType   string
+		wantHost   string
+	}{
+		{
+			name:     "CDN with plain value",
+			section:  "   hostname = rhsm.redhat.com\n   prefix = /subscription",
+			wantType: "Red Hat CDN",
+			wantHost: "rhsm.redhat.com",
+		},
+		{
+			name:     "CDN with subdomain",
+			section:  "   hostname = subscription.rhsm.redhat.com",
+			wantType: "Red Hat CDN",
+			wantHost: "subscription.rhsm.redhat.com",
+		},
+		{
+			name:     "CDN with bracketed value",
+			section:  "   hostname = [rhsm.redhat.com]\n   prefix = [/subscription]",
+			wantType: "Red Hat CDN",
+			wantHost: "rhsm.redhat.com",
+		},
+		{
+			name:     "Satellite with custom hostname",
+			section:  "   hostname = flxsatprd01.central.fluxys.int\n   prefix = /rhsm",
+			wantType: "Satellite",
+			wantHost: "flxsatprd01.central.fluxys.int",
+		},
+		{
+			name:     "Satellite with satellite in hostname",
+			section:  "   hostname = satellite.example.com",
+			wantType: "Satellite",
+			wantHost: "satellite.example.com",
+		},
+		{
+			name:     "empty section",
+			section:  "",
+			wantType: "Unknown",
+			wantHost: "",
+		},
+		{
+			name:     "no hostname line",
+			section:  "   prefix = /subscription\n   port = 443",
+			wantType: "Unknown",
+			wantHost: "",
+		},
+		{
+			name:     "hostname with empty value",
+			section:  "   hostname = []",
+			wantType: "Unknown",
+			wantHost: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotHost := detectRegistrationType(tt.section)
+			if gotType != tt.wantType {
+				t.Errorf("regType = %q, want %q", gotType, tt.wantType)
+			}
+			if gotHost != tt.wantHost {
+				t.Errorf("serverHost = %q, want %q", gotHost, tt.wantHost)
+			}
+		})
+	}
+}

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -76,10 +76,14 @@ func (m Model) renderSubscription() string {
 	if m.showConfirm {
 		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
 	} else {
+		regTarget := "Register CDN"
+		if h.Entry.SatelliteURL != "" {
+			regTarget = "Register Satellite"
+		}
 		s += m.renderSudoPromptOrHintBar([][]string{
 			{"↑↓", "Navigate"},
 			{"u", "Unregister"},
-			{"g", "Register CDN"},
+			{"g", regTarget},
 			{"d", "Disable Repo"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -30,6 +30,9 @@ type defaultsFile struct {
 	ServiceFilter   []string `yaml:"service_filter"`
 	ErrorLogSince   string   `yaml:"error_log_since"`
 	RefreshInterval string   `yaml:"refresh_interval"`
+	RHOrgID         string   `yaml:"rh_org_id"`
+	RHActivationKey string   `yaml:"rh_activation_key"`
+	SatelliteURL    string   `yaml:"satellite_url"`
 }
 
 type groupFile struct {
@@ -39,13 +42,16 @@ type groupFile struct {
 }
 
 type hostEntryFile struct {
-	Name          string   `yaml:"name"`
-	Hostname      string   `yaml:"hostname"`
-	User          string   `yaml:"user"`
-	Port          int      `yaml:"port"`
-	Timeout       string   `yaml:"timeout"`
-	SystemdMode   string   `yaml:"systemd_mode"`
-	ServiceFilter []string `yaml:"service_filter"`
+	Name            string   `yaml:"name"`
+	Hostname        string   `yaml:"hostname"`
+	User            string   `yaml:"user"`
+	Port            int      `yaml:"port"`
+	Timeout         string   `yaml:"timeout"`
+	SystemdMode     string   `yaml:"systemd_mode"`
+	ServiceFilter   []string `yaml:"service_filter"`
+	RHOrgID         string   `yaml:"rh_org_id"`
+	RHActivationKey string   `yaml:"rh_activation_key"`
+	SatelliteURL    string   `yaml:"satellite_url"`
 }
 
 // ParseFleetFile reads and parses a single fleet YAML file.
@@ -85,6 +91,9 @@ func ParseFleetFile(path string) (Fleet, error) {
 		ServiceFilter:   raw.Defaults.ServiceFilter,
 		ErrorLogSince:   raw.Defaults.ErrorLogSince,
 		RefreshInterval: raw.Defaults.RefreshInterval,
+		RHOrgID:         raw.Defaults.RHOrgID,
+		RHActivationKey: raw.Defaults.RHActivationKey,
+		SatelliteURL:    raw.Defaults.SatelliteURL,
 	}
 	if defaults.Port == 0 {
 		defaults.Port = 22
@@ -158,11 +167,14 @@ func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string
 		}
 
 		h := HostEntry{
-			Name:        r.Name,
-			Hostname:    r.Hostname,
-			User:        r.User,
-			Port:        r.Port,
-			SystemdMode: r.SystemdMode,
+			Name:            r.Name,
+			Hostname:        r.Hostname,
+			User:            r.User,
+			Port:            r.Port,
+			SystemdMode:     r.SystemdMode,
+			RHOrgID:         r.RHOrgID,
+			RHActivationKey: r.RHActivationKey,
+			SatelliteURL:    r.SatelliteURL,
 		}
 
 		// service filter: host → group → defaults
@@ -184,6 +196,16 @@ func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string
 		}
 		if h.SystemdMode == "" {
 			h.SystemdMode = defaults.SystemdMode
+		}
+		// RH subscription: if host defines its own org, it's a complete override — don't inherit satellite_url
+		if h.RHOrgID != "" {
+			if h.RHActivationKey == "" {
+				h.RHActivationKey = defaults.RHActivationKey
+			}
+		} else {
+			h.RHOrgID = defaults.RHOrgID
+			h.RHActivationKey = defaults.RHActivationKey
+			h.SatelliteURL = defaults.SatelliteURL
 		}
 
 		if r.Timeout != "" {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -24,6 +24,9 @@ type HostDefaults struct {
 	ServiceFilter   []string      `yaml:"service_filter"`
 	ErrorLogSince   string
 	RefreshInterval string
+	RHOrgID         string `yaml:"rh_org_id"`
+	RHActivationKey string `yaml:"rh_activation_key"`
+	SatelliteURL    string `yaml:"satellite_url"`
 }
 
 // HostGroup provides visual grouping of hosts.
@@ -34,13 +37,16 @@ type HostGroup struct {
 
 // HostEntry represents a single host definition in a fleet file.
 type HostEntry struct {
-	Name          string        `yaml:"name"`
-	Hostname      string        `yaml:"hostname"`
-	User          string        `yaml:"user"`
-	Port          int           `yaml:"port"`
-	Timeout       time.Duration `yaml:"timeout"`
-	SystemdMode   string        `yaml:"systemd_mode"`
-	ServiceFilter []string
+	Name            string        `yaml:"name"`
+	Hostname        string        `yaml:"hostname"`
+	User            string        `yaml:"user"`
+	Port            int           `yaml:"port"`
+	Timeout         time.Duration `yaml:"timeout"`
+	SystemdMode     string        `yaml:"systemd_mode"`
+	ServiceFilter   []string
+	RHOrgID         string `yaml:"rh_org_id"`
+	RHActivationKey string `yaml:"rh_activation_key"`
+	SatelliteURL    string `yaml:"satellite_url"`
 }
 
 // Host is the runtime representation of a host with connection state.


### PR DESCRIPTION
## Summary

- Fix registration type detection: parse `hostname = value` format (not just `[bracketed]`), use `HasSuffix` for `rhsm.redhat.com` to handle subdomains like `subscription.rhsm.redhat.com`, any other hostname is Satellite
- Add `rh_org_id`, `rh_activation_key`, `satellite_url` to fleet defaults and host-level config with proper delegation — host-level `rh_org_id` overrides entire registration config (no inherited `satellite_url`)
- Register action (`g`) builds command from config: CDN (`--org` + `--activationkey`) or Satellite (install katello-ca-consumer + register with `--force`)
- Hint bar dynamically shows `Register CDN` or `Register Satellite` based on host config
- 8 detection test cases, updated action tests covering CDN/Satellite/override/fallback scenarios