### PR TITLE
feat: configurable fleet directory + first-run wizard + config view (FLE-68)

### DIFF
--- a/internal/app/handover.go
+++ b/internal/app/handover.go
@@ -87,7 +87,10 @@ func (e *editorExec) Run() error {
 		editor = "vi"
 	}
 
-	c := exec.Command(editor, e.path)
+	// Split editor string to support "code --wait" style commands
+	parts := strings.Fields(editor)
+	args := append(parts[1:], e.path)
+	c := exec.Command(parts[0], args...)
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr

--- a/internal/app/handover.go
+++ b/internal/app/handover.go
@@ -89,6 +89,9 @@ func (e *editorExec) Run() error {
 
 	// Split editor string to support "code --wait" style commands
 	parts := strings.Fields(editor)
+	if len(parts) == 0 {
+		parts = []string{"vi"}
+	}
 	args := append(parts[1:], e.path)
 	c := exec.Command(parts[0], args...)
 	c.Stdin = os.Stdin

--- a/internal/app/handover.go
+++ b/internal/app/handover.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -20,7 +21,8 @@ type sshHandoverFinishedMsg struct {
 
 // editFinishedMsg is sent when the editor returns.
 type editFinishedMsg struct {
-	Err error
+	Err        error
+	configEdit bool // true when config.yaml was edited (triggers config reload)
 }
 
 // sshExec wraps an SSH command with terminal handover.
@@ -68,12 +70,16 @@ func (s *sshExec) SetStderr(_ io.Writer) {}
 
 // editorExec wraps an editor command for terminal handover.
 type editorExec struct {
-	path string
-	err  error
+	path   string
+	editor string // resolved editor command
+	err    error
 }
 
 func (e *editorExec) Run() error {
-	editor := os.Getenv("EDITOR")
+	editor := e.editor
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
 	if editor == "" {
 		editor = os.Getenv("VISUAL")
 	}
@@ -96,9 +102,18 @@ func (e *editorExec) SetStderr(_ io.Writer) {}
 // editFleetFile opens the selected fleet file in the user's editor.
 func (m Model) editFleetFile() tea.Cmd {
 	f := m.fleets[m.fleetCursor]
-	e := &editorExec{path: f.Path}
+	e := &editorExec{path: f.Path, editor: m.appCfg.Editor()}
 	return tea.Exec(e, func(err error) tea.Msg {
 		return editFinishedMsg{Err: e.err}
+	})
+}
+
+// editConfigFile opens config.yaml in the user's editor.
+func (m Model) editConfigFile() tea.Cmd {
+	path := filepath.Join(config.ConfigPath(), "config.yaml")
+	e := &editorExec{path: path, editor: m.appCfg.Editor()}
+	return tea.Exec(e, func(err error) tea.Msg {
+		return editFinishedMsg{Err: e.err, configEdit: true}
 	})
 }
 

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -12,6 +12,12 @@ import (
 )
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// modal overlay -- intercept all keys
+	if m.modal != nil && !m.modal.Done() {
+		cmd := m.modal.HandleKey(msg)
+		return m, cmd
+	}
+
 	// log detail mode -- any key goes back
 	if m.showLogDetail {
 		m.showLogDetail = false
@@ -358,6 +364,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleK8sPodDetailKeys(msg)
 	case viewK8sPodLogs:
 		return m.handleK8sPodLogKeys(msg)
+	case viewConfig:
+		return m.handleConfigKeys(msg)
 	}
 	return m, nil
 }
@@ -372,12 +380,15 @@ func (m Model) handleFleetPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.fleetCursor < len(m.fleets)-1 {
 			m.fleetCursor++
 		}
+	case "c":
+		m.view = viewConfig
+		return m, nil
 	case "e":
 		if len(m.fleets) > 0 {
 			return m, m.editFleetFile()
 		}
 	case "r":
-		fleets, err := config.ScanFleets()
+		fleets, err := config.ScanFleets(m.appCfg.FleetDir)
 		if err != nil {
 			m.flash = fmt.Sprintf("Reload failed: %v", err)
 			m.flashError = true

--- a/internal/app/modal.go
+++ b/internal/app/modal.go
@@ -1,0 +1,302 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// StepContent is the interface for modal step content types.
+type StepContent interface {
+	HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool)
+	View(width int) string
+	Result() any
+}
+
+// ModalStep represents a single step in a multi-step modal.
+type ModalStep struct {
+	Title   string
+	Content StepContent
+}
+
+// ModalOverlay is a centered dialog rendered on top of the current view.
+type ModalOverlay struct {
+	title      string
+	steps      []ModalStep
+	current    int
+	results    []any
+	OnComplete func([]any) tea.Cmd
+	OnCancel   func() tea.Cmd
+	done       bool
+}
+
+// NewModalOverlay creates a new modal overlay.
+func NewModalOverlay(title string, steps []ModalStep, onComplete func([]any) tea.Cmd, onCancel func() tea.Cmd) *ModalOverlay {
+	return &ModalOverlay{
+		title:      title,
+		steps:      steps,
+		results:    make([]any, 0, len(steps)),
+		OnComplete: onComplete,
+		OnCancel:   onCancel,
+	}
+}
+
+// HandleKey processes a key event, returning an optional tea.Cmd.
+func (m *ModalOverlay) HandleKey(msg tea.KeyMsg) tea.Cmd {
+	if msg.Type == tea.KeyEsc {
+		if m.current == 0 {
+			m.done = true
+			if m.OnCancel != nil {
+				return m.OnCancel()
+			}
+			return nil
+		}
+		// Go back: trim results and restore previous step
+		m.current--
+		if len(m.results) > m.current {
+			m.results = m.results[:m.current]
+		}
+		return nil
+	}
+
+	step := &m.steps[m.current]
+	newContent, cmd, done := step.Content.HandleKey(msg)
+	step.Content = newContent
+
+	if done {
+		m.results = append(m.results, step.Content.Result())
+		m.current++
+		if m.current >= len(m.steps) {
+			m.done = true
+			if m.OnComplete != nil {
+				return m.OnComplete(m.results)
+			}
+			return cmd
+		}
+	}
+	return cmd
+}
+
+// View renders the modal overlay on top of a background view.
+func (m *ModalOverlay) View(bgView string, width, height int) string {
+	modalWidth := min(width-10, 80)
+	modalWidth = max(modalWidth, 50)
+	innerWidth := modalWidth - 4 // padding
+
+	// Title bar
+	stepInfo := fmt.Sprintf("Step %d/%d", m.current+1, len(m.steps))
+	titleGap := innerWidth - len(m.title) - len(stepInfo)
+	if titleGap < 1 {
+		titleGap = 1
+	}
+	titleLine := modalTitleStyle.Render(m.title) + strings.Repeat(" ", titleGap) + modalDimStyle.Render(stepInfo)
+
+	// Step content
+	stepTitle := ""
+	content := ""
+	if m.current < len(m.steps) {
+		stepTitle = m.steps[m.current].Title
+		content = m.steps[m.current].Content.View(innerWidth)
+	}
+
+	// Footer
+	footer := modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
+		"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("cancel")
+	if m.current > 0 {
+		footer = modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
+			"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("back")
+	}
+
+	// Build modal box
+	box := lipgloss.NewStyle().
+		Width(modalWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorBlue).
+		Padding(1, 2).
+		Render(titleLine + "\n\n" + stepTitle + "\n\n" + content + "\n\n" + footer)
+
+	// Place centered modal; the bgView parameter is available for future
+	// compositing but the current approach uses Place's whitespace fill
+	// to create the dimmed-background effect.
+	_ = bgView
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, box,
+		lipgloss.WithWhitespaceBackground(lipgloss.Color("0")),
+		lipgloss.WithWhitespaceForeground(lipgloss.Color("235")),
+		lipgloss.WithWhitespaceChars("░"),
+	)
+}
+
+// Done returns true if the modal has completed or been cancelled.
+func (m *ModalOverlay) Done() bool {
+	return m.done
+}
+
+// --- TextInputContent ---
+
+// TextInputContent is a single-line text input with optional validation.
+type TextInputContent struct {
+	prompt   string
+	value    string
+	validate func(string) error
+	err      string
+}
+
+// NewTextInputContent creates a text input step.
+func NewTextInputContent(prompt string, validate func(string) error) StepContent {
+	return &TextInputContent{prompt: prompt, validate: validate}
+}
+
+func (t *TextInputContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.Type {
+	case tea.KeyEnter:
+		if t.value == "" {
+			t.err = "Value cannot be empty"
+			return t, nil, false
+		}
+		if t.validate != nil {
+			if err := t.validate(t.value); err != nil {
+				t.err = err.Error()
+				return t, nil, false
+			}
+		}
+		t.err = ""
+		return t, nil, true
+	case tea.KeyBackspace:
+		if len(t.value) > 0 {
+			runes := []rune(t.value)
+			t.value = string(runes[:len(runes)-1])
+		}
+		t.err = ""
+	default:
+		if msg.Type == tea.KeyRunes {
+			t.value += string(msg.Runes)
+			t.err = ""
+		}
+	}
+	return t, nil, false
+}
+
+func (t *TextInputContent) View(width int) string {
+	cursor := "█"
+	input := t.value + cursor
+	line := modalInputStyle.Width(width).Render(input)
+	if t.err != "" {
+		line += "\n" + modalErrorStyle.Render(t.err)
+	}
+	return line
+}
+
+func (t *TextInputContent) Result() any {
+	return t.value
+}
+
+// Value returns the current text input value.
+func (t *TextInputContent) Value() string {
+	return t.value
+}
+
+// SetValue sets the text input value (used for pre-populating).
+func (t *TextInputContent) SetValue(v string) {
+	t.value = v
+}
+
+// --- SelectContent ---
+
+// SelectContent is an arrow-key list picker.
+type SelectContent struct {
+	prompt  string
+	options []string
+	cursor  int
+}
+
+// NewSelectContent creates a select picker step.
+func NewSelectContent(prompt string, options []string) StepContent {
+	return &SelectContent{prompt: prompt, options: options}
+}
+
+func (s *SelectContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.String() {
+	case "up", "k":
+		if s.cursor > 0 {
+			s.cursor--
+		}
+	case "down", "j":
+		if s.cursor < len(s.options)-1 {
+			s.cursor++
+		}
+	case "enter":
+		return s, nil, true
+	}
+	return s, nil, false
+}
+
+func (s *SelectContent) View(width int) string {
+	var lines []string
+	for i, opt := range s.options {
+		cursor := "  "
+		if i == s.cursor {
+			cursor = "▸ "
+		}
+		style := normalRowStyle
+		if i == s.cursor {
+			style = selectedRowStyle
+		}
+		lines = append(lines, style.Render(cursor+opt))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (s *SelectContent) Result() any {
+	if s.cursor < len(s.options) {
+		return s.options[s.cursor]
+	}
+	return ""
+}
+
+// --- StaticContent ---
+
+// StaticContent is scrollable read-only text (for help overlays).
+type StaticContent struct {
+	text   string
+	scroll int
+}
+
+// NewStaticContent creates a read-only text step.
+func NewStaticContent(text string) StepContent {
+	return &StaticContent{text: text}
+}
+
+func (s *StaticContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.String() {
+	case "up", "k":
+		if s.scroll > 0 {
+			s.scroll--
+		}
+	case "down", "j":
+		s.scroll++
+	case "enter":
+		return s, nil, true
+	}
+	return s, nil, false
+}
+
+func (s *StaticContent) View(width int) string {
+	lines := strings.Split(s.text, "\n")
+	if s.scroll >= len(lines) {
+		s.scroll = len(lines) - 1
+	}
+	if s.scroll < 0 {
+		s.scroll = 0
+	}
+	visible := lines[s.scroll:]
+	if len(visible) > 20 {
+		visible = visible[:20]
+	}
+	return strings.Join(visible, "\n")
+}
+
+func (s *StaticContent) Result() any {
+	return nil
+}

--- a/internal/app/modal_test.go
+++ b/internal/app/modal_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTextInputContent_HandleKey(t *testing.T) {
+	t.Run("rune accumulation", func(t *testing.T) {
+		ti := NewTextInputContent("Enter path:", nil)
+		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
+		ti2, _, done := ti.HandleKey(msg)
+		if done {
+			t.Error("should not be done after rune")
+		}
+		if ti2.(*TextInputContent).Value() != "a" {
+			t.Errorf("value = %q, want %q", ti2.(*TextInputContent).Value(), "a")
+		}
+	})
+
+	t.Run("backspace", func(t *testing.T) {
+		ti := NewTextInputContent("Enter path:", nil)
+		// type "abc"
+		for _, r := range "abc" {
+			ti, _, _ = ti.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+		// backspace
+		ti, _, _ = ti.HandleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		if ti.(*TextInputContent).Value() != "ab" {
+			t.Errorf("value = %q, want %q", ti.(*TextInputContent).Value(), "ab")
+		}
+	})
+
+	t.Run("enter with valid input", func(t *testing.T) {
+		ti := NewTextInputContent("Enter path:", nil)
+		// type something
+		for _, r := range "/tmp" {
+			ti, _, _ = ti.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+		_, _, done := ti.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		if !done {
+			t.Error("expected done on Enter with valid input")
+		}
+	})
+
+	t.Run("enter with validation error", func(t *testing.T) {
+		validator := func(s string) error {
+			return fmt.Errorf("invalid")
+		}
+		ti := NewTextInputContent("Enter path:", validator)
+		for _, r := range "bad" {
+			ti, _, _ = ti.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+		ti2, _, done := ti.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		if done {
+			t.Error("should not be done when validation fails")
+		}
+		if ti2.(*TextInputContent).err == "" {
+			t.Error("expected error message set")
+		}
+	})
+}
+
+func TestSelectContent_HandleKey(t *testing.T) {
+	t.Run("down moves cursor", func(t *testing.T) {
+		sc := NewSelectContent("Pick:", []string{"vim", "nvim", "nano"})
+		sc2, _, _ := sc.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+		if sc2.(*SelectContent).cursor != 1 {
+			t.Errorf("cursor = %d, want 1", sc2.(*SelectContent).cursor)
+		}
+	})
+
+	t.Run("up at 0 stays", func(t *testing.T) {
+		sc := NewSelectContent("Pick:", []string{"vim", "nvim"})
+		sc2, _, _ := sc.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+		if sc2.(*SelectContent).cursor != 0 {
+			t.Errorf("cursor = %d, want 0", sc2.(*SelectContent).cursor)
+		}
+	})
+
+	t.Run("enter selects", func(t *testing.T) {
+		sc := NewSelectContent("Pick:", []string{"vim", "nvim", "nano"})
+		// move to nvim
+		sc, _, _ = sc.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+		_, _, done := sc.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		if !done {
+			t.Error("expected done on Enter")
+		}
+		if sc.(*SelectContent).Result().(string) != "nvim" {
+			t.Errorf("result = %q, want %q", sc.(*SelectContent).Result(), "nvim")
+		}
+	})
+}
+
+func TestModalOverlay_EscCancels(t *testing.T) {
+	cancelled := false
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "Step 1", Content: NewTextInputContent("Input:", nil)},
+	}, func(results []any) tea.Cmd { return nil }, func() tea.Cmd {
+		cancelled = true
+		return nil
+	})
+
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !cancelled {
+		t.Error("Esc at step 0 should call OnCancel")
+	}
+}
+
+func TestModalOverlay_EscGoesBack(t *testing.T) {
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "Step 1", Content: NewTextInputContent("Input:", nil)},
+		{Title: "Step 2", Content: NewSelectContent("Pick:", []string{"a", "b"})},
+	}, func(results []any) tea.Cmd { return nil }, func() tea.Cmd { return nil })
+
+	// type something and advance to step 2
+	for _, r := range "/tmp" {
+		m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.current != 1 {
+		t.Fatalf("expected step 1, got %d", m.current)
+	}
+
+	// Esc should go back to step 0
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.current != 0 {
+		t.Errorf("expected step 0 after Esc, got %d", m.current)
+	}
+}
+
+func TestModalOverlay_MultiStepAdvance(t *testing.T) {
+	var gotResults []any
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "Step 1", Content: NewTextInputContent("Input:", nil)},
+		{Title: "Step 2", Content: NewSelectContent("Pick:", []string{"vim", "nvim"})},
+	}, func(results []any) tea.Cmd {
+		gotResults = results
+		return nil
+	}, func() tea.Cmd { return nil })
+
+	// Step 1: type path and Enter
+	for _, r := range "/tmp" {
+		m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Step 2: select nvim (down + Enter)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if len(gotResults) != 2 {
+		t.Fatalf("got %d results, want 2", len(gotResults))
+	}
+	if gotResults[0] != "/tmp" {
+		t.Errorf("result[0] = %v, want /tmp", gotResults[0])
+	}
+	if gotResults[1] != "nvim" {
+		t.Errorf("result[1] = %v, want nvim", gotResults[1])
+	}
+}

--- a/internal/app/modal_wizard.go
+++ b/internal/app/modal_wizard.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
@@ -14,6 +16,11 @@ type wizardCompleteMsg struct {
 
 // wizardCancelMsg is sent when the user cancels the wizard.
 type wizardCancelMsg struct{}
+
+// wizardErrorMsg is sent when the wizard encounters an error during finalization.
+type wizardErrorMsg struct {
+	err error
+}
 
 // wizardNeedCustomEditorMsg triggers a follow-up modal for custom editor input.
 type wizardNeedCustomEditorMsg struct {
@@ -86,17 +93,17 @@ func finalizeWizard(fleetDir, editor string) tea.Cmd {
 	return func() tea.Msg {
 		configDir := config.ConfigPath()
 		if err := config.WriteDefaultAppConfig(configDir, fleetDir, editor); err != nil {
-			return wizardCancelMsg{}
+			return wizardErrorMsg{err: fmt.Errorf("writing config: %w", err)}
 		}
 
 		appCfg, err := config.LoadAppConfig(configDir)
 		if err != nil {
-			return wizardCancelMsg{}
+			return wizardErrorMsg{err: fmt.Errorf("loading config: %w", err)}
 		}
 
 		fleets, err := config.ScanFleets(appCfg.FleetDir)
 		if err != nil {
-			return wizardCancelMsg{}
+			return wizardErrorMsg{err: fmt.Errorf("scanning fleets: %w", err)}
 		}
 
 		return wizardCompleteMsg{appCfg: appCfg, fleets: fleets}

--- a/internal/app/modal_wizard.go
+++ b/internal/app/modal_wizard.go
@@ -1,0 +1,110 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+// wizardCompleteMsg is sent when the first-run wizard finishes.
+type wizardCompleteMsg struct {
+	appCfg config.AppConfig
+	fleets []config.Fleet
+}
+
+// wizardCancelMsg is sent when the user cancels the wizard.
+type wizardCancelMsg struct{}
+
+// wizardNeedCustomEditorMsg triggers a follow-up modal for custom editor input.
+type wizardNeedCustomEditorMsg struct {
+	fleetDir string
+}
+
+// NewFirstRunWizard creates the 2-step first-run setup modal.
+// If user selects "custom" editor, a follow-up modal is triggered via wizardNeedCustomEditorMsg.
+func NewFirstRunWizard() *ModalOverlay {
+	return newWizardSteps()
+}
+
+func newWizardSteps() *ModalOverlay {
+	editorOptions := []string{"vim", "neovim", "nano", "custom"}
+
+	steps := []ModalStep{
+		{
+			Title: "Enter the path to your fleet files directory",
+			Content: NewTextInputContent("Fleet directory:", func(s string) error {
+				return config.ValidateFleetDir(s)
+			}),
+		},
+		{
+			Title:   "Select your preferred editor",
+			Content: NewSelectContent("Editor:", editorOptions),
+		},
+	}
+
+	return NewModalOverlay("FleetDesk Setup", steps,
+		func(results []any) tea.Cmd {
+			fleetDir := results[0].(string)
+			editorChoice := results[1].(string)
+
+			if editorChoice == "custom" {
+				return func() tea.Msg {
+					return wizardNeedCustomEditorMsg{fleetDir: fleetDir}
+				}
+			}
+
+			editor := editorChoice
+			if editorChoice == "neovim" {
+				editor = "nvim"
+			}
+
+			return finalizeWizard(fleetDir, editor)
+		},
+		cancelWizard,
+	)
+}
+
+// newCustomEditorWizard creates a 1-step modal for custom editor input.
+func newCustomEditorWizard(fleetDir string) *ModalOverlay {
+	steps := []ModalStep{
+		{
+			Title:   "Enter your editor command",
+			Content: NewTextInputContent("Editor command:", nil),
+		},
+	}
+
+	return NewModalOverlay("FleetDesk Setup", steps,
+		func(results []any) tea.Cmd {
+			editor := results[0].(string)
+			return finalizeWizard(fleetDir, editor)
+		},
+		cancelWizard,
+	)
+}
+
+func finalizeWizard(fleetDir, editor string) tea.Cmd {
+	return func() tea.Msg {
+		configDir := config.ConfigPath()
+		if err := config.WriteDefaultAppConfig(configDir, fleetDir, editor); err != nil {
+			return wizardCancelMsg{}
+		}
+
+		appCfg, err := config.LoadAppConfig(configDir)
+		if err != nil {
+			return wizardCancelMsg{}
+		}
+
+		fleets, err := config.ScanFleets(appCfg.FleetDir)
+		if err != nil {
+			return wizardCancelMsg{}
+		}
+
+		return wizardCompleteMsg{appCfg: appCfg, fleets: fleets}
+	}
+}
+
+func cancelWizard() tea.Cmd {
+	return func() tea.Msg {
+		return wizardCancelMsg{}
+	}
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -442,8 +442,9 @@ type Model struct {
 	appCfg config.AppConfig
 
 	// modal overlay
-	modal          *ModalOverlay
+	modal           *ModalOverlay
 	wizardCancelled bool
+	wizardExitError error
 }
 
 func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logger, version string) Model {
@@ -470,6 +471,11 @@ func (m Model) Init() tea.Cmd {
 // WizardCancelled returns true if the first-run wizard was cancelled.
 func (m Model) WizardCancelled() bool {
 	return m.wizardCancelled
+}
+
+// WizardError returns the error that caused the wizard to fail, or nil.
+func (m Model) WizardError() error {
+	return m.wizardExitError
 }
 
 // handleSudoOrFlash checks if err is a sudo password error.
@@ -529,6 +535,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case wizardCancelMsg:
 		m.modal = nil
 		m.wizardCancelled = true
+		return m, tea.Quit
+
+	case wizardErrorMsg:
+		m.modal = nil
+		m.wizardCancelled = true
+		m.wizardExitError = msg.err
 		return m, tea.Quit
 
 	case wizardNeedCustomEditorMsg:

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -211,6 +211,7 @@ const (
 	viewK8sPodList
 	viewK8sPodDetail
 	viewK8sPodLogs
+	viewConfig
 )
 
 // resourceCount is the number of items in the resource picker (0-indexed).
@@ -436,22 +437,39 @@ type Model struct {
 
 	// app info
 	version string
+
+	// config
+	appCfg config.AppConfig
+
+	// modal overlay
+	modal          *ModalOverlay
+	wizardCancelled bool
 }
 
-func NewModel(fleets []config.Fleet, logger *slog.Logger, version string) Model {
-	return Model{
+func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logger, version string) Model {
+	m := Model{
 		view:    viewFleetPicker,
 		fleets:  fleets,
-		ssh:   ssh.NewManager(logger),
-		azure: azure.NewManager(logger),
-		k8s:   k8s.NewManager(logger),
+		appCfg:  appCfg,
+		ssh:     ssh.NewManager(logger),
+		azure:   azure.NewManager(logger),
+		k8s:     k8s.NewManager(logger),
 		logger:  logger,
 		version: version,
 	}
+	if appCfg.FleetDir == "" {
+		m.modal = NewFirstRunWizard()
+	}
+	return m
 }
 
 func (m Model) Init() tea.Cmd {
 	return nil
+}
+
+// WizardCancelled returns true if the first-run wizard was cancelled.
+func (m Model) WizardCancelled() bool {
+	return m.wizardCancelled
 }
 
 // handleSudoOrFlash checks if err is a sudo password error.
@@ -498,6 +516,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+		return m, nil
+
+	case wizardCompleteMsg:
+		m.modal = nil
+		m.appCfg = msg.appCfg
+		m.fleets = msg.fleets
+		m.view = viewFleetPicker
+		m.flash = "Setup complete"
+		return m, nil
+
+	case wizardCancelMsg:
+		m.modal = nil
+		m.wizardCancelled = true
+		return m, tea.Quit
+
+	case wizardNeedCustomEditorMsg:
+		m.modal = newCustomEditorWizard(msg.fleetDir)
 		return m, nil
 
 	case ssh.HostProbeResult:
@@ -1262,8 +1297,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.fetchServices()
 
 	case editFinishedMsg:
-		// reload fleets after editor returns
-		fleets, err := config.ScanFleets()
+		// reload config + fleets after editor returns
+		if msg.configEdit {
+			newCfg, cfgErr := config.LoadAppConfig(config.ConfigPath())
+			if cfgErr != nil {
+				m.flash = fmt.Sprintf("Config reload failed: %v", cfgErr)
+				m.flashError = true
+				return m, tea.EnterAltScreen
+			}
+			m.appCfg = newCfg
+		}
+		fleets, err := config.ScanFleets(m.appCfg.FleetDir)
 		if err != nil {
 			m.flash = fmt.Sprintf("Reload failed: %v", err)
 			m.flashError = true
@@ -1328,7 +1372,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 
 func (m Model) View() string {
+	// If modal is active, render it on top of the current view
+	if m.modal != nil && !m.modal.Done() {
+		bgView := m.renderCurrentView()
+		return m.modal.View(bgView, m.width, m.height)
+	}
+	return m.renderCurrentView()
+}
+
+func (m Model) renderCurrentView() string {
 	switch m.view {
+	case viewConfig:
+		return m.renderConfig()
 	case viewFleetPicker:
 		return m.renderFleetPicker()
 	case viewHostList:

--- a/internal/app/styles.go
+++ b/internal/app/styles.go
@@ -71,4 +71,26 @@ var (
 	groupHeaderStyle = lipgloss.NewStyle().
 				Foreground(colorBlue).
 				Bold(true)
+
+	// modal overlay
+	modalTitleStyle = lipgloss.NewStyle().
+			Foreground(colorBlue).
+			Bold(true)
+
+	modalDimStyle = lipgloss.NewStyle().
+			Foreground(colorDimmed)
+
+	modalKeyStyle = lipgloss.NewStyle().
+			Foreground(colorBlue).
+			Bold(true)
+
+	modalInputStyle = lipgloss.NewStyle().
+			Foreground(colorWhite).
+			Background(lipgloss.Color("236")).
+			Padding(0, 1)
+
+	modalErrorStyle = lipgloss.NewStyle().
+			Foreground(colorRed).
+			Bold(true)
+
 )

--- a/internal/app/view_config.go
+++ b/internal/app/view_config.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+func (m Model) renderConfig() string {
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	s := m.renderHeader("Config", 0, 0) + "\n"
+	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
+
+	settingCol := 22
+	s += borderedRow("", iw, normalRowStyle) + "\n"
+	s += borderedRow(fmt.Sprintf("  %-*s  %s", settingCol, "SETTING", "VALUE"), iw, colHeaderStyle) + "\n"
+	s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
+	s += borderedRow(fmt.Sprintf("    %-*s  %s", settingCol, "Fleet directory", m.appCfg.FleetDir), iw, normalRowStyle) + "\n"
+	s += borderedRow(fmt.Sprintf("    %-*s  %s", settingCol, "Editor", m.appCfg.Editor()), iw, normalRowStyle) + "\n"
+	s += borderedRow("", iw, normalRowStyle) + "\n"
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
+	s += m.renderHintBar([][]string{
+		{"e", "Edit config"},
+		{"r", "Reload"},
+		{"Esc", "Back"},
+	})
+	return s
+}
+
+func (m Model) handleConfigKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "e":
+		return m, m.editConfigFile()
+	case "r":
+		newCfg, err := config.LoadAppConfig(config.ConfigPath())
+		if err != nil {
+			m.flash = fmt.Sprintf("Reload failed: %v", err)
+			m.flashError = true
+			return m, nil
+		}
+		newFleets, err := config.ScanFleets(newCfg.FleetDir)
+		if err != nil {
+			m.flash = fmt.Sprintf("Fleet scan failed: %v", err)
+			m.flashError = true
+			return m, nil
+		}
+		m.appCfg = newCfg
+		m.fleets = newFleets
+		if m.fleetCursor >= len(m.fleets) {
+			m.fleetCursor = max(0, len(m.fleets)-1)
+		}
+		m.flash = "Config reloaded"
+		m.view = viewFleetPicker
+	case "esc":
+		m.view = viewFleetPicker
+	}
+	return m, nil
+}

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -18,7 +18,11 @@ func (m Model) renderFleetPicker() string {
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
 	if len(m.fleets) == 0 {
-		s += borderedRow("  No fleet files found in ~/.config/fleetdesk/", iw, normalRowStyle) + "\n"
+		noFleetMsg := "  No fleet files found"
+		if m.appCfg.FleetDir != "" {
+			noFleetMsg += " in " + m.appCfg.FleetDir
+		}
+		s += borderedRow(noFleetMsg, iw, normalRowStyle) + "\n"
 	} else {
 		nameCol := len("FLEET")
 		for _, f := range m.fleets {

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -105,6 +105,7 @@ func (m Model) renderFleetPicker() string {
 	s += m.renderSudoPromptOrHintBar([][]string{
 		{"Enter", "Select"},
 		{"e", "Edit"},
+		{"c", "Config"},
 		{"r", "Reload"},
 		{"q", "Quit"},
 	})

--- a/internal/config/appconfig.go
+++ b/internal/config/appconfig.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrNoConfig is returned when the config file does not exist.
+var ErrNoConfig = errors.New("config file not found")
+
+// AppConfig holds the application-level configuration.
+type AppConfig struct {
+	FleetDir string `yaml:"fleet_dir"`
+	editor   string // unexported — access via Editor()
+}
+
+// configFile is the on-disk YAML representation.
+type configFile struct {
+	FleetDir string `yaml:"fleet_dir"`
+	Editor   string `yaml:"editor"`
+}
+
+// Editor returns the configured editor, falling back to $EDITOR, $VISUAL, then vi.
+func (c AppConfig) Editor() string {
+	if c.editor != "" {
+		return c.editor
+	}
+	if e := os.Getenv("EDITOR"); e != "" {
+		return e
+	}
+	if v := os.Getenv("VISUAL"); v != "" {
+		return v
+	}
+	return "vi"
+}
+
+// LoadAppConfig reads and validates config.yaml from the given config directory.
+func LoadAppConfig(configDir string) (AppConfig, error) {
+	path := filepath.Join(configDir, "config.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return AppConfig{}, ErrNoConfig
+		}
+		return AppConfig{}, fmt.Errorf("reading config: %w", err)
+	}
+
+	var cf configFile
+	if err := yaml.Unmarshal(data, &cf); err != nil {
+		return AppConfig{}, fmt.Errorf("parsing config: %w", err)
+	}
+
+	if cf.FleetDir == "" {
+		return AppConfig{}, fmt.Errorf("fleet_dir is required in config.yaml")
+	}
+
+	// Expand tilde
+	fleetDir := expandTilde(cf.FleetDir)
+
+	// Validate directory exists and is readable+writable
+	if err := validateFleetDir(fleetDir); err != nil {
+		return AppConfig{}, err
+	}
+
+	return AppConfig{
+		FleetDir: fleetDir,
+		editor:   cf.Editor,
+	}, nil
+}
+
+// WriteDefaultAppConfig creates config.yaml with the given values.
+func WriteDefaultAppConfig(configDir, fleetDir, editor string) error {
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("creating config dir: %w", err)
+	}
+
+	cf := configFile{
+		FleetDir: fleetDir,
+		Editor:   editor,
+	}
+	data, err := yaml.Marshal(&cf)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	path := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+	return nil
+}
+
+// expandTilde replaces a leading ~ with the user's home directory.
+func expandTilde(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, path[1:])
+}
+
+// validateFleetDir checks that the directory exists and is readable+writable.
+func validateFleetDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("fleet directory does not exist: %s", dir)
+		}
+		return fmt.Errorf("checking fleet directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("fleet_dir is not a directory: %s", dir)
+	}
+
+	// Check read+write by attempting to open for reading and create a temp file
+	f, err := os.CreateTemp(dir, ".fleetdesk-check-*")
+	if err != nil {
+		return fmt.Errorf("fleet directory is not writable: %s", dir)
+	}
+	f.Close()
+	os.Remove(f.Name())
+
+	return nil
+}
+
+// ValidateFleetDir is the exported version for use by the wizard.
+func ValidateFleetDir(path string) error {
+	return validateFleetDir(expandTilde(path))
+}

--- a/internal/config/appconfig.go
+++ b/internal/config/appconfig.go
@@ -95,16 +95,24 @@ func WriteDefaultAppConfig(configDir, fleetDir, editor string) error {
 	return nil
 }
 
-// expandTilde replaces a leading ~ with the user's home directory.
+// expandTilde replaces a leading ~/ (or bare ~) with the user's home directory.
+// Does not expand ~user paths.
 func expandTilde(path string) string {
-	if !strings.HasPrefix(path, "~") {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return home
+	}
+	if !strings.HasPrefix(path, "~/") {
 		return path
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return path
 	}
-	return filepath.Join(home, path[1:])
+	return filepath.Join(home, path[2:])
 }
 
 // validateFleetDir checks that the directory exists and is readable+writable.

--- a/internal/config/appconfig.go
+++ b/internal/config/appconfig.go
@@ -30,10 +30,10 @@ func (c AppConfig) Editor() string {
 	if c.editor != "" {
 		return c.editor
 	}
-	if e := os.Getenv("EDITOR"); e != "" {
+	if e := strings.TrimSpace(os.Getenv("EDITOR")); e != "" {
 		return e
 	}
-	if v := os.Getenv("VISUAL"); v != "" {
+	if v := strings.TrimSpace(os.Getenv("VISUAL")); v != "" {
 		return v
 	}
 	return "vi"

--- a/internal/config/appconfig_test.go
+++ b/internal/config/appconfig_test.go
@@ -1,0 +1,154 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAppConfig_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := LoadAppConfig(dir)
+	if err != ErrNoConfig {
+		t.Errorf("got %v, want ErrNoConfig", err)
+	}
+}
+
+func TestLoadAppConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(":::invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAppConfig(dir)
+	if err == nil || err == ErrNoConfig {
+		t.Errorf("expected parse error, got %v", err)
+	}
+}
+
+func TestLoadAppConfig_MissingFleetDir(t *testing.T) {
+	dir := t.TempDir()
+	content := "editor: vim\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAppConfig(dir)
+	if err == nil {
+		t.Error("expected validation error for missing fleet_dir")
+	}
+}
+
+func TestLoadAppConfig_DirNotExist(t *testing.T) {
+	dir := t.TempDir()
+	content := "fleet_dir: /nonexistent/path/that/does/not/exist\neditor: vim\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadAppConfig(dir)
+	if err == nil {
+		t.Error("expected error for non-existent fleet_dir")
+	}
+}
+
+func TestLoadAppConfig_Valid(t *testing.T) {
+	dir := t.TempDir()
+	fleetDir := t.TempDir()
+	content := "fleet_dir: " + fleetDir + "\neditor: nvim\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadAppConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.FleetDir != fleetDir {
+		t.Errorf("FleetDir = %q, want %q", cfg.FleetDir, fleetDir)
+	}
+	if cfg.Editor() != "nvim" {
+		t.Errorf("Editor() = %q, want %q", cfg.Editor(), "nvim")
+	}
+}
+
+func TestAppConfig_Editor_ConfigWins(t *testing.T) {
+	t.Setenv("EDITOR", "emacs")
+	t.Setenv("VISUAL", "code")
+	cfg := AppConfig{FleetDir: "/tmp", editor: "nvim"}
+	if got := cfg.Editor(); got != "nvim" {
+		t.Errorf("Editor() = %q, want %q", got, "nvim")
+	}
+}
+
+func TestAppConfig_Editor_EnvFallback(t *testing.T) {
+	t.Setenv("EDITOR", "emacs")
+	t.Setenv("VISUAL", "code")
+	cfg := AppConfig{FleetDir: "/tmp"}
+	if got := cfg.Editor(); got != "emacs" {
+		t.Errorf("Editor() = %q, want %q", got, "emacs")
+	}
+}
+
+func TestAppConfig_Editor_VisualFallback(t *testing.T) {
+	t.Setenv("EDITOR", "")
+	t.Setenv("VISUAL", "code")
+	cfg := AppConfig{FleetDir: "/tmp"}
+	if got := cfg.Editor(); got != "code" {
+		t.Errorf("Editor() = %q, want %q", got, "code")
+	}
+}
+
+func TestAppConfig_Editor_Default(t *testing.T) {
+	t.Setenv("EDITOR", "")
+	t.Setenv("VISUAL", "")
+	cfg := AppConfig{FleetDir: "/tmp"}
+	if got := cfg.Editor(); got != "vi" {
+		t.Errorf("Editor() = %q, want %q", got, "vi")
+	}
+}
+
+func TestWriteDefaultAppConfig(t *testing.T) {
+	dir := t.TempDir()
+	fleetDir := t.TempDir()
+	err := WriteDefaultAppConfig(dir, fleetDir, "nvim")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// verify file was created and is readable
+	cfg, err := LoadAppConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadAppConfig after write: %v", err)
+	}
+	if cfg.FleetDir != fleetDir {
+		t.Errorf("FleetDir = %q, want %q", cfg.FleetDir, fleetDir)
+	}
+	if cfg.Editor() != "nvim" {
+		t.Errorf("Editor() = %q, want %q", cfg.Editor(), "nvim")
+	}
+}
+
+func TestValidateAppConfig_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	// Create a temp dir inside home to test tilde expansion
+	dir := t.TempDir()
+	fleetDir := t.TempDir()
+
+	// Write config with ~/... path
+	rel, err := filepath.Rel(home, fleetDir)
+	if err != nil {
+		t.Skip("fleet dir not under home")
+	}
+	content := "fleet_dir: ~/" + rel + "\neditor: vim\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadAppConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.FleetDir != fleetDir {
+		t.Errorf("FleetDir = %q, want %q (tilde not expanded)", cfg.FleetDir, fleetDir)
+	}
+}

--- a/internal/config/scanner.go
+++ b/internal/config/scanner.go
@@ -33,14 +33,9 @@ func ConfigPath() string {
 	return filepath.Join(home, configDir)
 }
 
-// ScanFleets reads all .yaml files from the config directory (excluding config.yaml)
+// ScanFleets reads all .yaml files from the given directory (excluding config.yaml)
 // and returns parsed fleet definitions.
-func ScanFleets() ([]Fleet, error) {
-	dir := ConfigPath()
-	if dir == "" {
-		return nil, fmt.Errorf("cannot determine home directory")
-	}
-
+func ScanFleets(dir string) ([]Fleet, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/config/scanner_test.go
+++ b/internal/config/scanner_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestFleetTypeOrder(t *testing.T) {
 	tests := []struct {
@@ -29,5 +33,47 @@ func TestFleetTypeOrder(t *testing.T) {
 	}
 	if fleetTypeOrder("azure") >= fleetTypeOrder("kubernetes") {
 		t.Error("azure should sort before kubernetes")
+	}
+}
+
+func TestScanFleets_AcceptsDir(t *testing.T) {
+	dir := t.TempDir()
+	// write a minimal fleet file
+	content := "name: test\ntype: vm\nhosts:\n  - name: h1\n    hostname: 10.0.0.1\n"
+	if err := os.WriteFile(filepath.Join(dir, "test.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fleets, err := ScanFleets(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fleets) != 1 {
+		t.Fatalf("got %d fleets, want 1", len(fleets))
+	}
+	if fleets[0].Name != "test" {
+		t.Errorf("fleet name = %q, want %q", fleets[0].Name, "test")
+	}
+}
+
+func TestScanFleets_SkipsConfigYaml(t *testing.T) {
+	dir := t.TempDir()
+	// write config.yaml — should be skipped
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("fleet_dir: /tmp\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// write a fleet file
+	content := "name: real\ntype: vm\nhosts:\n  - name: h1\n    hostname: 10.0.0.1\n"
+	if err := os.WriteFile(filepath.Join(dir, "fleet.yaml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fleets, err := ScanFleets(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fleets) != 1 {
+		t.Fatalf("got %d fleets, want 1 (config.yaml should be skipped)", len(fleets))
+	}
+	if fleets[0].Name != "real" {
+		t.Errorf("fleet name = %q, want %q", fleets[0].Name, "real")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -33,20 +33,46 @@ func main() {
 		os.Exit(0)
 	}
 
-	fleets, err := config.ScanFleets()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error scanning fleets: %v\n", err)
+	// Ensure config directory exists
+	configDir := config.ConfigPath()
+	if configDir != "" {
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "error creating config dir: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Load app config
+	appCfg, err := config.LoadAppConfig(configDir)
+	if err != nil && err != config.ErrNoConfig {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Scan fleets (only if config exists and has a fleet dir)
+	var fleets []config.Fleet
+	if appCfg.FleetDir != "" {
+		fleets, err = config.ScanFleets(appCfg.FleetDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error scanning fleets: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	logger := logging.InitLogger(debug, logging.LogDir())
 	defer logging.CloseAll()
 	logger.Info("fleetdesk starting", "version", version, "debug", debug, "fleets", len(fleets))
 
-	m := app.NewModel(fleets, logger, version)
+	m := app.NewModel(fleets, appCfg, logger, version)
 	p := tea.NewProgram(m, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
+	}
+
+	// If wizard was cancelled (no config after exit), show message
+	if fm, ok := finalModel.(app.Model); ok && fm.WizardCancelled() {
+		fmt.Println("FleetDesk requires a configuration file. Run fleetdesk again to complete setup.")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -71,8 +71,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// If wizard was cancelled (no config after exit), show message
+	// If wizard was cancelled or failed, show message
 	if fm, ok := finalModel.(app.Model); ok && fm.WizardCancelled() {
-		fmt.Println("FleetDesk requires a configuration file. Run fleetdesk again to complete setup.")
+		if wizErr := fm.WizardError(); wizErr != nil {
+			fmt.Fprintf(os.Stderr, "Setup failed: %v\n", wizErr)
+		} else {
+			fmt.Println("FleetDesk requires a configuration file. Run fleetdesk again to complete setup.")
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add `AppConfig` with `fleet_dir` and `editor` fields, loaded from `~/.config/fleetdesk/config.yaml`
- Reusable `ModalOverlay` abstraction (centered dialog with step navigation, key interception, dimmed background) — ready for FLE-66 (help overlay) and future dialogs
- First-run wizard: 2-step modal (fleet directory path + editor picker), with custom editor follow-up step
- Config view accessible via `c` from Fleet Picker (view/edit/reload config)
- `ScanFleets(dir)` refactored to accept directory parameter (dependency injection)
- Editor resolution chain: config.yaml → `$EDITOR` → `$VISUAL` → `vi`
- Startup guard: no fallback, wizard on first launch, clean break from hardcoded path
- 20 new unit tests across config and modal packages

## Architecture contract

Linear comment on FLE-68 — all design decisions followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)