### PR TITLE
feat: migrate prompts to modal overlay (FLE-69)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -163,32 +163,6 @@ func (m Model) fetchContainers() func() tea.Msg {
 	}
 }
 
-// confirmSvcAction returns a tea.Cmd that runs a systemctl action via terminal handover with sudo.
-// After the action, it shows systemctl status so the user can see the result.
-func (m Model) confirmSvcAction(action string) (tea.Model, tea.Cmd) {
-	h := m.hosts[m.selectedHost]
-	unit := m.services[m.serviceCursor].Name + ".service"
-
-	sysctl := "sudo systemctl"
-	statusctl := "sudo systemctl"
-	if h.Entry.SystemdMode == "user" {
-		sysctl = "systemctl --user"
-		statusctl = "systemctl --user"
-	}
-
-	m.showConfirm = true
-	m.confirmMessage = fmt.Sprintf("%s %s? [Y/n]", action, unit)
-	m.confirmCmd = fmt.Sprintf(
-		`%s %s %s; rc=$?; echo ''; if [ $rc -eq 0 ]; then echo '✓ %s %s succeeded'; else echo '✗ %s %s failed (exit '$rc')'; fi; echo ''; %s status %s --no-pager 2>&1; true`,
-		sysctl, action, unit,
-		action, unit,
-		action, unit,
-		statusctl, unit,
-	)
-	m.confirmBanner = fmt.Sprintf("%s %s on %s", action, unit, h.Entry.Name)
-	return m, nil
-}
-
 // --- Service Detail ---
 
 type fetchServiceDetailMsg struct {
@@ -208,16 +182,17 @@ func (m Model) confirmDetailSvcAction(action string) (tea.Model, tea.Cmd) {
 		sysctl = "systemctl --user"
 	}
 
-	m.showConfirm = true
-	m.confirmMessage = fmt.Sprintf("%s %s? [Y/n]", action, unit)
-	m.confirmCmd = fmt.Sprintf(
+	cmd := fmt.Sprintf(
 		`%s %s '%s'; rc=$?; echo ''; if [ $rc -eq 0 ]; then echo '✓ %s %s succeeded'; else echo '✗ %s %s failed (exit '$rc')'; fi; echo ''; %s status '%s' --no-pager 2>&1; true`,
 		sysctl, action, q,
 		action, unit,
 		action, unit,
 		sysctl, q,
 	)
-	m.confirmBanner = fmt.Sprintf("%s %s on %s", action, unit, h.Entry.Name)
+	banner := fmt.Sprintf("%s %s on %s", action, unit, h.Entry.Name)
+	m.modal = NewConfirmModal("Confirm",
+		fmt.Sprintf("%s %s? [Y/n]", action, unit),
+		sshHandover(h, []string{cmd}, banner))
 	return m, nil
 }
 

--- a/internal/app/deploy_key_test.go
+++ b/internal/app/deploy_key_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDeployKeyKeybind(t *testing.T) {
-	t.Run("K on online host shows confirm prompt", func(t *testing.T) {
+	t.Run("K on online host shows confirm modal", func(t *testing.T) {
 		m := newTestModel()
 		m.view = viewHostList
 		m.hosts = []config.Host{{
@@ -22,13 +22,10 @@ func TestDeployKeyKeybind(t *testing.T) {
 		result, cmd := m.handleHostListKeys(msg)
 		m2 := result.(Model)
 		if cmd != nil {
-			t.Error("expected nil cmd — confirm prompt should not fire command yet")
+			t.Error("expected nil cmd — confirm modal should not fire command yet")
 		}
-		if !m2.showConfirm {
-			t.Error("expected showConfirm = true")
-		}
-		if m2.pendingHandover == nil {
-			t.Error("expected pendingHandover to be set")
+		if m2.modal == nil {
+			t.Error("expected modal to be set")
 		}
 	})
 
@@ -41,21 +38,21 @@ func TestDeployKeyKeybind(t *testing.T) {
 		}}
 		m.hostCursor = 0
 		m.selectedHost = 0
-		m.showConfirm = true
-		m.confirmMessage = "Deploy SSH key to ansible@host1? [Y/n]"
-		m.pendingHandover = func() tea.Msg { return nil } // stub
 
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
-		result, cmd := m.handleKey(msg)
+		// Set up modal via the K keybind
+		result, _ := m.handleHostListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
 		m2 := result.(Model)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set after K")
+		}
+
+		// Confirm with Y
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
 		if cmd == nil {
 			t.Error("expected non-nil cmd after confirming deploy key")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false after confirm")
-		}
-		if m2.pendingHandover != nil {
-			t.Error("expected pendingHandover to be cleared after confirm")
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after confirm")
 		}
 	})
 
@@ -67,20 +64,18 @@ func TestDeployKeyKeybind(t *testing.T) {
 			Status: config.HostOnline,
 		}}
 		m.hostCursor = 0
-		m.showConfirm = true
-		m.pendingHandover = func() tea.Msg { return nil } // stub
 
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
-		result, cmd := m.handleKey(msg)
+		// Set up modal via the K keybind
+		result, _ := m.handleHostListKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'K'}})
 		m2 := result.(Model)
-		if cmd != nil {
-			t.Error("expected nil cmd after cancelling")
+
+		// Cancel with N
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+		if cmd == nil {
+			t.Error("expected non-nil cmd from cancel (confirmCancelledMsg)")
 		}
-		if m2.flash != "Cancelled" {
-			t.Errorf("flash = %q, want %q", m2.flash, "Cancelled")
-		}
-		if m2.pendingHandover != nil {
-			t.Error("expected pendingHandover to be cleared after cancel")
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after cancel")
 		}
 	})
 

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -718,35 +718,6 @@ func (m *Model) applyProbeInfo(idx int, info ssh.ProbeInfo) {
 	m.hosts[idx].ListeningPorts = info.ListeningPorts
 }
 
-// retryRemainingPasswordHosts retries connection for hosts that still need a password.
-// Uses the password from the last successful retry (stored temporarily in sshManager).
-func (m Model) retryRemainingPasswordHosts() tea.Cmd {
-	var cmds []tea.Cmd
-	for i, h := range m.hosts {
-		if h.NeedsPassword && h.Status == config.HostUnreachable {
-			idx := i
-			hh := h
-			sm := m.ssh
-			// Clear NeedsPassword before launching retry to prevent duplicate
-			// retries — each PasswordRetryResult triggers this function again,
-			// and without this guard the same hosts get retried exponentially.
-			m.hosts[i].NeedsPassword = false
-			m.logger.Debug("retryRemainingPasswordHosts", "host_idx", idx, "host", hh.Entry.Name)
-			cmds = append(cmds, func() tea.Msg {
-				return sm.RetryWithCachedPassword(idx, hh)
-			})
-		}
-	}
-	if len(cmds) == 0 {
-		m.logger.Debug("retryRemainingPasswordHosts done, no hosts remaining")
-		// all done -- clear the cached password
-		m.ssh.ClearPassword()
-		return nil
-	}
-	m.logger.Debug("retryRemainingPasswordHosts", "retry_count", len(cmds))
-	return tea.Batch(cmds...)
-}
-
 // startProbe launches parallel SSH connections and probes for all hosts.
 // Returns a batch of commands, one per host, that will send hostProbeResult messages.
 func (m Model) startProbe() tea.Cmd {
@@ -829,13 +800,6 @@ func (m Model) containerDetailLines() []string {
 		}
 	}
 	return lines
-}
-
-// retryWithPassword attempts to connect a specific host using password auth.
-func retryWithPassword(sm *ssh.Manager, idx int, h config.Host, password string) tea.Cmd {
-	return func() tea.Msg {
-		return sm.ConnectWithPassword(idx, h, password)
-	}
 }
 
 // buildAzureSubList creates the runtime subscription list from an Azure fleet definition.

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -147,137 +147,6 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// confirmation prompt mode
-	if m.showConfirm {
-		switch msg.String() {
-		case "y", "Y":
-			// fall through
-		case "n", "N", "esc":
-			m.showConfirm = false
-			m.confirmCmd = ""
-			m.confirmBanner = ""
-			m.pendingHandover = nil
-			m.flash = "Cancelled"
-			return m, nil
-		default:
-			if msg.Type == tea.KeyEnter {
-				// Enter = default yes, fall through
-			} else {
-				return m, nil
-			}
-		}
-		// confirmed -- execute
-		m.showConfirm = false
-
-		if m.pendingTransition != nil {
-			t := m.pendingTransition
-			m.pendingTransition = nil
-			key := t.ResourceType + "/" + t.ResourceName
-			if m.transitions == nil {
-				m.transitions = make(map[string]transition)
-			}
-			m.transitions[key] = *t
-			m.flash = ""
-			execCmd := t.ExecFn
-			// Only start poll chain for poll-strategy transitions
-			if t.Strategy == "poll" && !m.polling {
-				m.polling = true
-				return m, tea.Batch(execCmd, m.startPoll())
-			}
-			return m, execCmd
-		}
-
-		if m.pendingHandover != nil {
-			c := m.pendingHandover
-			m.pendingHandover = nil
-			m.flash = ""
-			return m, c
-		}
-
-		h := m.hosts[m.selectedHost]
-		cmd := m.confirmCmd
-		banner := m.confirmBanner
-		m.confirmCmd = ""
-		m.confirmBanner = ""
-		m.flash = ""
-		return m, sshHandover(h, []string{cmd}, banner)
-	}
-
-	// password prompt mode -- capture input (only on host list view)
-	if m.showPasswordPrompt && m.view == viewHostList {
-		switch msg.Type {
-		case tea.KeyEnter:
-			m.showPasswordPrompt = false
-			password := m.passwordInput
-			m.passwordInput = "" // clear input immediately
-			m.flash = ""
-			m.ssh.SetCachedPassword(password)
-			// retry ALL password-needing hosts in one batch
-			var cmds []tea.Cmd
-			for i, h := range m.hosts {
-				if h.NeedsPassword && (h.Status == config.HostUnreachable || i == m.passwordHostIdx) {
-					m.hosts[i].Status = config.HostConnecting
-					ii := i
-					hh := h
-					sm := m.ssh
-					cmds = append(cmds, func() tea.Msg {
-						return sm.ConnectWithPassword(ii, hh, password)
-					})
-				}
-			}
-			return m, tea.Batch(cmds...)
-		case tea.KeyEsc:
-			m.showPasswordPrompt = false
-			m.hosts[m.passwordHostIdx].Status = config.HostUnreachable
-			m.hosts[m.passwordHostIdx].Error = "password prompt cancelled"
-			m.flash = ""
-			return m, nil
-		case tea.KeyBackspace:
-			if len(m.passwordInput) > 0 {
-				m.passwordInput = m.passwordInput[:len(m.passwordInput)-1]
-			}
-		default:
-			if msg.Type == tea.KeyRunes {
-				m.passwordInput += string(msg.Runes)
-			}
-		}
-		return m, nil
-	}
-
-	// sudo password prompt mode -- capture input on any SSH view
-	if m.showSudoPrompt {
-		switch msg.Type {
-		case tea.KeyEnter:
-			if m.sudoInput == "" {
-				return m, nil
-			}
-			m.showSudoPrompt = false
-			password := m.sudoInput
-			m.sudoInput = ""
-			m.ssh.SetSudoPassword(m.selectedHost, password)
-			retry := m.pendingSudoRetry
-			m.pendingSudoRetry = nil
-			return m, retry
-		case tea.KeyEsc:
-			m.showSudoPrompt = false
-			m.sudoInput = ""
-			m.pendingSudoRetry = nil
-			m.flash = "Sudo password prompt cancelled"
-			m.flashError = true
-			return m, nil
-		case tea.KeyBackspace:
-			if len(m.sudoInput) > 0 {
-				runes := []rune(m.sudoInput)
-				m.sudoInput = string(runes[:len(runes)-1])
-			}
-		default:
-			if msg.Type == tea.KeyRunes {
-				m.sudoInput += string(msg.Runes)
-			}
-		}
-		return m, nil
-	}
-
 	m.flash = ""
 	m.flashError = false
 
@@ -480,18 +349,17 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.selectedHost = m.hostCursor
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("Deploy SSH key to %s@%s? [Y/n]", h.Entry.User, h.Entry.Name)
 			sshTarget := shellQuote(h.Entry.User) + "@" + shellQuote(h.Entry.Hostname)
 			portStr := fmt.Sprintf("%d", h.Entry.Port)
-			// Ensure home dir exists (IPA/IDM hosts may not have it until first login)
-			// then deploy key. Both commands prompt for password via terminal handover.
 			script := fmt.Sprintf(
 				"ssh -t -o StrictHostKeyChecking=no -p %s '%s' 'sudo mkdir -p $HOME/.ssh && sudo chown -R $(id -u):$(id -g) $HOME && chmod 700 $HOME/.ssh' && ssh-copy-id -o StrictHostKeyChecking=no -p %s '%s'",
 				portStr, sshTarget, portStr, sshTarget)
-			m.pendingHandover = cmdHandover("bash",
+			handover := cmdHandover("bash",
 				[]string{"-c", script},
 				fmt.Sprintf("deploy key to %s@%s", h.Entry.User, h.Entry.Name))
+			m.modal = NewConfirmModal("Confirm",
+				fmt.Sprintf("Deploy SSH key to %s@%s? [Y/n]", h.Entry.User, h.Entry.Name),
+				handover)
 		}
 	case "R":
 		if len(m.hosts) > 0 {
@@ -502,10 +370,10 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.selectedHost = m.hostCursor
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("REBOOT %s? [Y/n]", h.Entry.Name)
-			m.confirmCmd = `sudo reboot; echo 'Reboot initiated'`
-			m.confirmBanner = fmt.Sprintf("reboot %s", h.Entry.Name)
+			hh := h
+			m.modal = NewConfirmModal("Confirm",
+				fmt.Sprintf("REBOOT %s? [Y/n]", h.Entry.Name),
+				sshHandover(hh, []string{`sudo reboot; echo 'Reboot initiated'`}, fmt.Sprintf("reboot %s", h.Entry.Name)))
 		}
 	case "d":
 		m.metrics = make(map[int]config.HostMetrics)
@@ -1009,16 +877,14 @@ func (m Model) handleUpdateListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateCursor = 0
 	case "u":
 		h := m.hosts[m.selectedHost]
-		m.showConfirm = true
-		m.confirmMessage = fmt.Sprintf("Apply ALL updates on %s? [Y/n]", h.Entry.Name)
-		m.confirmCmd = `sudo dnf update -y --setopt=skip_if_unavailable=1; echo ''; echo 'Update complete. Press Enter to return...'`
-		m.confirmBanner = fmt.Sprintf("full update on %s", h.Entry.Name)
+		m.modal = NewConfirmModal("Confirm",
+			fmt.Sprintf("Apply ALL updates on %s? [Y/n]", h.Entry.Name),
+			sshHandover(h, []string{`sudo dnf update -y --setopt=skip_if_unavailable=1; echo ''; echo 'Update complete. Press Enter to return...'`}, fmt.Sprintf("full update on %s", h.Entry.Name)))
 	case "p":
 		h := m.hosts[m.selectedHost]
-		m.showConfirm = true
-		m.confirmMessage = fmt.Sprintf("Apply SECURITY updates on %s? [Y/n]", h.Entry.Name)
-		m.confirmCmd = `sudo dnf update --security -y --setopt=skip_if_unavailable=1; echo ''; echo 'Security update complete. Press Enter to return...'`
-		m.confirmBanner = fmt.Sprintf("security update on %s", h.Entry.Name)
+		m.modal = NewConfirmModal("Confirm",
+			fmt.Sprintf("Apply SECURITY updates on %s? [Y/n]", h.Entry.Name),
+			sshHandover(h, []string{`sudo dnf update --security -y --setopt=skip_if_unavailable=1; echo ''; echo 'Security update complete. Press Enter to return...'`}, fmt.Sprintf("security update on %s", h.Entry.Name)))
 	case "1", "2", "3":
 		col := int(msg.Runes[0] - '0')
 		if col >= 1 && col <= 3 {
@@ -1141,10 +1007,10 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if regType == "Satellite" {
 			cmd += " && sudo dnf remove -y katello-ca-consumer-*"
 		}
-		m.showConfirm = true
-		m.confirmMessage = fmt.Sprintf("Unregister from %s? [Y/n]", regType)
-		m.confirmCmd = cmd
-		m.confirmBanner = fmt.Sprintf("unregister from %s on %s", regType, h.Entry.Name)
+		banner := fmt.Sprintf("unregister from %s on %s", regType, h.Entry.Name)
+		m.modal = NewConfirmModal("Confirm",
+			fmt.Sprintf("Unregister from %s? [Y/n]", regType),
+			sshHandover(h, []string{cmd}, banner))
 	case "g":
 		h := m.hosts[m.selectedHost]
 		orgID := h.Entry.RHOrgID
@@ -1165,20 +1031,21 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			cmd = fmt.Sprintf("sudo subscription-manager register --org='%s' --activationkey='%s'",
 				shellQuote(orgID), shellQuote(actKey))
 		}
-		m.showConfirm = true
-		m.confirmMessage = fmt.Sprintf("Register to %s? [Y/n]", target)
-		m.confirmCmd = cmd
-		m.confirmBanner = fmt.Sprintf("register to %s on %s", target, h.Entry.Name)
+		banner := fmt.Sprintf("register to %s on %s", target, h.Entry.Name)
+		m.modal = NewConfirmModal("Confirm",
+			fmt.Sprintf("Register to %s? [Y/n]", target),
+			sshHandover(h, []string{cmd}, banner))
 	case "d":
 		if len(m.subscriptions) > 0 {
 			sub := m.subscriptions[m.subscriptionCursor]
 			if strings.HasPrefix(sub.Field, "Repo: ") {
 				repoID := strings.TrimPrefix(sub.Field, "Repo: ")
 				h := m.hosts[m.selectedHost]
-				m.showConfirm = true
-				m.confirmMessage = fmt.Sprintf("Disable repo %s? [Y/n]", repoID)
-				m.confirmCmd = fmt.Sprintf("sudo dnf config-manager --set-disabled '%s' && echo '' && echo '\u2713 Repo %s disabled'", shellQuote(repoID), repoID)
-				m.confirmBanner = fmt.Sprintf("disable %s on %s", repoID, h.Entry.Name)
+				cmd := fmt.Sprintf("sudo dnf config-manager --set-disabled '%s' && echo '' && echo '\u2713 Repo %s disabled'", shellQuote(repoID), repoID)
+				banner := fmt.Sprintf("disable %s on %s", repoID, h.Entry.Name)
+				m.modal = NewConfirmModal("Confirm",
+					fmt.Sprintf("Disable repo %s? [Y/n]", repoID),
+					sshHandover(h, []string{cmd}, banner))
 			}
 		}
 	case "r":
@@ -1798,24 +1665,24 @@ func (m Model) handleAzureVMListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if vm.PowerState == "running" {
 				m.flash = fmt.Sprintf("%s is already running", vm.Name)
 			} else {
-				m.showConfirm = true
-				m.confirmMessage = fmt.Sprintf("start %s? [Y/n]", vm.Name)
 				am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 				vmName, rg := vm.Name, vm.ResourceGroup
-				m.pendingTransition = &transition{
-					ResourceType: "vm", ResourceName: vm.Name,
-					Action: "start", Display: "starting...", TargetState: "running",
-					Strategy: "poll",
-					ExecFn: m.executeAzureVMAction(vmName, rg, "start"),
-					PollFn: func() (string, error) {
-						states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
-						if err != nil { return "", err }
-						if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
-						return "", fmt.Errorf("vm %s not in poll results", vmName)
-					},
-					RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
-					IsTransitioning: isAzureTransitioningState,
-				}
+				m.modal = NewTransitionConfirmModal(
+					fmt.Sprintf("start %s? [Y/n]", vm.Name),
+					transition{
+						ResourceType: "vm", ResourceName: vm.Name,
+						Action: "start", Display: "starting...", TargetState: "running",
+						Strategy: "poll",
+						ExecFn: m.executeAzureVMAction(vmName, rg, "start"),
+						PollFn: func() (string, error) {
+							states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
+							if err != nil { return "", err }
+							if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
+							return "", fmt.Errorf("vm %s not in poll results", vmName)
+						},
+						RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
+						IsTransitioning: isAzureTransitioningState,
+					})
 			}
 		}
 	case "o":
@@ -1825,24 +1692,24 @@ func (m Model) handleAzureVMListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if vm.PowerState == "deallocated" {
 				m.flash = fmt.Sprintf("%s is already deallocated", vm.Name)
 			} else {
-				m.showConfirm = true
-				m.confirmMessage = fmt.Sprintf("deallocate %s? [Y/n]", vm.Name)
 				am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 				vmName, rg := vm.Name, vm.ResourceGroup
-				m.pendingTransition = &transition{
-					ResourceType: "vm", ResourceName: vm.Name,
-					Action: "deallocate", Display: "deallocating...", TargetState: "deallocated",
-					Strategy: "poll",
-					ExecFn: m.executeAzureVMAction(vmName, rg, "deallocate"),
-					PollFn: func() (string, error) {
-						states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
-						if err != nil { return "", err }
-						if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
-						return "", fmt.Errorf("vm %s not in poll results", vmName)
-					},
-					RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
-					IsTransitioning: isAzureTransitioningState,
-				}
+				m.modal = NewTransitionConfirmModal(
+					fmt.Sprintf("deallocate %s? [Y/n]", vm.Name),
+					transition{
+						ResourceType: "vm", ResourceName: vm.Name,
+						Action: "deallocate", Display: "deallocating...", TargetState: "deallocated",
+						Strategy: "poll",
+						ExecFn: m.executeAzureVMAction(vmName, rg, "deallocate"),
+						PollFn: func() (string, error) {
+							states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
+							if err != nil { return "", err }
+							if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
+							return "", fmt.Errorf("vm %s not in poll results", vmName)
+						},
+						RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
+						IsTransitioning: isAzureTransitioningState,
+					})
 			}
 		}
 	case "t":
@@ -1852,24 +1719,24 @@ func (m Model) handleAzureVMListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if vm.PowerState != "running" {
 				m.flash = fmt.Sprintf("%s is not running (state: %s)", vm.Name, vm.PowerState)
 			} else {
-				m.showConfirm = true
-				m.confirmMessage = fmt.Sprintf("restart %s? [Y/n]", vm.Name)
 				am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 				vmName, rg := vm.Name, vm.ResourceGroup
-				m.pendingTransition = &transition{
-					ResourceType: "vm", ResourceName: vm.Name,
-					Action: "restart", Display: "restarting...", TargetState: "running",
-					Strategy: "poll",
-					ExecFn: m.executeAzureVMAction(vmName, rg, "restart"),
-					PollFn: func() (string, error) {
-						states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
-						if err != nil { return "", err }
-						if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
-						return "", fmt.Errorf("vm %s not in poll results", vmName)
-					},
-					RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
-					IsTransitioning: isAzureTransitioningState,
-				}
+				m.modal = NewTransitionConfirmModal(
+					fmt.Sprintf("restart %s? [Y/n]", vm.Name),
+					transition{
+						ResourceType: "vm", ResourceName: vm.Name,
+						Action: "restart", Display: "restarting...", TargetState: "running",
+						Strategy: "poll",
+						ExecFn: m.executeAzureVMAction(vmName, rg, "restart"),
+						PollFn: func() (string, error) {
+							states, err := azure.FetchVMPowerStates(am, sub.ID, []string{vmName}, logger)
+							if err != nil { return "", err }
+							if s, ok := states[strings.ToLower(vmName)]; ok { return s, nil }
+							return "", fmt.Errorf("vm %s not in poll results", vmName)
+						},
+						RefreshFn: func() tea.Cmd { return m.fetchAzureVMs() },
+						IsTransitioning: isAzureTransitioningState,
+					})
 			}
 		}
 	case "/":
@@ -1959,70 +1826,70 @@ func (m Model) handleAzureAKSListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		filtered := m.filteredAzureAKS()
 		if len(filtered) > 0 && m.azureAKSCursor < len(filtered) {
 			c := filtered[m.azureAKSCursor]
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("start %s? [Y/n]", c.Name)
 			am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 			clusterName, rg := c.Name, c.ResourceGroup
-			m.pendingTransition = &transition{
-				ResourceType: "aks", ResourceName: c.Name,
-				Action: "start", Display: "starting...", TargetState: "running",
-				Strategy: "poll",
-				ExecFn: m.executeAzureAKSAction(clusterName, rg, "start"),
-				PollFn: func() (string, error) {
-					states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
-					if err != nil { return "", err }
-					if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
-					return "gone", nil
-				},
-				RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
-				IsTransitioning: isAzureTransitioningState,
-			}
+			m.modal = NewTransitionConfirmModal(
+				fmt.Sprintf("start %s? [Y/n]", c.Name),
+				transition{
+					ResourceType: "aks", ResourceName: c.Name,
+					Action: "start", Display: "starting...", TargetState: "running",
+					Strategy: "poll",
+					ExecFn: m.executeAzureAKSAction(clusterName, rg, "start"),
+					PollFn: func() (string, error) {
+						states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
+						if err != nil { return "", err }
+						if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
+						return "gone", nil
+					},
+					RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
+					IsTransitioning: isAzureTransitioningState,
+				})
 		}
 	case "o":
 		filtered := m.filteredAzureAKS()
 		if len(filtered) > 0 && m.azureAKSCursor < len(filtered) {
 			c := filtered[m.azureAKSCursor]
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("stop %s? [Y/n]", c.Name)
 			am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 			clusterName, rg := c.Name, c.ResourceGroup
-			m.pendingTransition = &transition{
-				ResourceType: "aks", ResourceName: c.Name,
-				Action: "stop", Display: "stopping...", TargetState: "stopped",
-				Strategy: "poll",
-				ExecFn: m.executeAzureAKSAction(clusterName, rg, "stop"),
-				PollFn: func() (string, error) {
-					states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
-					if err != nil { return "", err }
-					if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
-					return "gone", nil
-				},
-				RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
-				IsTransitioning: isAzureTransitioningState,
-			}
+			m.modal = NewTransitionConfirmModal(
+				fmt.Sprintf("stop %s? [Y/n]", c.Name),
+				transition{
+					ResourceType: "aks", ResourceName: c.Name,
+					Action: "stop", Display: "stopping...", TargetState: "stopped",
+					Strategy: "poll",
+					ExecFn: m.executeAzureAKSAction(clusterName, rg, "stop"),
+					PollFn: func() (string, error) {
+						states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
+						if err != nil { return "", err }
+						if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
+						return "gone", nil
+					},
+					RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
+					IsTransitioning: isAzureTransitioningState,
+				})
 		}
 	case "d":
 		filtered := m.filteredAzureAKS()
 		if len(filtered) > 0 && m.azureAKSCursor < len(filtered) {
 			c := filtered[m.azureAKSCursor]
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("DELETE cluster %s? This is irreversible! [Y/n]", c.Name)
 			am, sub, logger := m.azure, m.azureSubs[m.selectedAzureSub], m.logger
 			clusterName, rg := c.Name, c.ResourceGroup
-			m.pendingTransition = &transition{
-				ResourceType: "aks", ResourceName: c.Name,
-				Action: "delete", Display: "deleting...", TargetState: "gone",
-				Strategy: "poll",
-				ExecFn: m.executeAzureAKSAction(clusterName, rg, "delete"),
-				PollFn: func() (string, error) {
-					states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
-					if err != nil { return "", err }
-					if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
-					return "gone", nil
-				},
-				RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
-				IsTransitioning: isAzureTransitioningState,
-			}
+			m.modal = NewTransitionConfirmModal(
+				fmt.Sprintf("DELETE cluster %s? This is irreversible! [Y/n]", c.Name),
+				transition{
+					ResourceType: "aks", ResourceName: c.Name,
+					Action: "delete", Display: "deleting...", TargetState: "gone",
+					Strategy: "poll",
+					ExecFn: m.executeAzureAKSAction(clusterName, rg, "delete"),
+					PollFn: func() (string, error) {
+						states, err := azure.FetchAKSPowerStates(am, sub.ID, []string{clusterName}, logger)
+						if err != nil { return "", err }
+						if s, ok := states[strings.ToLower(clusterName)]; ok { return s, nil }
+						return "gone", nil
+					},
+					RefreshFn: func() tea.Cmd { return m.fetchAzureAKSClusters() },
+					IsTransitioning: isAzureTransitioningState,
+				})
 		}
 	case "/":
 		m.filterActive = true
@@ -2155,19 +2022,19 @@ func (m Model) handleK8sContextListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "d":
 		if len(m.k8sContexts) > 0 && m.k8sContextCursor < len(m.k8sContexts) {
 			ctx := m.k8sContexts[m.k8sContextCursor]
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("delete context %s? [Y/n]", ctx.Name)
 			ctxName := ctx.Name
 			clusterName := m.k8sClusters[m.selectedK8sCluster].Name
-			m.pendingTransition = &transition{
-				ResourceType: "k8s-context", ResourceName: ctx.Name,
-				Action: "delete", Display: "deleting...",
-				Strategy: "oneshot",
-				ExecFn: m.executeK8sContextDelete(ctxName),
-				RefreshFn: func() tea.Cmd {
-					return m.fetchK8sContexts(clusterName)
-				},
-			}
+			m.modal = NewTransitionConfirmModal(
+				fmt.Sprintf("delete context %s? [Y/n]", ctx.Name),
+				transition{
+					ResourceType: "k8s-context", ResourceName: ctx.Name,
+					Action: "delete", Display: "deleting...",
+					Strategy: "oneshot",
+					ExecFn: m.executeK8sContextDelete(ctxName),
+					RefreshFn: func() tea.Cmd {
+						return m.fetchK8sContexts(clusterName)
+					},
+				})
 		}
 	case "r":
 		m.k8sContexts = nil
@@ -2479,30 +2346,30 @@ func (m Model) handleK8sPodListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		filtered := m.filteredK8sPodList()
 		if len(filtered) > 0 && m.k8sPodCursor < len(filtered) {
 			p := filtered[m.k8sPodCursor]
-			m.showConfirm = true
-			m.confirmMessage = fmt.Sprintf("delete pod %s? [Y/n]", p.Name)
 			km, ctxName := m.k8s, m.selectedK8sContext
 			podName, podNs := p.Name, p.Namespace
 			ns := m.k8sNamespaces[m.selectedK8sNamespace].Name
 			wlName := m.k8sWorkloads[m.selectedK8sWorkload].Name
-			m.pendingTransition = &transition{
-				ResourceType: "k8s-pod", ResourceName: p.Name,
-				Action: "delete", Display: "deleting...", TargetState: "gone",
-				Strategy: "poll",
-				ExecFn: m.executeK8sPodAction(podNs, podName, "delete"),
-				PollFn: func() (string, error) {
-					_, err := km.RunCommand("get", "pod", podName, "-n", podNs, "--context", ctxName, "-o", "name")
-					if err != nil {
-						errStr := err.Error()
-						if strings.Contains(errStr, "not found") || strings.Contains(errStr, "NotFound") {
-							return "gone", nil
+			m.modal = NewTransitionConfirmModal(
+				fmt.Sprintf("delete pod %s? [Y/n]", p.Name),
+				transition{
+					ResourceType: "k8s-pod", ResourceName: p.Name,
+					Action: "delete", Display: "deleting...", TargetState: "gone",
+					Strategy: "poll",
+					ExecFn: m.executeK8sPodAction(podNs, podName, "delete"),
+					PollFn: func() (string, error) {
+						_, err := km.RunCommand("get", "pod", podName, "-n", podNs, "--context", ctxName, "-o", "name")
+						if err != nil {
+							errStr := err.Error()
+							if strings.Contains(errStr, "not found") || strings.Contains(errStr, "NotFound") {
+								return "gone", nil
+							}
+							return "", err
 						}
-						return "", err
-					}
-					return "exists", nil
-				},
-				RefreshFn: func() tea.Cmd { return m.fetchK8sPods(ns, wlName) },
-			}
+						return "exists", nil
+					},
+					RefreshFn: func() tea.Cmd { return m.fetchK8sPods(ns, wlName) },
+				})
 		}
 	case "r":
 		m.k8sPodList = nil

--- a/internal/app/modal.go
+++ b/internal/app/modal.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -29,6 +30,7 @@ type ModalOverlay struct {
 	results    []any
 	OnComplete func([]any) tea.Cmd
 	OnCancel   func() tea.Cmd
+	FooterFn   func() string // optional custom footer; if nil, default footer is used
 	done       bool
 }
 
@@ -86,12 +88,17 @@ func (m *ModalOverlay) View(bgView string, width, height int) string {
 	innerWidth := modalWidth - 4 // padding
 
 	// Title bar
-	stepInfo := fmt.Sprintf("Step %d/%d", m.current+1, len(m.steps))
-	titleGap := innerWidth - len(m.title) - len(stepInfo)
-	if titleGap < 1 {
-		titleGap = 1
+	var titleLine string
+	if len(m.steps) > 1 {
+		stepInfo := fmt.Sprintf("Step %d/%d", m.current+1, len(m.steps))
+		titleGap := innerWidth - len(m.title) - len(stepInfo)
+		if titleGap < 1 {
+			titleGap = 1
+		}
+		titleLine = modalTitleStyle.Render(m.title) + strings.Repeat(" ", titleGap) + modalDimStyle.Render(stepInfo)
+	} else {
+		titleLine = modalTitleStyle.Render(m.title)
 	}
-	titleLine := modalTitleStyle.Render(m.title) + strings.Repeat(" ", titleGap) + modalDimStyle.Render(stepInfo)
 
 	// Step content
 	stepTitle := ""
@@ -102,11 +109,16 @@ func (m *ModalOverlay) View(bgView string, width, height int) string {
 	}
 
 	// Footer
-	footer := modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
-		"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("cancel")
-	if m.current > 0 {
+	var footer string
+	if m.FooterFn != nil {
+		footer = m.FooterFn()
+	} else {
 		footer = modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
-			"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("back")
+			"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("cancel")
+		if m.current > 0 {
+			footer = modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
+				"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("back")
+		}
 	}
 
 	// Build modal box
@@ -141,11 +153,17 @@ type TextInputContent struct {
 	value    string
 	validate func(string) error
 	err      string
+	masked   bool
 }
 
 // NewTextInputContent creates a text input step.
 func NewTextInputContent(prompt string, validate func(string) error) StepContent {
 	return &TextInputContent{prompt: prompt, validate: validate}
+}
+
+// NewMaskedTextInputContent creates a masked text input step (for passwords).
+func NewMaskedTextInputContent(prompt string) StepContent {
+	return &TextInputContent{prompt: prompt, masked: true}
 }
 
 func (t *TextInputContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
@@ -180,7 +198,11 @@ func (t *TextInputContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool
 
 func (t *TextInputContent) View(width int) string {
 	cursor := "█"
-	input := t.value + cursor
+	display := t.value
+	if t.masked {
+		display = strings.Repeat("*", utf8.RuneCountInString(t.value))
+	}
+	input := display + cursor
 	line := modalInputStyle.Width(width).Render(input)
 	if t.err != "" {
 		line += "\n" + modalErrorStyle.Render(t.err)
@@ -299,4 +321,37 @@ func (s *StaticContent) View(width int) string {
 
 func (s *StaticContent) Result() any {
 	return nil
+}
+
+// --- ConfirmContent ---
+
+// ConfirmContent is a Y/N confirmation dialog.
+type ConfirmContent struct {
+	message   string
+	confirmed bool
+}
+
+// NewConfirmContent creates a confirmation step.
+func NewConfirmContent(message string) StepContent {
+	return &ConfirmContent{message: message}
+}
+
+func (c *ConfirmContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.String() {
+	case "y", "Y", "enter":
+		c.confirmed = true
+		return c, nil, true
+	case "n", "N":
+		c.confirmed = false
+		return c, nil, true
+	}
+	return c, nil, false
+}
+
+func (c *ConfirmContent) View(width int) string {
+	return flashErrorStyle.Render(c.message)
+}
+
+func (c *ConfirmContent) Result() any {
+	return c.confirmed
 }

--- a/internal/app/modal_prompts.go
+++ b/internal/app/modal_prompts.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// --- Message types for modal prompt results ---
+
+// passwordEnteredMsg is sent when the SSH password modal is completed.
+type passwordEnteredMsg struct {
+	password string
+	hostIdx  int
+}
+
+// passwordCancelledMsg is sent when the SSH password modal is cancelled.
+type passwordCancelledMsg struct {
+	hostIdx int
+}
+
+// sudoEnteredMsg is sent when the sudo password modal is completed.
+type sudoEnteredMsg struct {
+	password string
+	hostIdx  int
+	retry    tea.Cmd
+}
+
+// sudoCancelledMsg is sent when the sudo password modal is cancelled.
+type sudoCancelledMsg struct{}
+
+// transitionConfirmedMsg is sent when a transition confirm modal is confirmed.
+type transitionConfirmedMsg struct {
+	t transition
+}
+
+// confirmCancelledMsg is sent when any confirm modal is cancelled.
+type confirmCancelledMsg struct{}
+
+// --- Modal constructors ---
+
+// NewPasswordModal creates a 1-step masked input modal for SSH password.
+func NewPasswordModal(user, host string, hostIdx int) *ModalOverlay {
+	prompt := fmt.Sprintf("Password for %s@%s:", user, host)
+	m := NewModalOverlay("SSH Password", []ModalStep{
+		{Title: prompt, Content: NewMaskedTextInputContent(prompt)},
+	}, func(results []any) tea.Cmd {
+		pw := results[0].(string)
+		idx := hostIdx
+		return func() tea.Msg {
+			return passwordEnteredMsg{password: pw, hostIdx: idx}
+		}
+	}, func() tea.Cmd {
+		idx := hostIdx
+		return func() tea.Msg {
+			return passwordCancelledMsg{hostIdx: idx}
+		}
+	})
+	return m
+}
+
+// NewSudoModal creates a 1-step masked input modal for sudo password.
+func NewSudoModal(user, host string, hostIdx int, retry tea.Cmd) *ModalOverlay {
+	prompt := fmt.Sprintf("Sudo password for %s:", user)
+	m := NewModalOverlay("Sudo Password", []ModalStep{
+		{Title: prompt, Content: NewMaskedTextInputContent(prompt)},
+	}, func(results []any) tea.Cmd {
+		pw := results[0].(string)
+		idx := hostIdx
+		r := retry
+		return func() tea.Msg {
+			return sudoEnteredMsg{password: pw, hostIdx: idx, retry: r}
+		}
+	}, func() tea.Cmd {
+		return func() tea.Msg {
+			return sudoCancelledMsg{}
+		}
+	})
+	return m
+}
+
+// NewConfirmModal creates a 1-step Y/N confirmation modal.
+// onConfirm is the tea.Cmd to execute when confirmed.
+func NewConfirmModal(title, message string, onConfirm tea.Cmd) *ModalOverlay {
+	m := NewModalOverlay(title, []ModalStep{
+		{Title: "", Content: NewConfirmContent(message)},
+	}, func(results []any) tea.Cmd {
+		confirmed := results[0].(bool)
+		if confirmed {
+			return onConfirm
+		}
+		return func() tea.Msg {
+			return confirmCancelledMsg{}
+		}
+	}, func() tea.Cmd {
+		return func() tea.Msg {
+			return confirmCancelledMsg{}
+		}
+	})
+	m.FooterFn = func() string {
+		return modalKeyStyle.Render("Y/Enter") + " " + modalDimStyle.Render("confirm") +
+			"  " + modalKeyStyle.Render("N/Esc") + " " + modalDimStyle.Render("cancel")
+	}
+	return m
+}
+
+// NewTransitionConfirmModal creates a confirm modal for transition actions (Azure/K8s).
+func NewTransitionConfirmModal(message string, t transition) *ModalOverlay {
+	return NewConfirmModal("Confirm", message, func() tea.Msg {
+		return transitionConfirmedMsg{t: t}
+	})
+}

--- a/internal/app/modal_test.go
+++ b/internal/app/modal_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -159,5 +160,131 @@ func TestModalOverlay_MultiStepAdvance(t *testing.T) {
 	}
 	if gotResults[1] != "nvim" {
 		t.Errorf("result[1] = %v, want nvim", gotResults[1])
+	}
+}
+
+func TestConfirmContent_YConfirms(t *testing.T) {
+	cc := NewConfirmContent("Delete this? [Y/n]")
+	_, _, done := cc.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
+	if !done {
+		t.Error("expected done on Y")
+	}
+	if cc.Result().(bool) != true {
+		t.Error("expected Result()=true on Y")
+	}
+}
+
+func TestConfirmContent_EnterConfirms(t *testing.T) {
+	cc := NewConfirmContent("Delete this? [Y/n]")
+	_, _, done := cc.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !done {
+		t.Error("expected done on Enter")
+	}
+	if cc.Result().(bool) != true {
+		t.Error("expected Result()=true on Enter")
+	}
+}
+
+func TestConfirmContent_NRejects(t *testing.T) {
+	cc := NewConfirmContent("Delete this? [Y/n]")
+	_, _, done := cc.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	if !done {
+		t.Error("expected done on n")
+	}
+	if cc.Result().(bool) != false {
+		t.Error("expected Result()=false on n")
+	}
+}
+
+func TestConfirmContent_OtherKeyNoOp(t *testing.T) {
+	cc := NewConfirmContent("Delete this? [Y/n]")
+	_, _, done := cc.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if done {
+		t.Error("expected no-op on arbitrary key")
+	}
+}
+
+func TestNewConfirmModal_EscCallsOnCancel(t *testing.T) {
+	cancelled := false
+	m := NewModalOverlay("Confirm", []ModalStep{
+		{Title: "", Content: NewConfirmContent("Do it? [Y/n]")},
+	}, func(results []any) tea.Cmd {
+		return nil
+	}, func() tea.Cmd {
+		cancelled = true
+		return nil
+	})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !cancelled {
+		t.Error("Esc should call OnCancel")
+	}
+}
+
+func TestNewConfirmModal_NCallsOnCancel(t *testing.T) {
+	var completedWith []any
+	m := NewModalOverlay("Confirm", []ModalStep{
+		{Title: "", Content: NewConfirmContent("Do it? [Y/n]")},
+	}, func(results []any) tea.Cmd {
+		completedWith = results
+		return nil
+	}, func() tea.Cmd {
+		return nil
+	})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	if completedWith == nil {
+		t.Fatal("expected OnComplete to be called")
+	}
+	if completedWith[0].(bool) != false {
+		t.Error("expected Result()=false for N")
+	}
+}
+
+func TestTextInputContent_Masked(t *testing.T) {
+	ti := NewMaskedTextInputContent("Password:")
+	for _, r := range "secret" {
+		ti, _, _ = ti.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	view := ti.View(80)
+	if strings.Contains(view, "secret") {
+		t.Error("masked view should not show raw value")
+	}
+	if !strings.Contains(view, "******") {
+		t.Error("masked view should show asterisks")
+	}
+	// Result still returns raw value
+	if ti.Result().(string) != "secret" {
+		t.Errorf("Result() = %q, want %q", ti.Result(), "secret")
+	}
+}
+
+func TestModalOverlay_SingleStepHidesCounter(t *testing.T) {
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "Only step", Content: NewTextInputContent("Input:", nil)},
+	}, func(results []any) tea.Cmd { return nil }, func() tea.Cmd { return nil })
+	view := m.View("", 100, 40)
+	if strings.Contains(view, "Step 1/1") {
+		t.Error("single-step modal should not show step counter")
+	}
+}
+
+func TestModalOverlay_MultiStepShowsCounter(t *testing.T) {
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "Step 1", Content: NewTextInputContent("Input:", nil)},
+		{Title: "Step 2", Content: NewSelectContent("Pick:", []string{"a"})},
+	}, func(results []any) tea.Cmd { return nil }, func() tea.Cmd { return nil })
+	view := m.View("", 100, 40)
+	if !strings.Contains(view, "Step 1/2") {
+		t.Error("multi-step modal should show step counter")
+	}
+}
+
+func TestModalOverlay_FooterFn(t *testing.T) {
+	m := NewModalOverlay("Test", []ModalStep{
+		{Title: "", Content: NewConfirmContent("Do it?")},
+	}, func(results []any) tea.Cmd { return nil }, func() tea.Cmd { return nil })
+	m.FooterFn = func() string { return "custom footer" }
+	view := m.View("", 100, 40)
+	if !strings.Contains(view, "custom footer") {
+		t.Error("expected custom footer in view")
 	}
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -158,6 +158,7 @@ type fetchAzureActivityLogMsg struct {
 type sudoTestMsg struct {
 	Password string
 	Success  bool
+	Retry    tea.Cmd
 }
 
 func (m Model) tickCmd() tea.Cmd {
@@ -405,27 +406,10 @@ type Model struct {
 	// log detail
 	showLogDetail bool
 
-	// confirmation prompt
-	showConfirm    bool
-	confirmMessage string
-	confirmCmd      string
-	confirmBanner   string
-	pendingHandover tea.Cmd
-
 	// SSH
 	ssh   *ssh.Manager
 	azure *azure.Manager
 	logger *slog.Logger
-
-	// password prompt
-	passwordInput      string
-	passwordHostIdx    int
-	showPasswordPrompt bool
-
-	// sudo password prompt
-	showSudoPrompt   bool
-	sudoInput        string
-	pendingSudoRetry tea.Cmd // fetch closure to re-run after sudo password is obtained
 
 	// flash message
 	flash      string
@@ -487,13 +471,17 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 		return m, nil, false
 	}
 	idx := m.selectedHost
-	m.pendingSudoRetry = retry
+	user := ""
+	host := ""
+	if idx < len(m.hosts) {
+		user = m.hosts[idx].Entry.User
+		host = m.hosts[idx].Entry.Name
+	}
 
 	// Wrong cached password: it was tried and failed — clear and re-prompt.
 	if m.ssh.GetSudoPassword(idx) != "" {
 		m.ssh.SetSudoPassword(idx, "")
-		m.showSudoPrompt = true
-		m.sudoInput = ""
+		m.modal = NewSudoModal(user, host, idx, retry)
 		return m, nil, true
 	}
 
@@ -501,19 +489,19 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 	sshPw := m.ssh.GetCachedPassword()
 	if sshPw != "" {
 		sm := m.ssh
+		r := retry
 		testCmd := func() tea.Msg {
 			sm.SetSudoPassword(idx, sshPw)
 			out, runErr := sm.RunSudoCommand(idx, "sudo true")
 			sm.SetSudoPassword(idx, "") // always clear — model Update sets it on success
 			success := runErr == nil && !ssh.IsSudoOutput(out)
-			return sudoTestMsg{Password: sshPw, Success: success}
+			return sudoTestMsg{Password: sshPw, Success: success, Retry: r}
 		}
 		return m, testCmd, true
 	}
 
 	// No SSH password cached (key auth): show prompt directly.
-	m.showSudoPrompt = true
-	m.sudoInput = ""
+	m.modal = NewSudoModal(user, host, idx, retry)
 	return m, nil, true
 }
 
@@ -556,10 +544,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.hosts[msg.Index].Error = "password required"
 					m.hosts[msg.Index].NeedsPassword = true
 					// show prompt if not already showing one
-					if !m.showPasswordPrompt {
-						m.passwordHostIdx = msg.Index
-						m.passwordInput = ""
-						m.showPasswordPrompt = true
+					if m.modal == nil || m.modal.Done() {
+						h := m.hosts[msg.Index]
+						m.modal = NewPasswordModal(h.Entry.User, h.Entry.Name, msg.Index)
 					}
 					return m, nil
 				}
@@ -968,13 +955,75 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sudoTestMsg:
 		if msg.Success {
 			m.ssh.SetSudoPassword(m.selectedHost, msg.Password)
-			retry := m.pendingSudoRetry
-			m.pendingSudoRetry = nil
-			return m, retry
+			return m, msg.Retry
 		}
 		// SSH password didn't work as sudo password — show prompt.
-		m.showSudoPrompt = true
-		m.sudoInput = ""
+		idx := m.selectedHost
+		user := ""
+		host := ""
+		if idx < len(m.hosts) {
+			user = m.hosts[idx].Entry.User
+			host = m.hosts[idx].Entry.Name
+		}
+		m.modal = NewSudoModal(user, host, idx, msg.Retry)
+		return m, nil
+
+	case passwordEnteredMsg:
+		m.modal = nil
+		m.ssh.SetCachedPassword(msg.password)
+		var cmds []tea.Cmd
+		for i, h := range m.hosts {
+			if h.NeedsPassword && (h.Status == config.HostUnreachable || i == msg.hostIdx) {
+				m.hosts[i].Status = config.HostConnecting
+				ii := i
+				hh := h
+				sm := m.ssh
+				pw := msg.password
+				cmds = append(cmds, func() tea.Msg {
+					return sm.ConnectWithPassword(ii, hh, pw)
+				})
+			}
+		}
+		return m, tea.Batch(cmds...)
+
+	case passwordCancelledMsg:
+		m.modal = nil
+		if msg.hostIdx < len(m.hosts) {
+			m.hosts[msg.hostIdx].Status = config.HostUnreachable
+			m.hosts[msg.hostIdx].Error = "password prompt cancelled"
+		}
+		return m, nil
+
+	case sudoEnteredMsg:
+		m.modal = nil
+		m.ssh.SetSudoPassword(msg.hostIdx, msg.password)
+		return m, msg.retry
+
+	case sudoCancelledMsg:
+		m.modal = nil
+		m.flash = "Sudo password prompt cancelled"
+		m.flashError = true
+		return m, nil
+
+	case transitionConfirmedMsg:
+		m.modal = nil
+		t := msg.t
+		key := t.ResourceType + "/" + t.ResourceName
+		if m.transitions == nil {
+			m.transitions = make(map[string]transition)
+		}
+		m.transitions[key] = t
+		m.flash = ""
+		execCmd := t.ExecFn
+		if t.Strategy == "poll" && !m.polling {
+			m.polling = true
+			return m, tea.Batch(execCmd, m.startPoll())
+		}
+		return m, execCmd
+
+	case confirmCancelledMsg:
+		m.modal = nil
+		m.flash = "Cancelled"
 		return m, nil
 
 	case fetchMetricsMsg:

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1382,6 +1382,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.EnterAltScreen
 
 	case sshHandoverFinishedMsg:
+		m.modal = nil
 		// refresh list after terminal handover returns
 		switch m.view {
 		case viewServiceList:

--- a/internal/app/subscription_actions_test.go
+++ b/internal/app/subscription_actions_test.go
@@ -29,7 +29,7 @@ func subscriptionModel(regType string, extraSubs ...config.Subscription) Model {
 // --- Unregister (u key) ---
 
 func TestUnregisterAction(t *testing.T) {
-	t.Run("u on unregistered host flashes error, no confirm", func(t *testing.T) {
+	t.Run("u on unregistered host flashes error, no modal", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}}
 		result, cmd := m.handleSubscriptionKeys(msg)
@@ -37,8 +37,8 @@ func TestUnregisterAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false")
+		if m2.modal != nil {
+			t.Error("expected modal = nil")
 		}
 		if m2.flash != "Host is not registered" {
 			t.Errorf("flash = %q, want %q", m2.flash, "Host is not registered")
@@ -48,7 +48,7 @@ func TestUnregisterAction(t *testing.T) {
 		}
 	})
 
-	t.Run("u on empty registration flashes error, no confirm", func(t *testing.T) {
+	t.Run("u on empty registration flashes error, no modal", func(t *testing.T) {
 		m := subscriptionModel("")
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}}
 		result, cmd := m.handleSubscriptionKeys(msg)
@@ -56,15 +56,15 @@ func TestUnregisterAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false")
+		if m2.modal != nil {
+			t.Error("expected modal = nil")
 		}
 		if !m2.flashError {
 			t.Error("expected flashError = true")
 		}
 	})
 
-	t.Run("u on CDN host shows confirm, no katello removal", func(t *testing.T) {
+	t.Run("u on CDN host shows confirm modal", func(t *testing.T) {
 		m := subscriptionModel("Red Hat CDN")
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}}
 		result, cmd := m.handleSubscriptionKeys(msg)
@@ -72,24 +72,12 @@ func TestUnregisterAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd")
 		}
-		if !m2.showConfirm {
-			t.Error("expected showConfirm = true")
-		}
-		if strings.Contains(m2.confirmCmd, "katello") {
-			t.Errorf("CDN unregister should not remove katello, got: %s", m2.confirmCmd)
-		}
-		if !strings.Contains(m2.confirmCmd, "subscription-manager unregister") {
-			t.Errorf("expected unregister command, got: %s", m2.confirmCmd)
-		}
-		if !strings.Contains(m2.confirmCmd, "subscription-manager clean") {
-			t.Errorf("expected clean command, got: %s", m2.confirmCmd)
-		}
-		if !strings.Contains(m2.confirmMessage, "Red Hat CDN") {
-			t.Errorf("confirmMessage = %q, should mention registration type", m2.confirmMessage)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
 	})
 
-	t.Run("u on Satellite host shows confirm with katello removal", func(t *testing.T) {
+	t.Run("u on Satellite host shows confirm modal", func(t *testing.T) {
 		m := subscriptionModel("Satellite")
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}}
 		result, cmd := m.handleSubscriptionKeys(msg)
@@ -97,48 +85,40 @@ func TestUnregisterAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd")
 		}
-		if !m2.showConfirm {
-			t.Error("expected showConfirm = true")
-		}
-		if !strings.Contains(m2.confirmCmd, "katello") {
-			t.Errorf("Satellite unregister must remove katello, got: %s", m2.confirmCmd)
-		}
-		if !strings.Contains(m2.confirmMessage, "Satellite") {
-			t.Errorf("confirmMessage = %q, should mention Satellite", m2.confirmMessage)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
 	})
 
-	t.Run("u confirm yes fires sshHandover", func(t *testing.T) {
+	t.Run("u confirm yes completes modal", func(t *testing.T) {
 		m := subscriptionModel("Red Hat CDN")
-		m.showConfirm = true
-		m.confirmMessage = "Unregister from Red Hat CDN? [Y/n]"
-		m.confirmCmd = "sudo subscription-manager unregister && sudo subscription-manager clean"
-		m.confirmBanner = "unregister from Red Hat CDN on host1"
-
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
-		result, cmd := m.handleKey(msg)
+		result, _ := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
 		m2 := result.(Model)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
+		}
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
 		if cmd == nil {
 			t.Error("expected non-nil cmd after confirming unregister")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false after confirm")
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after confirm")
 		}
 	})
 
 	t.Run("u confirm no cancels", func(t *testing.T) {
 		m := subscriptionModel("Red Hat CDN")
-		m.showConfirm = true
-		m.confirmCmd = "sudo subscription-manager unregister && sudo subscription-manager clean"
-
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
-		result, cmd := m.handleKey(msg)
+		result, _ := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
 		m2 := result.(Model)
-		if cmd != nil {
-			t.Error("expected nil cmd after cancel")
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
-		if m2.flash != "Cancelled" {
-			t.Errorf("flash = %q, want %q", m2.flash, "Cancelled")
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+		if cmd == nil {
+			t.Error("expected non-nil cmd from cancel (confirmCancelledMsg)")
+		}
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after cancel")
 		}
 	})
 }
@@ -154,15 +134,15 @@ func TestRegisterCDNAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false without config")
+		if m2.modal != nil {
+			t.Error("expected modal = nil without config")
 		}
 		if !m2.flashError {
 			t.Error("expected flashError = true")
 		}
 	})
 
-	t.Run("g with CDN config registers to CDN", func(t *testing.T) {
+	t.Run("g with CDN config shows confirm modal", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
 		m.hosts[0].Entry.RHOrgID = "12345"
 		m.hosts[0].Entry.RHActivationKey = "ak-cdn"
@@ -172,18 +152,12 @@ func TestRegisterCDNAction(t *testing.T) {
 		if cmd != nil {
 			t.Error("expected nil cmd — confirm not yet fired")
 		}
-		if !m2.showConfirm {
-			t.Error("expected showConfirm = true")
-		}
-		if !strings.Contains(m2.confirmMessage, "Red Hat CDN") {
-			t.Errorf("confirmMessage = %q, should mention Red Hat CDN", m2.confirmMessage)
-		}
-		if strings.Contains(m2.confirmCmd, "katello") {
-			t.Errorf("CDN register should not install katello, got: %s", m2.confirmCmd)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
 	})
 
-	t.Run("g with satellite_url registers to Satellite", func(t *testing.T) {
+	t.Run("g with satellite_url shows confirm modal", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
 		m.hosts[0].Entry.RHOrgID = "Fluxys"
 		m.hosts[0].Entry.RHActivationKey = "ak-sat"
@@ -191,14 +165,8 @@ func TestRegisterCDNAction(t *testing.T) {
 		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 		result, _ := m.handleSubscriptionKeys(msg)
 		m2 := result.(Model)
-		if !strings.Contains(m2.confirmMessage, "Satellite") {
-			t.Errorf("confirmMessage = %q, should mention Satellite", m2.confirmMessage)
-		}
-		if !strings.Contains(m2.confirmCmd, "katello-ca-consumer") {
-			t.Errorf("Satellite register should install katello, got: %s", m2.confirmCmd)
-		}
-		if !strings.Contains(m2.confirmCmd, "--force") {
-			t.Errorf("Satellite register should use --force, got: %s", m2.confirmCmd)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
 	})
 
@@ -210,43 +178,45 @@ func TestRegisterCDNAction(t *testing.T) {
 			msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}}
 			result, _ := m.handleSubscriptionKeys(msg)
 			m2 := result.(Model)
-			if !m2.showConfirm {
-				t.Errorf("regType=%q: expected showConfirm = true", regType)
+			if m2.modal == nil {
+				t.Errorf("regType=%q: expected modal to be set", regType)
 			}
 		}
 	})
 
-	t.Run("g confirm yes fires handover", func(t *testing.T) {
+	t.Run("g confirm yes completes modal", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
-		m.showConfirm = true
-		m.confirmMessage = "Register to Red Hat CDN? [Y/n]"
-		m.confirmCmd = "sudo subscription-manager register --org=12345 --activationkey=ak-test"
-		m.confirmBanner = "register to Red Hat CDN on host1"
-
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
-		result, cmd := m.handleKey(msg)
+		m.hosts[0].Entry.RHOrgID = "12345"
+		m.hosts[0].Entry.RHActivationKey = "ak-test"
+		result, _ := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
 		m2 := result.(Model)
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
+		}
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
 		if cmd == nil {
 			t.Error("expected non-nil cmd after confirming register")
 		}
-		if m2.showConfirm {
-			t.Error("expected showConfirm = false after confirm")
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after confirm")
 		}
 	})
 
 	t.Run("g confirm no cancels", func(t *testing.T) {
 		m := subscriptionModel("Unknown")
-		m.showConfirm = true
-		m.confirmCmd = "sudo subscription-manager register --org=12345 --activationkey=ak-test"
-
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
-		result, cmd := m.handleKey(msg)
+		m.hosts[0].Entry.RHOrgID = "12345"
+		m.hosts[0].Entry.RHActivationKey = "ak-test"
+		result, _ := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
 		m2 := result.(Model)
-		if cmd != nil {
-			t.Error("expected nil cmd after cancel")
+		if m2.modal == nil {
+			t.Fatal("expected modal to be set")
 		}
-		if m2.flash != "Cancelled" {
-			t.Errorf("flash = %q, want %q", m2.flash, "Cancelled")
+		cmd := m2.modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+		if cmd == nil {
+			t.Error("expected non-nil cmd from cancel")
+		}
+		if !m2.modal.Done() {
+			t.Error("expected modal to be done after cancel")
 		}
 	})
 }

--- a/internal/app/sudo_test.go
+++ b/internal/app/sudo_test.go
@@ -3,7 +3,6 @@ package app
 import (
 	"errors"
 	"log/slog"
-	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -22,84 +21,74 @@ func newTestModel() Model {
 	}
 }
 
-// TestSudoPromptKeyCapture verifies keyboard handling when showSudoPrompt is active.
-func TestSudoPromptKeyCapture(t *testing.T) {
-	t.Run("rune appended", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if m2.sudoInput != "a" {
-			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "a")
+// TestSudoModalKeyCapture verifies keyboard handling when sudo modal is active.
+func TestSudoModalKeyCapture(t *testing.T) {
+	t.Run("rune accumulates in masked input", func(t *testing.T) {
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+		ti := modal.steps[0].Content.(*TextInputContent)
+		if ti.Value() != "a" {
+			t.Errorf("value = %q, want %q", ti.Value(), "a")
 		}
 	})
 
-	t.Run("backspace single byte", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = "abc"
-		msg := tea.KeyMsg{Type: tea.KeyBackspace}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if m2.sudoInput != "ab" {
-			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "ab")
+	t.Run("backspace removes last rune", func(t *testing.T) {
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		for _, r := range "abc" {
+			modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+		modal.HandleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		ti := modal.steps[0].Content.(*TextInputContent)
+		if ti.Value() != "ab" {
+			t.Errorf("value = %q, want %q", ti.Value(), "ab")
 		}
 	})
 
 	t.Run("backspace multi-byte rune", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = "pàss" // à is 2 bytes in UTF-8
-		msg := tea.KeyMsg{Type: tea.KeyBackspace}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if m2.sudoInput != "pàs" {
-			t.Errorf("sudoInput = %q, want %q", m2.sudoInput, "pàs")
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		for _, r := range "pàss" {
+			modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		}
+		modal.HandleKey(tea.KeyMsg{Type: tea.KeyBackspace})
+		ti := modal.steps[0].Content.(*TextInputContent)
+		if ti.Value() != "pàs" {
+			t.Errorf("value = %q, want %q", ti.Value(), "pàs")
 		}
 	})
 
-	t.Run("enter with empty input is no-op", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = ""
-		msg := tea.KeyMsg{Type: tea.KeyEnter}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if !m2.showSudoPrompt {
-			t.Error("showSudoPrompt should remain true on empty enter")
+	t.Run("enter with empty input is rejected", func(t *testing.T) {
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		modal.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		if modal.Done() {
+			t.Error("modal should not be done on empty enter")
 		}
 	})
 
-	t.Run("enter with password clears prompt", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = "mypassword"
-		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
-		m.selectedHost = 0
-		msg := tea.KeyMsg{Type: tea.KeyEnter}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if m2.showSudoPrompt {
-			t.Error("showSudoPrompt should be false after entering password")
+	t.Run("enter with password completes modal", func(t *testing.T) {
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		for _, r := range "mypassword" {
+			modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		}
-		if m2.sudoInput != "" {
-			t.Errorf("sudoInput should be cleared, got %q", m2.sudoInput)
+		cmd := modal.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+		if !modal.Done() {
+			t.Error("modal should be done after entering password")
+		}
+		if cmd == nil {
+			t.Error("expected non-nil cmd from OnComplete")
 		}
 	})
 
-	t.Run("esc cancels prompt", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = "typing"
-		msg := tea.KeyMsg{Type: tea.KeyEsc}
-		result, _ := m.handleKey(msg)
-		m2 := result.(Model)
-		if m2.showSudoPrompt {
-			t.Error("showSudoPrompt should be false after Esc")
+	t.Run("esc cancels modal", func(t *testing.T) {
+		modal := NewSudoModal("alice", "host1", 0, nil)
+		for _, r := range "typing" {
+			modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 		}
-		if m2.flash == "" {
-			t.Error("flash should be set after Esc")
+		cmd := modal.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+		if !modal.Done() {
+			t.Error("modal should be done after Esc")
+		}
+		if cmd == nil {
+			t.Error("expected non-nil cmd from OnCancel")
 		}
 	})
 }
@@ -120,7 +109,7 @@ func TestHandleSudoOrFlash(t *testing.T) {
 		}
 	})
 
-	t.Run("sudo error with no cached passwords shows prompt", func(t *testing.T) {
+	t.Run("sudo error with no cached passwords shows modal", func(t *testing.T) {
 		m := newTestModel()
 		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
 		err := ssh.ErrSudoRequired
@@ -128,8 +117,8 @@ func TestHandleSudoOrFlash(t *testing.T) {
 		if !ok {
 			t.Error("expected ok=true for sudo error")
 		}
-		if !m2.showSudoPrompt {
-			t.Error("expected showSudoPrompt=true when no passwords cached")
+		if m2.modal == nil {
+			t.Error("expected modal to be set when no passwords cached")
 		}
 		if cmd != nil {
 			t.Error("expected cmd=nil when showing prompt directly")
@@ -145,15 +134,15 @@ func TestHandleSudoOrFlash(t *testing.T) {
 		if !ok {
 			t.Error("expected ok=true for sudo error")
 		}
-		if m2.showSudoPrompt {
-			t.Error("expected showSudoPrompt=false when silently testing SSH password")
+		if m2.modal != nil {
+			t.Error("expected modal=nil when silently testing SSH password")
 		}
 		if cmd == nil {
 			t.Error("expected non-nil cmd for silent sudo test")
 		}
 	})
 
-	t.Run("sudo error with wrong cached sudo password clears and prompts", func(t *testing.T) {
+	t.Run("sudo error with wrong cached sudo password clears and shows modal", func(t *testing.T) {
 		m := newTestModel()
 		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1"}}}
 		m.ssh.SetSudoPassword(0, "wrongpw")
@@ -162,42 +151,14 @@ func TestHandleSudoOrFlash(t *testing.T) {
 		if !ok {
 			t.Error("expected ok=true for sudo error")
 		}
-		if !m2.showSudoPrompt {
-			t.Error("expected showSudoPrompt=true after clearing wrong sudo password")
+		if m2.modal == nil {
+			t.Error("expected modal to be set after clearing wrong sudo password")
 		}
 		if cmd != nil {
 			t.Error("expected cmd=nil when showing prompt")
 		}
 		if m2.ssh.GetSudoPassword(0) != "" {
 			t.Error("expected sudo password to be cleared")
-		}
-	})
-}
-
-// TestRenderSudoPromptOrHintBar verifies the hint bar rendering with and without sudo prompt.
-func TestRenderSudoPromptOrHintBar(t *testing.T) {
-	t.Run("sudo prompt active shows masked password and username", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = true
-		m.sudoInput = "pw"
-		m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host1", User: "alice"}}}
-		m.selectedHost = 0
-		out := m.renderSudoPromptOrHintBar(nil)
-		if !strings.Contains(out, "alice") {
-			t.Errorf("expected username 'alice' in output, got: %q", out)
-		}
-		if !strings.Contains(out, "**") {
-			t.Errorf("expected masked password '**' in output, got: %q", out)
-		}
-	})
-
-	t.Run("no sudo prompt delegates to hint bar", func(t *testing.T) {
-		m := newTestModel()
-		m.showSudoPrompt = false
-		hints := [][]string{{"Enter", "Confirm"}}
-		out := m.renderSudoPromptOrHintBar(hints)
-		if !strings.Contains(out, "<") {
-			t.Errorf("expected hint bar key brackets in output, got: %q", out)
 		}
 	})
 }

--- a/internal/app/view_account.go
+++ b/internal/app/view_account.go
@@ -162,7 +162,7 @@ func (m Model) renderAccountList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 {"Enter", "Detail"},

--- a/internal/app/view_azure_aks.go
+++ b/internal/app/view_azure_aks.go
@@ -223,9 +223,7 @@ func (m Model) renderAzureAKSList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else if m.filterActive {
+	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
 		maxSortCol := 8 + len(displayTags)

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -148,9 +148,7 @@ func (m Model) renderAzureVMList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else if m.filterActive {
+	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
 		s += m.renderHintBar([][]string{

--- a/internal/app/view_common.go
+++ b/internal/app/view_common.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
@@ -27,21 +26,6 @@ func (m Model) renderHeader(breadcrumb string, current, total int) string {
 		gap = 0
 	}
 	return left + strings.Repeat(" ", gap) + right
-}
-
-// renderSudoPromptOrHintBar renders the sudo password prompt if active,
-// otherwise delegates to renderHintBar. Use in all SSH-based VM views.
-func (m Model) renderSudoPromptOrHintBar(hints [][]string) string {
-	if m.showSudoPrompt {
-		user := ""
-		if m.selectedHost < len(m.hosts) {
-			user = m.hosts[m.selectedHost].Entry.User
-		}
-		masked := strings.Repeat("*", utf8.RuneCountInString(m.sudoInput))
-		prompt := fmt.Sprintf("  Sudo password for %s: %s\u2588", user, masked)
-		return hintBarStyle.Width(m.width).Render(prompt)
-	}
-	return m.renderHintBar(hints)
 }
 
 func (m Model) renderHintBar(hints [][]string) string {

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -64,7 +64,7 @@ func (m Model) renderContainerList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderSudoPromptOrHintBar([][]string{
+		s += m.renderHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -147,7 +147,7 @@ func (m Model) renderContainerList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-3", "Sort"},

--- a/internal/app/view_cron.go
+++ b/internal/app/view_cron.go
@@ -101,7 +101,7 @@ func (m Model) renderCronList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"1-3", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_disk.go
+++ b/internal/app/view_disk.go
@@ -59,7 +59,7 @@ func (m Model) renderDiskList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderSudoPromptOrHintBar([][]string{
+		s += m.renderHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -148,7 +148,7 @@ func (m Model) renderDiskList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-6", "Sort"},

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -106,7 +106,7 @@ func (m Model) renderFleetPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"Enter", "Select"},
 		{"e", "Edit"},
 		{"c", "Config"},

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -114,27 +114,16 @@ func (m Model) renderHostList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	if m.showPasswordPrompt {
-		user := m.hosts[m.passwordHostIdx].Entry.User
-		masked := strings.Repeat("*", len(m.passwordInput))
-		prompt := fmt.Sprintf("  Password for %s: %s\u2588", user, masked)
-		s += hintBarStyle.Width(m.width).Render(prompt)
-	} else if m.showSudoPrompt {
-		s += m.renderSudoPromptOrHintBar(nil)
-	} else if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else {
-		s += m.renderHintBar([][]string{
-			{"↑↓", "Navigate"},
-			{"Enter", "Drill In"},
-			{"x", "Shell"},
-			{"K", "Deploy Key"},
-			{"d", "Metrics"},
-			{"R", "Reboot"},
-			{"r", "Refresh"},
-			{"Esc", "Back"},
-			{"q", "Quit"},
-		})
-	}
+	s += m.renderHintBar([][]string{
+		{"↑↓", "Navigate"},
+		{"Enter", "Drill In"},
+		{"x", "Shell"},
+		{"K", "Deploy Key"},
+		{"d", "Metrics"},
+		{"R", "Reboot"},
+		{"r", "Refresh"},
+		{"Esc", "Back"},
+		{"q", "Quit"},
+	})
 	return s
 }

--- a/internal/app/view_k8s_contexts.go
+++ b/internal/app/view_k8s_contexts.go
@@ -93,9 +93,7 @@ func (m Model) renderK8sContextList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else if m.filterActive {
+	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
 		s += m.renderHintBar([][]string{

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -137,9 +137,7 @@ func (m Model) renderK8sPodList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else if m.filterActive {
+	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
 		s += m.renderHintBar([][]string{

--- a/internal/app/view_logs.go
+++ b/internal/app/view_logs.go
@@ -50,7 +50,7 @@ func (m Model) renderLogLevelPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "View Logs"},
 		{"r", "Refresh"},
@@ -214,7 +214,7 @@ func (m Model) renderErrorLogList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderSudoPromptOrHintBar([][]string{
+		s += m.renderHintBar([][]string{
 			{"↑↓", "Navigate"},
 			{"1-3", "Sort"},
 			{"Enter", "Detail"},

--- a/internal/app/view_metrics.go
+++ b/internal/app/view_metrics.go
@@ -156,7 +156,7 @@ func (m Model) renderMetrics() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"r", "Refresh"},

--- a/internal/app/view_network.go
+++ b/internal/app/view_network.go
@@ -64,7 +64,7 @@ func (m Model) renderNetworkPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},

--- a/internal/app/view_network_firewall.go
+++ b/internal/app/view_network_firewall.go
@@ -133,7 +133,7 @@ func (m Model) renderNetworkFirewall() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_interfaces.go
+++ b/internal/app/view_network_interfaces.go
@@ -116,7 +116,7 @@ func (m Model) renderNetworkInterfaces() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_ports.go
+++ b/internal/app/view_network_ports.go
@@ -109,7 +109,7 @@ func (m Model) renderNetworkPorts() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_network_routes.go
+++ b/internal/app/view_network_routes.go
@@ -118,7 +118,7 @@ func (m Model) renderNetworkRoutes() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_resource.go
+++ b/internal/app/view_resource.go
@@ -101,7 +101,7 @@ func (m Model) renderResourcePicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},

--- a/internal/app/view_security_audit.go
+++ b/internal/app/view_security_audit.go
@@ -102,7 +102,7 @@ func (m Model) renderAuditSummary() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_failed_logins.go
+++ b/internal/app/view_security_failed_logins.go
@@ -95,7 +95,7 @@ func (m Model) renderFailedLogins() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_selinux.go
+++ b/internal/app/view_security_selinux.go
@@ -99,7 +99,7 @@ func (m Model) renderSELinuxDenials() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_security_sudo.go
+++ b/internal/app/view_security_sudo.go
@@ -102,7 +102,7 @@ func (m Model) renderSudoActivity() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderSudoPromptOrHintBar([][]string{
+	s += m.renderHintBar([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -138,19 +138,15 @@ func (m Model) renderServiceList() string {
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-		if m.showConfirm {
-			s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-		} else {
-			s += m.renderSudoPromptOrHintBar([][]string{
-				{"\u2191\u2193", "Scroll"},
-				{"/", "Search"},
-				{"s", "Start"},
-				{"o", "Stop"},
-				{"t", "Restart"},
-				{"r", "Refresh"},
-				{"Esc", "Back"},
-			})
-		}
+		s += m.renderHintBar([][]string{
+			{"\u2191\u2193", "Scroll"},
+			{"/", "Search"},
+			{"s", "Start"},
+			{"o", "Stop"},
+			{"t", "Restart"},
+			{"r", "Refresh"},
+			{"Esc", "Back"},
+		})
 		return s
 	}
 
@@ -233,12 +229,10 @@ func (m Model) renderServiceList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else if m.filterActive {
+	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderSudoPromptOrHintBar([][]string{
+		s += m.renderHintBar([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"1-4", "Sort"},
 			{"Enter", "Detail"},

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -73,21 +73,17 @@ func (m Model) renderSubscription() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else {
-		regTarget := "Register CDN"
-		if h.Entry.SatelliteURL != "" {
-			regTarget = "Register Satellite"
-		}
-		s += m.renderSudoPromptOrHintBar([][]string{
-			{"↑↓", "Navigate"},
-			{"u", "Unregister"},
-			{"g", regTarget},
-			{"d", "Disable Repo"},
-			{"r", "Refresh"},
-			{"Esc", "Back"},
-		})
+	regTarget := "Register CDN"
+	if h.Entry.SatelliteURL != "" {
+		regTarget = "Register Satellite"
 	}
+	s += m.renderHintBar([][]string{
+		{"↑↓", "Navigate"},
+		{"u", "Unregister"},
+		{"g", regTarget},
+		{"d", "Disable Repo"},
+		{"r", "Refresh"},
+		{"Esc", "Back"},
+	})
 	return s
 }

--- a/internal/app/view_updates.go
+++ b/internal/app/view_updates.go
@@ -59,7 +59,7 @@ func (m Model) renderUpdateList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderSudoPromptOrHintBar([][]string{
+		s += m.renderHintBar([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
 		})
@@ -149,19 +149,15 @@ func (m Model) renderUpdateList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	if m.showConfirm {
-		s += hintBarStyle.Width(m.width).Render("  " + flashErrorStyle.Render(m.confirmMessage))
-	} else {
-		s += m.renderSudoPromptOrHintBar([][]string{
-			{"↑↓", "Navigate"},
-			{"Enter", "Detail"},
-			{"1-3", "Sort"},
-			{"/", "Search"},
-			{"u", "Update All"},
-			{"p", "Security Only"},
-			{"r", "Refresh"},
-			{"Esc", "Back"},
-		})
-	}
+	s += m.renderHintBar([][]string{
+		{"↑↓", "Navigate"},
+		{"Enter", "Detail"},
+		{"1-3", "Sort"},
+		{"/", "Search"},
+		{"u", "Update All"},
+		{"p", "Security Only"},
+		{"r", "Refresh"},
+		{"Esc", "Back"},
+	})
 	return s
 }


### PR DESCRIPTION
## Summary

- Replace 3 hand-rolled prompt patterns (SSH password, sudo password, destructive confirmations) with the `ModalOverlay` component from FLE-68
- Add `ConfirmContent` type with Y/N key handling, masked `TextInputContent` for passwords, and `FooterFn` for custom modal footers
- Hide step counter for single-step modals
- Remove 11 dead model fields (`showConfirm`, `confirmMessage`, `confirmCmd`, `confirmBanner`, `pendingHandover`, `showPasswordPrompt`, `passwordInput`, `passwordHostIdx`, `showSudoPrompt`, `sudoInput`, `pendingSudoRetry`)
- Remove `renderSudoPromptOrHintBar` and simplify 24 view files to use `renderHintBar` directly
- Migrate 15 confirm trigger sites in `keys.go` and 2 in `commands.go` to use `NewConfirmModal`/`NewTransitionConfirmModal`
- Rewrite tests for modal-based assertions, add 11 new modal tests
- Net -86 lines (36 files, 752 added, 726 removed)