### PR TITLE
feat: help overlay, about modal, loading modals (FLE-66, FLE-72, FLE-70)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -462,7 +462,7 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "updates", "host_idx", idx)
 		// get pending updates and security updates in one command
-		cmd := `dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
+		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
 		out, err := sm.RunCommand(idx, cmd)
 		// dnf check-update returns exit 100 when updates are available
 		if err != nil && !strings.Contains(out, "===SECURITY===") {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -464,11 +464,14 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		// get pending updates and security updates in one command
 		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
 		out, err := sm.RunSudoCommand(idx, cmd)
+		// Check for sudo password prompt before anything else —
+		// the ===SECURITY=== sentinel is always present (echo runs
+		// regardless), so the old err+sentinel check would skip this.
+		if ssh.IsSudoOutput(out) {
+			return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+		}
 		// dnf check-update returns exit 100 when updates are available
 		if err != nil && !strings.Contains(out, "===SECURITY===") {
-			if ssh.IsSudoOutput(out) {
-				return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
-			}
 			logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)
 			return fetchUpdatesMsg{err: fmt.Errorf("updates: %w", err)}
 		}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -512,12 +512,21 @@ func (m Model) fetchUpdates() func() tea.Msg {
 			}
 		}
 
+		inObsoleting := false
 		for _, line := range strings.Split(strings.TrimSpace(updatesSection), "\n") {
-			line = strings.TrimSpace(line)
-			if line == "" || strings.HasPrefix(line, "Last metadata") || strings.HasPrefix(line, "Obsoleting") || strings.HasPrefix(line, "Is this ok") || strings.HasPrefix(line, "Not root") || strings.HasPrefix(line, "Microsoft") || strings.HasPrefix(line, "Error:") || strings.HasPrefix(line, "Warning:") || strings.HasPrefix(line, "Importing") || strings.HasPrefix(line, "Userid") || strings.HasPrefix(line, "Fingerprint") || strings.HasPrefix(line, "From") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" || strings.HasPrefix(trimmed, "Last metadata") || strings.HasPrefix(trimmed, "Is this ok") || strings.HasPrefix(trimmed, "Not root") || strings.HasPrefix(trimmed, "Microsoft") || strings.HasPrefix(trimmed, "Error:") || strings.HasPrefix(trimmed, "Warning:") || strings.HasPrefix(trimmed, "Importing") || strings.HasPrefix(trimmed, "Userid") || strings.HasPrefix(trimmed, "Fingerprint") || strings.HasPrefix(trimmed, "From") {
 				continue
 			}
-			fields := strings.Fields(line)
+			// Skip entire Obsoleting Packages section — duplicates of updates listed above
+			if strings.HasPrefix(trimmed, "Obsoleting") {
+				inObsoleting = true
+				continue
+			}
+			if inObsoleting {
+				continue
+			}
+			fields := strings.Fields(trimmed)
 			// package lines have format: name.arch  version  repo
 			if len(fields) < 2 || !strings.Contains(fields[0], ".") {
 				continue

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -463,9 +463,12 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		logger.Debug("fetch start", "view", "updates", "host_idx", idx)
 		// get pending updates and security updates in one command
 		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
-		out, err := sm.RunCommand(idx, cmd)
+		out, err := sm.RunSudoCommand(idx, cmd)
 		// dnf check-update returns exit 100 when updates are available
 		if err != nil && !strings.Contains(out, "===SECURITY===") {
+			if ssh.IsSudoOutput(out) {
+				return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
 			logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)
 			return fetchUpdatesMsg{err: fmt.Errorf("updates: %w", err)}
 		}

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -472,9 +472,14 @@ func (m Model) fetchUpdates() func() tea.Msg {
 			return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
 		}
 		// dnf check-update returns exit 100 when updates are available
-		if err != nil && !strings.Contains(out, "===SECURITY===") {
-			logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)
-			return fetchUpdatesMsg{err: fmt.Errorf("updates: %w", err)}
+		if err != nil {
+			if ssh.IsSudoOutput(out) {
+				return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+			}
+			if !strings.Contains(out, "===SECURITY===") {
+				logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)
+				return fetchUpdatesMsg{err: fmt.Errorf("updates: %w", err)}
+			}
 		}
 
 		parts := strings.SplitN(out, "===SECURITY===", 2)

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -464,9 +464,11 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		// get pending updates and security updates in one command
 		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
 		out, err := sm.RunSudoCommand(idx, cmd)
-		// Check for sudo password prompt before sentinel check —
-		// the echo always runs so ===SECURITY=== is always present.
-		if ssh.IsSudoOutput(out) {
+		// Only check for sudo prompt when no password is cached.
+		// When cached, rewriteSudoCmd pipes the password via -S, and
+		// the 2>&1 in the dnf command captures "[sudo] password for"
+		// into stdout — IsSudoOutput would false-positive.
+		if sm.GetSudoPassword(idx) == "" && ssh.IsSudoOutput(out) {
 			return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
 		}
 		// dnf check-update returns exit 100 when updates are available

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -462,14 +462,8 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "updates", "host_idx", idx)
 		// get pending updates and security updates in one command
-		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
-		out, err := sm.RunSudoCommand(idx, cmd)
-		// Check for sudo password prompt before anything else —
-		// the ===SECURITY=== sentinel is always present (echo runs
-		// regardless), so the old err+sentinel check would skip this.
-		if ssh.IsSudoOutput(out) {
-			return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
-		}
+		cmd := `dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
+		out, err := sm.RunCommand(idx, cmd)
 		// dnf check-update returns exit 100 when updates are available
 		if err != nil && !strings.Contains(out, "===SECURITY===") {
 			logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -462,8 +462,13 @@ func (m Model) fetchUpdates() func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "updates", "host_idx", idx)
 		// get pending updates and security updates in one command
-		cmd := `dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
-		out, err := sm.RunCommand(idx, cmd)
+		cmd := `sudo dnf --setopt=skip_if_unavailable=1 check-update 2>&1; echo '===SECURITY==='; sudo dnf --setopt=skip_if_unavailable=1 updateinfo list --security --quiet 2>/dev/null`
+		out, err := sm.RunSudoCommand(idx, cmd)
+		// Check for sudo password prompt before sentinel check —
+		// the echo always runs so ===SECURITY=== is always present.
+		if ssh.IsSudoOutput(out) {
+			return fetchUpdatesMsg{err: fmt.Errorf("%w", ssh.ErrSudoRequired)}
+		}
 		// dnf check-update returns exit 100 when updates are available
 		if err != nil && !strings.Contains(out, "===SECURITY===") {
 			logger.Error("fetch failed", "view", "updates", "host_idx", idx, "err", err)

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -1,0 +1,517 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+)
+
+// helpSection formats a group of keybinds with a header.
+func helpSection(title string, binds [][]string) string {
+	var b strings.Builder
+	b.WriteString("  " + title + "\n")
+	b.WriteString("  " + strings.Repeat("\u2500", 30) + "\n")
+	for _, bind := range binds {
+		b.WriteString(fmt.Sprintf("  %-12s %s\n", bind[0], bind[1]))
+	}
+	return b.String()
+}
+
+func globalHelp(hasFilter bool) string {
+	binds := [][]string{
+		{"Esc", "Back / close"},
+		{"q", "Quit"},
+		{"?", "Help"},
+	}
+	if hasFilter {
+		binds = append([][]string{
+			{"/", "Filter"},
+		}, binds...)
+	}
+	return helpSection("Global", binds)
+}
+
+func helpForView(v view) string {
+	switch v {
+	case viewFleetPicker:
+		return helpFleetPicker()
+	case viewHostList:
+		return helpHostList()
+	case viewMetrics:
+		return helpMetrics()
+	case viewResourcePicker:
+		return helpResourcePicker()
+	case viewServiceList:
+		return helpServiceList()
+	case viewContainerList:
+		return helpContainerList()
+	case viewCronList:
+		return helpCronList()
+	case viewLogLevelPicker:
+		return helpLogLevelPicker()
+	case viewErrorLogList:
+		return helpErrorLogList()
+	case viewUpdateList:
+		return helpUpdateList()
+	case viewDiskList:
+		return helpDiskList()
+	case viewSubscription:
+		return helpSubscription()
+	case viewAccountList:
+		return helpAccountList()
+	case viewNetworkPicker:
+		return helpNetworkPicker()
+	case viewNetworkInterfaces:
+		return helpNetworkInterfaces()
+	case viewNetworkPorts:
+		return helpNetworkPorts()
+	case viewNetworkRoutes:
+		return helpNetworkRoutes()
+	case viewNetworkFirewall:
+		return helpNetworkFirewall()
+	case viewSecurityFailedLogins:
+		return helpSecurityFailedLogins()
+	case viewSecuritySudo:
+		return helpSecuritySudo()
+	case viewSecuritySELinux:
+		return helpSecuritySELinux()
+	case viewSecurityAudit:
+		return helpSecurityAudit()
+	case viewAzureSubList:
+		return helpAzureSubList()
+	case viewAzureResourcePicker:
+		return helpAzureResourcePicker()
+	case viewAzureVMList:
+		return helpAzureVMList()
+	case viewAzureVMDetail:
+		return helpAzureVMDetail()
+	case viewAzureAKSList:
+		return helpAzureAKSList()
+	case viewAzureAKSDetail:
+		return helpAzureAKSDetail()
+	case viewK8sClusterList:
+		return helpK8sClusterList()
+	case viewK8sContextList:
+		return helpK8sContextList()
+	case viewK8sResourcePicker:
+		return helpK8sResourcePicker()
+	case viewK8sNodeList:
+		return helpK8sNodeList()
+	case viewK8sNodeDetail:
+		return helpK8sNodeDetail()
+	case viewK8sNamespaceList:
+		return helpK8sNamespaceList()
+	case viewK8sWorkloadList:
+		return helpK8sWorkloadList()
+	case viewK8sPodList:
+		return helpK8sPodList()
+	case viewK8sPodDetail:
+		return helpK8sPodDetail()
+	case viewK8sPodLogs:
+		return helpK8sPodLogs()
+	case viewConfig:
+		return helpConfig()
+	default:
+		return globalHelp(false)
+	}
+}
+
+func helpFleetPicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select fleet"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"a", "About"},
+		{"e", "Edit fleet file"},
+		{"c", "Config"},
+		{"r", "Reload fleets"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpHostList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Drill into host"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"x", "Shell (SSH)"},
+		{"K", "Deploy SSH key"},
+		{"R", "Reboot host"},
+		{"d", "Fleet metrics"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpMetrics() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-5", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpResourcePicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select resource"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpServiceList() string {
+	return helpSection("List Mode", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Open detail"},
+		{"1-4", "Sort by column"},
+		{"r", "Refresh"},
+	}) + "\n" + helpSection("Detail Mode", [][]string{
+		{"↑/↓ k/j", "Scroll logs"},
+		{"s", "Start service"},
+		{"o", "Stop service"},
+		{"t", "Restart service"},
+		{"r", "Refresh detail"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpContainerList() string {
+	return helpSection("List Mode", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Open detail"},
+		{"1-3", "Sort by column"},
+		{"l", "Follow logs"},
+		{"i", "Inspect"},
+		{"e", "Exec shell"},
+		{"r", "Refresh"},
+	}) + "\n" + helpSection("Detail Mode", [][]string{
+		{"↑/↓ k/j", "Scroll"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpCronList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-3", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpLogLevelPicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select level"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpErrorLogList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-3", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"l", "Full log (less)"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpUpdateList() string {
+	return helpSection("List Mode", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-3", "Sort by column"},
+		{"u", "Apply ALL updates"},
+		{"p", "Apply security updates"},
+		{"r", "Refresh"},
+	}) + "\n" + helpSection("Detail Mode", [][]string{
+		{"↑/↓ k/j", "Scroll"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpDiskList() string {
+	return helpSection("List Mode", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-6", "Sort by column"},
+		{"r", "Refresh"},
+	}) + "\n" + helpSection("Detail Mode", [][]string{
+		{"↑/↓ k/j", "Scroll"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpSubscription() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"u", "Unregister"},
+		{"g", "Register"},
+		{"d", "Disable repo"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpAccountList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-5", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpNetworkPicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select sub-view"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpNetworkInterfaces() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-4", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpNetworkPorts() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-4", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpNetworkRoutes() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-4", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpNetworkFirewall() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-5", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpSecurityFailedLogins() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-4", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpSecuritySudo() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-4", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpSecuritySELinux() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-5", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpSecurityAudit() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-5", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpAzureSubList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select subscription"},
+		{"1-3", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpAzureResourcePicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select resource type"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpAzureVMList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-7", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"s", "Start VM"},
+		{"o", "Deallocate VM"},
+		{"t", "Restart VM"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpAzureVMDetail() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Scroll"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"a", "Refresh activity log"},
+		{"r", "Refresh all"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpAzureAKSList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-9", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"s", "Start cluster"},
+		{"o", "Stop cluster"},
+		{"d", "Delete cluster"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpAzureAKSDetail() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Scroll activity log"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"a", "Refresh activity log"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpK8sClusterList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select cluster"},
+		{"1-3", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sContextList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select context"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"d", "Delete context"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sResourcePicker() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select resource type"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpK8sNodeList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View detail"},
+		{"1-9", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sNodeDetail() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"1-9", "Sort pods by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sNamespaceList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select namespace"},
+		{"1-7", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sWorkloadList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "Select workload"},
+		{"1-3", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sPodList() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"Enter", "View pod detail"},
+		{"1-6", "Sort by column"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"l", "View logs (workload)"},
+		{"d", "Delete pod"},
+		{"r", "Refresh"},
+	}) + "\n" + globalHelp(true)
+}
+
+func helpK8sPodDetail() string {
+	return helpSection("Navigation", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"g", "Go to top"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"l", "View logs (pod)"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpK8sPodLogs() string {
+	return helpSection("List Mode", [][]string{
+		{"↑/↓ k/j", "Move cursor"},
+		{"G", "Go to bottom"},
+		{"g", "Go to top"},
+		{"Enter", "View log detail"},
+	}) + "\n" + helpSection("Actions", [][]string{
+		{"s", "Start/stop streaming"},
+		{"d", "Cycle level filter"},
+		{"c", "Toggle sidecar logs"},
+	}) + "\n" + helpSection("Detail Mode", [][]string{
+		{"↑/↓ k/j", "Scroll"},
+		{"g", "Go to top"},
+	}) + "\n" + globalHelp(false)
+}
+
+func helpConfig() string {
+	return helpSection("Actions", [][]string{
+		{"e", "Edit config"},
+		{"r", "Reload"},
+	}) + "\n" + globalHelp(false)
+}

--- a/internal/app/help_test.go
+++ b/internal/app/help_test.go
@@ -1,0 +1,158 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestHelpForView_AllViewsCovered(t *testing.T) {
+	// Every view constant must return non-empty help text.
+	views := []view{
+		viewFleetPicker, viewHostList, viewMetrics, viewResourcePicker,
+		viewServiceList, viewContainerList, viewCronList, viewLogLevelPicker,
+		viewErrorLogList, viewUpdateList, viewDiskList, viewSubscription,
+		viewAccountList, viewNetworkPicker, viewNetworkInterfaces,
+		viewNetworkPorts, viewNetworkRoutes, viewNetworkFirewall,
+		viewSecurityFailedLogins, viewSecuritySudo, viewSecuritySELinux,
+		viewSecurityAudit, viewAzureSubList, viewAzureResourcePicker,
+		viewAzureVMList, viewAzureVMDetail, viewAzureAKSList,
+		viewAzureAKSDetail, viewK8sClusterList, viewK8sContextList,
+		viewK8sResourcePicker, viewK8sNodeList, viewK8sNodeDetail,
+		viewK8sNamespaceList, viewK8sWorkloadList, viewK8sPodList,
+		viewK8sPodDetail, viewK8sPodLogs, viewConfig,
+	}
+	for _, v := range views {
+		text := helpForView(v)
+		if text == "" {
+			t.Errorf("helpForView(%d) returned empty string", v)
+		}
+	}
+}
+
+func TestHelpForView_ContainsGlobalSection(t *testing.T) {
+	views := []view{
+		viewFleetPicker, viewHostList, viewServiceList,
+		viewAzureVMList, viewK8sPodList, viewConfig,
+	}
+	for _, v := range views {
+		text := helpForView(v)
+		if !strings.Contains(text, "Global") {
+			t.Errorf("helpForView(%d) missing Global section", v)
+		}
+		if !strings.Contains(text, "Quit") {
+			t.Errorf("helpForView(%d) missing q/Quit in Global section", v)
+		}
+		if !strings.Contains(text, "Help") {
+			t.Errorf("helpForView(%d) missing ?/Help in Global section", v)
+		}
+	}
+}
+
+func TestHelpForView_ContainsNavigationSection(t *testing.T) {
+	// Views with explicit Navigation group
+	views := []view{
+		viewFleetPicker, viewHostList, viewMetrics,
+		viewResourcePicker, viewSubscription,
+	}
+	for _, v := range views {
+		text := helpForView(v)
+		if !strings.Contains(text, "Navigation") {
+			t.Errorf("helpForView(%d) missing Navigation section", v)
+		}
+	}
+}
+
+func TestHelpForView_MultiModeViewsShowBothModes(t *testing.T) {
+	// Services has both list and detail modes
+	text := helpForView(viewServiceList)
+	if !strings.Contains(text, "List Mode") {
+		t.Error("services help missing List Mode section")
+	}
+	if !strings.Contains(text, "Detail Mode") {
+		t.Error("services help missing Detail Mode section")
+	}
+}
+
+func TestHelpForView_FilterViewsShowFilter(t *testing.T) {
+	// Views that support / filter should show it in Global section
+	text := helpForView(viewServiceList)
+	if !strings.Contains(text, "Filter") {
+		t.Error("services help missing / Filter in Global section")
+	}
+}
+
+func TestHintWithHelp(t *testing.T) {
+	hints := [][]string{
+		{"Enter", "Select"},
+		{"Esc", "Back"},
+	}
+	result := hintWithHelp(hints)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 hints, got %d", len(result))
+	}
+	last := result[len(result)-1]
+	if last[0] != "?" || last[1] != "Help" {
+		t.Errorf("last hint = %v, want [? Help]", last)
+	}
+	// Original slice should not be modified
+	if len(hints) != 2 {
+		t.Error("hintWithHelp should not modify original slice")
+	}
+}
+
+func TestStaticContent_QuestionMarkDismisses(t *testing.T) {
+	sc := NewStaticContent("some help text")
+	_, _, done := sc.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	if !done {
+		t.Error("? should dismiss StaticContent")
+	}
+}
+
+func TestHelpOverlay_QuestionMarkOpensModal(t *testing.T) {
+	// Simulate pressing ? in handleKey by constructing the modal directly
+	// (same logic as handleKey)
+	text := helpForView(viewHostList)
+	modal := NewModalOverlay("Keybindings", []ModalStep{
+		{Title: "", Content: NewStaticContent(text)},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+
+	if modal.Done() {
+		t.Error("modal should not be done immediately")
+	}
+
+	// View should contain help text
+	view := modal.View("", 100, 40)
+	if !strings.Contains(view, "Keybindings") {
+		t.Error("modal view should contain title")
+	}
+}
+
+func TestHelpOverlay_QuestionMarkClosesModal(t *testing.T) {
+	text := helpForView(viewHostList)
+	modal := NewModalOverlay("Keybindings", []ModalStep{
+		{Title: "", Content: NewStaticContent(text)},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+
+	// Press ? to close (StaticContent handles it)
+	modal.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	if !modal.Done() {
+		t.Error("? should dismiss the help overlay")
+	}
+}
+
+func TestHelpOverlay_EscClosesModal(t *testing.T) {
+	text := helpForView(viewHostList)
+	modal := NewModalOverlay("Keybindings", []ModalStep{
+		{Title: "", Content: NewStaticContent(text)},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+
+	modal.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !modal.Done() {
+		t.Error("Esc should dismiss the help overlay")
+	}
+}

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -716,6 +716,7 @@ func (m *Model) applyProbeInfo(idx int, info ssh.ProbeInfo) {
 	m.hosts[idx].InterfacesUp = info.InterfacesUp
 	m.hosts[idx].InterfacesTotal = info.InterfacesTotal
 	m.hosts[idx].ListeningPorts = info.ListeningPorts
+	m.hosts[idx].UpdateCount = info.UpdateCount
 }
 
 // startProbe launches parallel SSH connections and probes for all hosts.

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -465,90 +465,90 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.serviceCursor = 0
 			m.sortColumn = 0
 			m.view = viewServiceList
-			showLoading(&m, "Loading services...")
+			showLoading(&m, "services", "Loading services...")
 			return m, m.fetchServices()
 		case 1: // Containers
 			m.containerCursor = 0
 			m.sortColumn = 0
 			m.view = viewContainerList
-			showLoading(&m, "Loading containers...")
+			showLoading(&m, "containers", "Loading containers...")
 			return m, m.fetchContainers()
 		case 2: // Cron Jobs
 			m.cronCursor = 0
 			m.sortColumn = 0
 			m.view = viewCronList
-			showLoading(&m, "Loading cron jobs...")
+			showLoading(&m, "cron", "Loading cron jobs...")
 			return m, m.fetchCronJobs()
 		case 3: // Error Logs -> Log Level Picker
 			m.logLevelCursor = 0
 			m.sortColumn = 0
 			m.view = viewLogLevelPicker
-			showLoading(&m, "Loading log levels...")
+			showLoading(&m, "loglevels", "Loading log levels...")
 			return m, m.fetchLogLevels()
 		case 4: // Updates
 			m.updateCursor = 0
 			m.sortColumn = 0
 			m.view = viewUpdateList
-			showLoading(&m, "Loading updates...")
+			showLoading(&m, "updates", "Loading updates...")
 			return m, m.fetchUpdates()
 		case 5: // Disk
 			m.diskCursor = 0
 			m.sortColumn = 0
 			m.view = viewDiskList
-			showLoading(&m, "Loading disk info...")
+			showLoading(&m, "disk", "Loading disk info...")
 			return m, m.fetchDisk()
 		case 6: // Subscription
 			m.subscriptionCursor = 0
 			m.sortColumn = 0
 			m.view = viewSubscription
-			showLoading(&m, "Loading subscription...")
+			showLoading(&m, "subscription", "Loading subscription...")
 			return m, m.fetchSubscription()
 		case 7: // Accounts
 			m.accountCursor = 0
 			m.sortColumn = 0
 			m.view = viewAccountList
-			showLoading(&m, "Loading accounts...")
+			showLoading(&m, "accounts", "Loading accounts...")
 			return m, m.fetchAccounts()
 		case 8: // Network
 			m.networkCursor = 0
 			m.sortColumn = 0
 			m.view = viewNetworkPicker
-			showLoading(&m, "Loading network info...")
+			showLoading(&m, "network", "Loading network info...")
 			return m, m.fetchNetworkInfo()
 		case 9: // Failed Logins
 			m.failedLoginCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityFailedLogins
-			showLoading(&m, "Loading failed logins...")
+			showLoading(&m, "failedlogins", "Loading failed logins...")
 			return m, m.fetchFailedLogins()
 		case 10: // Sudo Activity
 			m.sudoCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySudo
-			showLoading(&m, "Loading sudo activity...")
+			showLoading(&m, "sudo", "Loading sudo activity...")
 			return m, m.fetchSudoActivity()
 		case 11: // SELinux Denials
 			m.selinuxCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySELinux
-			showLoading(&m, "Loading SELinux denials...")
+			showLoading(&m, "selinux", "Loading SELinux denials...")
 			return m, m.fetchSELinuxDenials()
 		case 12: // Audit Summary
 			m.auditCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityAudit
-			showLoading(&m, "Loading audit summary...")
+			showLoading(&m, "audit", "Loading audit summary...")
 			return m, m.fetchAuditSummary()
 		}
 	case "r":
 		m.services = nil
 		m.containers = nil
 		m.updates = nil
-		showLoading(&m, "Loading resource counts...")
+		showLoading(&m, "resourcecounts", "Loading resource counts...")
 		return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 	case "esc":
 		m.view = viewHostList
@@ -643,7 +643,7 @@ func (m Model) handleServiceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.services = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading services...")
+		showLoading(&m, "services", "Loading services...")
 		return m, m.fetchServices()
 	case "esc":
 		if m.filterText != "" {
@@ -734,7 +734,7 @@ func (m Model) handleContainerListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.containers = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading containers...")
+		showLoading(&m, "containers", "Loading containers...")
 		return m, m.fetchContainers()
 	case "esc":
 		if m.filterText != "" {
@@ -776,7 +776,7 @@ func (m Model) handleCronListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.cronJobs = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading cron jobs...")
+		showLoading(&m, "cron", "Loading cron jobs...")
 		return m, m.fetchCronJobs()
 	case "esc":
 		if m.filterText != "" {
@@ -809,7 +809,7 @@ func (m Model) handleLogLevelPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		m.logLevels = nil
-		showLoading(&m, "Loading log levels...")
+		showLoading(&m, "loglevels", "Loading log levels...")
 		return m, m.fetchLogLevels()
 	case "esc":
 		m.view = viewResourcePicker
@@ -859,7 +859,7 @@ func (m Model) handleErrorLogListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.errorLogs = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading error logs...")
+		showLoading(&m, "errorlogs", "Loading error logs...")
 		return m, m.fetchErrorLogs()
 	case "esc":
 		if m.filterText != "" {
@@ -936,7 +936,7 @@ func (m Model) handleUpdateListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.updates = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading updates...")
+		showLoading(&m, "updates", "Loading updates...")
 		return m, m.fetchUpdates()
 	case "esc":
 		if m.filterText != "" {
@@ -1003,7 +1003,7 @@ func (m Model) handleDiskListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.disks = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading disk info...")
+		showLoading(&m, "disk", "Loading disk info...")
 		return m, m.fetchDisk()
 	case "esc":
 		if m.filterText != "" {
@@ -1087,7 +1087,7 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		m.subscriptions = nil
-		showLoading(&m, "Loading subscription...")
+		showLoading(&m, "subscription", "Loading subscription...")
 		return m, m.fetchSubscription()
 	case "esc":
 		m.view = viewResourcePicker
@@ -1136,7 +1136,7 @@ func (m Model) handleAccountListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.accounts = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading accounts...")
+		showLoading(&m, "accounts", "Loading accounts...")
 		return m, m.fetchAccounts()
 	case "esc":
 		if m.filterText != "" {
@@ -1186,7 +1186,7 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.fetchFirewall()
 		}
 	case "r":
-		showLoading(&m, "Loading network info...")
+		showLoading(&m, "network", "Loading network info...")
 		return m, m.fetchNetworkInfo()
 	case "esc":
 		m.view = viewResourcePicker
@@ -1223,7 +1223,7 @@ func (m Model) handleInterfaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.interfaces = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading interfaces...")
+		showLoading(&m, "interfaces", "Loading interfaces...")
 		return m, m.fetchInterfaces()
 	case "esc":
 		if m.filterText != "" {
@@ -1267,7 +1267,7 @@ func (m Model) handlePortListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.ports = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading ports...")
+		showLoading(&m, "ports", "Loading ports...")
 		return m, m.fetchPorts()
 	case "esc":
 		if m.filterText != "" {
@@ -1310,7 +1310,7 @@ func (m Model) handleFirewallListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.firewallRules = nil
 		m.sortColumn = 0
 		m.firewallBackend = ""
-		showLoading(&m, "Loading firewall...")
+		showLoading(&m, "firewall", "Loading firewall...")
 		return m, m.fetchFirewall()
 	case "esc":
 		if m.filterText != "" {
@@ -1352,7 +1352,7 @@ func (m Model) handleRouteListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.routes = nil
 		m.sortColumn = 0
-		showLoading(&m, "Loading routes...")
+		showLoading(&m, "routes", "Loading routes...")
 		return m, m.fetchRoutes()
 	case "esc":
 		if m.filterText != "" {
@@ -1396,7 +1396,7 @@ func (m Model) handleFailedLoginKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.failedLogins = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading failed logins...")
+		showLoading(&m, "failedlogins", "Loading failed logins...")
 		return m, m.fetchFailedLogins()
 	case "esc":
 		if m.filterText != "" {
@@ -1440,7 +1440,7 @@ func (m Model) handleSudoKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.sudoEntries = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading sudo activity...")
+		showLoading(&m, "sudo", "Loading sudo activity...")
 		return m, m.fetchSudoActivity()
 	case "esc":
 		if m.filterText != "" {
@@ -1484,7 +1484,7 @@ func (m Model) handleSELinuxKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selinuxDenials = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading SELinux denials...")
+		showLoading(&m, "selinux", "Loading SELinux denials...")
 		return m, m.fetchSELinuxDenials()
 	case "esc":
 		if m.filterText != "" {
@@ -1528,7 +1528,7 @@ func (m Model) handleAuditKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.auditEvents = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		showLoading(&m, "Loading audit summary...")
+		showLoading(&m, "audit", "Loading audit summary...")
 		return m, m.fetchAuditSummary()
 	case "esc":
 		if m.filterText != "" {
@@ -1660,7 +1660,7 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 		m.azureResourceCounts = azure.AzureResourceCounts{}
 		m.azureResourceErr = nil
 		m.azureCountsLoaded = false
-		showLoading(&m, "Loading resource counts...")
+		showLoading(&m, "resourcecounts", "Loading resource counts...")
 		return m, m.fetchAzureResourceCounts()
 	case "esc":
 		m.view = viewAzureSubList
@@ -1789,7 +1789,7 @@ func (m Model) handleAzureVMListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.azureVMs = nil
 		m.azureVMCursor = 0
-		showLoading(&m, "Loading VMs...")
+		showLoading(&m, "vms", "Loading VMs...")
 		return m, m.fetchAzureVMs()
 	case "esc":
 		m.view = viewAzureResourcePicker
@@ -1942,7 +1942,7 @@ func (m Model) handleAzureAKSListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.azureAKSClusters = nil
 		m.azureAKSCursor = 0
-		showLoading(&m, "Loading AKS clusters...")
+		showLoading(&m, "aks", "Loading AKS clusters...")
 		return m, m.fetchAzureAKSClusters()
 	case "esc":
 		m.view = viewAzureResourcePicker
@@ -2075,7 +2075,7 @@ func (m Model) handleK8sContextListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sContexts = nil
 		m.k8sContextCursor = 0
-		showLoading(&m, "Loading contexts...")
+		showLoading(&m, "contexts", "Loading contexts...")
 		return m, m.fetchK8sContexts(m.k8sClusters[m.selectedK8sCluster].Name)
 	case "/":
 		m.filterActive = true
@@ -2127,7 +2127,7 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.k8sResourceCounts = k8s.K8sResourceCounts{}
 		m.k8sResourceErrors = nil
 		m.k8sCountsLoaded = false
-		showLoading(&m, "Loading resource counts...")
+		showLoading(&m, "resourcecounts", "Loading resource counts...")
 		return m, m.fetchK8sResourceCounts()
 	case "esc":
 		m.view = viewK8sContextList
@@ -2180,7 +2180,7 @@ func (m Model) handleK8sNodeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sNodes = nil
 		m.k8sNodeCursor = 0
-		showLoading(&m, "Loading nodes...")
+		showLoading(&m, "nodes", "Loading nodes...")
 		return m, m.fetchK8sNodes()
 	case "esc":
 		m.view = viewK8sResourcePicker
@@ -2277,7 +2277,7 @@ func (m Model) handleK8sNamespaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sNamespaces = nil
 		m.k8sNamespaceCursor = 0
-		showLoading(&m, "Loading namespaces...")
+		showLoading(&m, "namespaces", "Loading namespaces...")
 		return m, m.fetchK8sNamespaces()
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sNamespaceCursor = 0 } else {
@@ -2324,7 +2324,7 @@ func (m Model) handleK8sWorkloadListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.k8sWorkloads = nil
 		m.k8sWorkloadCursor = 0
 		ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
-		showLoading(&m, "Loading workloads...")
+		showLoading(&m, "workloads", "Loading workloads...")
 		return m, m.fetchK8sWorkloads(ns)
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sWorkloadCursor = 0 } else {
@@ -2415,7 +2415,7 @@ func (m Model) handleK8sPodListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.k8sPodCursor = 0
 		ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
 		w := m.filteredK8sWorkloads()[m.selectedK8sWorkload]
-		showLoading(&m, "Loading pods...")
+		showLoading(&m, "pods", "Loading pods...")
 		return m, m.fetchK8sPods(ns, w.Name)
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sPodCursor = 0 } else {

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -415,8 +415,6 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.selectedHost = m.hostCursor
 			m.resourceCursor = 0
-			m.services = nil
-			m.containers = nil
 			m.view = viewResourcePicker
 			// pre-fetch for accurate counts
 			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
@@ -442,49 +440,41 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch m.resourceCursor {
 		case 0: // Services
 			m.serviceCursor = 0
-			m.services = nil
 			m.sortColumn = 0
 			m.view = viewServiceList
 			return m, m.fetchServices()
 		case 1: // Containers
 			m.containerCursor = 0
-			m.containers = nil
 			m.sortColumn = 0
 			m.view = viewContainerList
 			return m, m.fetchContainers()
 		case 2: // Cron Jobs
 			m.cronCursor = 0
-			m.cronJobs = nil
 			m.sortColumn = 0
 			m.view = viewCronList
 			return m, m.fetchCronJobs()
 		case 3: // Error Logs -> Log Level Picker
 			m.logLevelCursor = 0
-			m.logLevels = nil
 			m.sortColumn = 0
 			m.view = viewLogLevelPicker
 			return m, m.fetchLogLevels()
 		case 4: // Updates
 			m.updateCursor = 0
-			m.updates = nil
 			m.sortColumn = 0
 			m.view = viewUpdateList
 			return m, m.fetchUpdates()
 		case 5: // Disk
 			m.diskCursor = 0
-			m.disks = nil
 			m.sortColumn = 0
 			m.view = viewDiskList
 			return m, m.fetchDisk()
 		case 6: // Subscription
 			m.subscriptionCursor = 0
-			m.subscriptions = nil
 			m.sortColumn = 0
 			m.view = viewSubscription
 			return m, m.fetchSubscription()
 		case 7: // Accounts
 			m.accountCursor = 0
-			m.accounts = nil
 			m.sortColumn = 0
 			m.view = viewAccountList
 			return m, m.fetchAccounts()
@@ -495,28 +485,24 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.fetchNetworkInfo()
 		case 9: // Failed Logins
 			m.failedLoginCursor = 0
-			m.failedLogins = nil
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityFailedLogins
 			return m, m.fetchFailedLogins()
 		case 10: // Sudo Activity
 			m.sudoCursor = 0
-			m.sudoEntries = nil
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySudo
 			return m, m.fetchSudoActivity()
 		case 11: // SELinux Denials
 			m.selinuxCursor = 0
-			m.selinuxDenials = nil
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySELinux
 			return m, m.fetchSELinuxDenials()
 		case 12: // Audit Summary
 			m.auditCursor = 0
-			m.auditEvents = nil
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityAudit
@@ -782,7 +768,6 @@ func (m Model) handleLogLevelPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			selected := m.logLevels[m.logLevelCursor]
 			m.selectedLogLevel = selected.Code
 			m.errorCursor = 0
-			m.errorLogs = nil
 			m.view = viewErrorLogList
 			return m, m.fetchErrorLogs()
 		}
@@ -1142,26 +1127,22 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch m.networkCursor {
 		case 0: // Interfaces
 			m.interfaceCursor = 0
-			m.interfaces = nil
 			m.sortColumn = 0
 			m.view = viewNetworkInterfaces
 			return m, m.fetchInterfaces()
 		case 1: // Ports
 			m.portCursor = 0
-			m.ports = nil
 			m.sortColumn = 0
 			m.filterText = ""
 			m.view = viewNetworkPorts
 			return m, m.fetchPorts()
 		case 2: // Routes & DNS
 			m.routeCursor = 0
-			m.routes = nil
 			m.sortColumn = 0
 			m.view = viewNetworkRoutes
 			return m, m.fetchRoutes()
 		case 3: // Firewall
 			m.firewallCursor = 0
-			m.firewallRules = nil
 			m.sortColumn = 0
 			m.firewallBackend = ""
 			m.filterText = ""

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -419,7 +419,6 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.containers = nil
 			m.view = viewResourcePicker
 			// pre-fetch for accurate counts
-			showLoading(&m, "Loading resource counts...")
 			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 		}
 	case "esc":
@@ -446,62 +445,53 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.services = nil
 			m.sortColumn = 0
 			m.view = viewServiceList
-			showLoading(&m, "Loading services...")
 			return m, m.fetchServices()
 		case 1: // Containers
 			m.containerCursor = 0
 			m.containers = nil
 			m.sortColumn = 0
 			m.view = viewContainerList
-			showLoading(&m, "Loading containers...")
 			return m, m.fetchContainers()
 		case 2: // Cron Jobs
 			m.cronCursor = 0
 			m.cronJobs = nil
 			m.sortColumn = 0
 			m.view = viewCronList
-			showLoading(&m, "Loading cron jobs...")
 			return m, m.fetchCronJobs()
 		case 3: // Error Logs -> Log Level Picker
 			m.logLevelCursor = 0
 			m.logLevels = nil
 			m.sortColumn = 0
 			m.view = viewLogLevelPicker
-			showLoading(&m, "Loading log levels...")
 			return m, m.fetchLogLevels()
 		case 4: // Updates
 			m.updateCursor = 0
 			m.updates = nil
 			m.sortColumn = 0
 			m.view = viewUpdateList
-			showLoading(&m, "Loading updates...")
 			return m, m.fetchUpdates()
 		case 5: // Disk
 			m.diskCursor = 0
 			m.disks = nil
 			m.sortColumn = 0
 			m.view = viewDiskList
-			showLoading(&m, "Loading disk info...")
 			return m, m.fetchDisk()
 		case 6: // Subscription
 			m.subscriptionCursor = 0
 			m.subscriptions = nil
 			m.sortColumn = 0
 			m.view = viewSubscription
-			showLoading(&m, "Loading subscription...")
 			return m, m.fetchSubscription()
 		case 7: // Accounts
 			m.accountCursor = 0
 			m.accounts = nil
 			m.sortColumn = 0
 			m.view = viewAccountList
-			showLoading(&m, "Loading accounts...")
 			return m, m.fetchAccounts()
 		case 8: // Network
 			m.networkCursor = 0
 			m.sortColumn = 0
 			m.view = viewNetworkPicker
-			showLoading(&m, "Loading network info...")
 			return m, m.fetchNetworkInfo()
 		case 9: // Failed Logins
 			m.failedLoginCursor = 0
@@ -509,7 +499,6 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityFailedLogins
-			showLoading(&m, "Loading failed logins...")
 			return m, m.fetchFailedLogins()
 		case 10: // Sudo Activity
 			m.sudoCursor = 0
@@ -517,7 +506,6 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySudo
-			showLoading(&m, "Loading sudo activity...")
 			return m, m.fetchSudoActivity()
 		case 11: // SELinux Denials
 			m.selinuxCursor = 0
@@ -525,7 +513,6 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySELinux
-			showLoading(&m, "Loading SELinux denials...")
 			return m, m.fetchSELinuxDenials()
 		case 12: // Audit Summary
 			m.auditCursor = 0
@@ -533,7 +520,6 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityAudit
-			showLoading(&m, "Loading audit summary...")
 			return m, m.fetchAuditSummary()
 		}
 	case "r":
@@ -1159,7 +1145,6 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.interfaces = nil
 			m.sortColumn = 0
 			m.view = viewNetworkInterfaces
-			showLoading(&m, "Loading interfaces...")
 			return m, m.fetchInterfaces()
 		case 1: // Ports
 			m.portCursor = 0
@@ -1167,14 +1152,12 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.sortColumn = 0
 			m.filterText = ""
 			m.view = viewNetworkPorts
-			showLoading(&m, "Loading ports...")
 			return m, m.fetchPorts()
 		case 2: // Routes & DNS
 			m.routeCursor = 0
 			m.routes = nil
 			m.sortColumn = 0
 			m.view = viewNetworkRoutes
-			showLoading(&m, "Loading routes...")
 			return m, m.fetchRoutes()
 		case 3: // Firewall
 			m.firewallCursor = 0
@@ -1183,7 +1166,6 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.firewallBackend = ""
 			m.filterText = ""
 			m.view = viewNetworkFirewall
-			showLoading(&m, "Loading firewall...")
 			return m, m.fetchFirewall()
 		}
 	case "r":
@@ -1592,7 +1574,6 @@ func (m Model) handleAzureSubListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.azureResourceErr = nil
 			m.azureCountsLoaded = false
 			m.view = viewAzureResourcePicker
-			showLoading(&m, "Loading resource counts...")
 			return m, m.fetchAzureResourceCounts()
 		}
 	case "r":
@@ -1647,7 +1628,6 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureVMList
-			showLoading(&m, "Loading VMs...")
 			return m, m.fetchAzureVMs()
 		case 1: // AKS Clusters
 			m.azureAKSClusters = nil
@@ -1657,7 +1637,6 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureAKSList
-			showLoading(&m, "Loading AKS clusters...")
 			return m, m.fetchAzureAKSClusters()
 		}
 	case "r":
@@ -2008,7 +1987,6 @@ func (m Model) handleK8sClusterListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.k8sContexts = nil
 			m.k8sContextCursor = 0
 			m.view = viewK8sContextList
-			showLoading(&m, "Loading contexts...")
 			return m, m.fetchK8sContexts(c.Name)
 		}
 	case "r":
@@ -2058,7 +2036,6 @@ func (m Model) handleK8sContextListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.k8sResourceErrors = nil
 			m.k8sCountsLoaded = false
 			m.view = viewK8sResourcePicker
-			showLoading(&m, "Loading resource counts...")
 			return m, m.fetchK8sResourceCounts()
 		}
 	case "d":
@@ -2116,7 +2093,6 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sNamespaceList
-			showLoading(&m, "Loading namespaces...")
 			return m, m.fetchK8sNamespaces()
 		case 1:
 			m.k8sNodes = nil
@@ -2125,7 +2101,6 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sNodeList
-			showLoading(&m, "Loading nodes...")
 			return m, m.fetchK8sNodes()
 		case 2:
 			m.flash = "ArgoCD Apps view coming in next PR"
@@ -2272,7 +2247,6 @@ func (m Model) handleK8sNamespaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sWorkloadList
-			showLoading(&m, "Loading workloads...")
 			return m, m.fetchK8sWorkloads(filtered[m.k8sNamespaceCursor].Name)
 		}
 	case "/":
@@ -2319,7 +2293,6 @@ func (m Model) handleK8sWorkloadListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterActive = false
 			ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
 			m.view = viewK8sPodList
-			showLoading(&m, "Loading pods...")
 			return m, m.fetchK8sPods(ns, w.Name)
 		}
 	case "/":
@@ -2389,8 +2362,6 @@ func (m Model) handleK8sPodListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filterText = ""
 		m.filterActive = false
 		m.sortColumn = 0
-		wl := m.k8sWorkloads[m.selectedK8sWorkload]
-		showLoading(&m, fmt.Sprintf("Loading logs for %s...", wl.Name))
 		ns := m.k8sNamespaces[m.selectedK8sNamespace].Name
 		return m, m.fetchK8sPodLogs(ns, podNames)
 	case "d":
@@ -2463,7 +2434,6 @@ func (m Model) handleK8sPodDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.filterText = ""
 				m.filterActive = false
 				m.sortColumn = 0
-				showLoading(&m, fmt.Sprintf("Loading logs for %s...", m.k8sPodDetail.Name))
 				ns := m.k8sPodDetail.Namespace
 				return m, m.fetchK8sPodLogs(ns, []string{m.k8sPodDetail.Name})
 			}

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -465,70 +465,83 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.serviceCursor = 0
 			m.sortColumn = 0
 			m.view = viewServiceList
+			showLoading(&m, "Loading services...")
 			return m, m.fetchServices()
 		case 1: // Containers
 			m.containerCursor = 0
 			m.sortColumn = 0
 			m.view = viewContainerList
+			showLoading(&m, "Loading containers...")
 			return m, m.fetchContainers()
 		case 2: // Cron Jobs
 			m.cronCursor = 0
 			m.sortColumn = 0
 			m.view = viewCronList
+			showLoading(&m, "Loading cron jobs...")
 			return m, m.fetchCronJobs()
 		case 3: // Error Logs -> Log Level Picker
 			m.logLevelCursor = 0
 			m.sortColumn = 0
 			m.view = viewLogLevelPicker
+			showLoading(&m, "Loading log levels...")
 			return m, m.fetchLogLevels()
 		case 4: // Updates
 			m.updateCursor = 0
 			m.sortColumn = 0
 			m.view = viewUpdateList
+			showLoading(&m, "Loading updates...")
 			return m, m.fetchUpdates()
 		case 5: // Disk
 			m.diskCursor = 0
 			m.sortColumn = 0
 			m.view = viewDiskList
+			showLoading(&m, "Loading disk info...")
 			return m, m.fetchDisk()
 		case 6: // Subscription
 			m.subscriptionCursor = 0
 			m.sortColumn = 0
 			m.view = viewSubscription
+			showLoading(&m, "Loading subscription...")
 			return m, m.fetchSubscription()
 		case 7: // Accounts
 			m.accountCursor = 0
 			m.sortColumn = 0
 			m.view = viewAccountList
+			showLoading(&m, "Loading accounts...")
 			return m, m.fetchAccounts()
 		case 8: // Network
 			m.networkCursor = 0
 			m.sortColumn = 0
 			m.view = viewNetworkPicker
+			showLoading(&m, "Loading network info...")
 			return m, m.fetchNetworkInfo()
 		case 9: // Failed Logins
 			m.failedLoginCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityFailedLogins
+			showLoading(&m, "Loading failed logins...")
 			return m, m.fetchFailedLogins()
 		case 10: // Sudo Activity
 			m.sudoCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySudo
+			showLoading(&m, "Loading sudo activity...")
 			return m, m.fetchSudoActivity()
 		case 11: // SELinux Denials
 			m.selinuxCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySELinux
+			showLoading(&m, "Loading SELinux denials...")
 			return m, m.fetchSELinuxDenials()
 		case 12: // Audit Summary
 			m.auditCursor = 0
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityAudit
+			showLoading(&m, "Loading audit summary...")
 			return m, m.fetchAuditSummary()
 		}
 	case "r":

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -434,8 +434,9 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selinuxDenials = nil
 			m.auditEvents = nil
 			m.view = viewResourcePicker
-			// pre-fetch for accurate counts
-			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
+			// pre-fetch for accurate counts (updates excluded — needs sudo,
+			// which may not be cached yet; fetched on view entry instead)
+			return m, tea.Batch(m.fetchServices(), m.fetchContainers())
 		}
 	case "esc":
 		m.ssh.Close()

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -413,6 +413,11 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.flashError = true
 				return m, nil
 			}
+			if !h.SudoReady {
+				// Test sudo on this host — prompt if needed, then navigate
+				m.selectedHost = m.hostCursor
+				return m, m.testSudo(m.hostCursor)
+			}
 			m.selectedHost = m.hostCursor
 			m.resourceCursor = 0
 			// Clear stale data from previous host

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -434,9 +434,8 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.selinuxDenials = nil
 			m.auditEvents = nil
 			m.view = viewResourcePicker
-			// pre-fetch for accurate counts (updates excluded — needs sudo,
-			// which may not be cached yet; fetched on view entry instead)
-			return m, tea.Batch(m.fetchServices(), m.fetchContainers())
+			// pre-fetch for accurate counts
+			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 		}
 	case "esc":
 		m.ssh.Close()

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1159,6 +1159,7 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.interfaces = nil
 			m.sortColumn = 0
 			m.view = viewNetworkInterfaces
+			showLoading(&m, "Loading interfaces...")
 			return m, m.fetchInterfaces()
 		case 1: // Ports
 			m.portCursor = 0
@@ -1166,12 +1167,14 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.sortColumn = 0
 			m.filterText = ""
 			m.view = viewNetworkPorts
+			showLoading(&m, "Loading ports...")
 			return m, m.fetchPorts()
 		case 2: // Routes & DNS
 			m.routeCursor = 0
 			m.routes = nil
 			m.sortColumn = 0
 			m.view = viewNetworkRoutes
+			showLoading(&m, "Loading routes...")
 			return m, m.fetchRoutes()
 		case 3: // Firewall
 			m.firewallCursor = 0
@@ -1180,6 +1183,7 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.firewallBackend = ""
 			m.filterText = ""
 			m.view = viewNetworkFirewall
+			showLoading(&m, "Loading firewall...")
 			return m, m.fetchFirewall()
 		}
 	case "r":

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -154,6 +154,17 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		m.azure.Close()
 		return m, tea.Quit
+	case "?":
+		text := helpForView(m.view)
+		m.modal = NewModalOverlay("Keybindings", []ModalStep{
+			{Title: "", Content: NewStaticContent(text)},
+		}, func(_ []any) tea.Cmd { return nil },
+			func() tea.Cmd { return nil })
+		m.modal.FooterFn = func() string {
+			return modalKeyStyle.Render("?/Esc") + " " + modalDimStyle.Render("close") +
+				"  " + modalKeyStyle.Render("↑↓") + " " + modalDimStyle.Render("scroll")
+		}
+		return m, nil
 	}
 
 	switch m.view {
@@ -252,6 +263,10 @@ func (m Model) handleFleetPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "c":
 		m.view = viewConfig
 		return m, nil
+	case "a":
+		modal, cmd := NewAboutModal(m.version, m.commit)
+		m.modal = modal
+		return m, cmd
 	case "e":
 		if len(m.fleets) > 0 {
 			return m, m.editFleetFile()
@@ -404,6 +419,7 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.containers = nil
 			m.view = viewResourcePicker
 			// pre-fetch for accurate counts
+			showLoading(&m, "Loading resource counts...")
 			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 		}
 	case "esc":
@@ -430,53 +446,62 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.services = nil
 			m.sortColumn = 0
 			m.view = viewServiceList
+			showLoading(&m, "Loading services...")
 			return m, m.fetchServices()
 		case 1: // Containers
 			m.containerCursor = 0
 			m.containers = nil
 			m.sortColumn = 0
 			m.view = viewContainerList
+			showLoading(&m, "Loading containers...")
 			return m, m.fetchContainers()
 		case 2: // Cron Jobs
 			m.cronCursor = 0
 			m.cronJobs = nil
 			m.sortColumn = 0
 			m.view = viewCronList
+			showLoading(&m, "Loading cron jobs...")
 			return m, m.fetchCronJobs()
 		case 3: // Error Logs -> Log Level Picker
 			m.logLevelCursor = 0
 			m.logLevels = nil
 			m.sortColumn = 0
 			m.view = viewLogLevelPicker
+			showLoading(&m, "Loading log levels...")
 			return m, m.fetchLogLevels()
 		case 4: // Updates
 			m.updateCursor = 0
 			m.updates = nil
 			m.sortColumn = 0
 			m.view = viewUpdateList
+			showLoading(&m, "Loading updates...")
 			return m, m.fetchUpdates()
 		case 5: // Disk
 			m.diskCursor = 0
 			m.disks = nil
 			m.sortColumn = 0
 			m.view = viewDiskList
+			showLoading(&m, "Loading disk info...")
 			return m, m.fetchDisk()
 		case 6: // Subscription
 			m.subscriptionCursor = 0
 			m.subscriptions = nil
 			m.sortColumn = 0
 			m.view = viewSubscription
+			showLoading(&m, "Loading subscription...")
 			return m, m.fetchSubscription()
 		case 7: // Accounts
 			m.accountCursor = 0
 			m.accounts = nil
 			m.sortColumn = 0
 			m.view = viewAccountList
+			showLoading(&m, "Loading accounts...")
 			return m, m.fetchAccounts()
 		case 8: // Network
 			m.networkCursor = 0
 			m.sortColumn = 0
 			m.view = viewNetworkPicker
+			showLoading(&m, "Loading network info...")
 			return m, m.fetchNetworkInfo()
 		case 9: // Failed Logins
 			m.failedLoginCursor = 0
@@ -484,6 +509,7 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityFailedLogins
+			showLoading(&m, "Loading failed logins...")
 			return m, m.fetchFailedLogins()
 		case 10: // Sudo Activity
 			m.sudoCursor = 0
@@ -491,6 +517,7 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySudo
+			showLoading(&m, "Loading sudo activity...")
 			return m, m.fetchSudoActivity()
 		case 11: // SELinux Denials
 			m.selinuxCursor = 0
@@ -498,6 +525,7 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecuritySELinux
+			showLoading(&m, "Loading SELinux denials...")
 			return m, m.fetchSELinuxDenials()
 		case 12: // Audit Summary
 			m.auditCursor = 0
@@ -505,13 +533,14 @@ func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.sortColumn = 0
 			m.view = viewSecurityAudit
+			showLoading(&m, "Loading audit summary...")
 			return m, m.fetchAuditSummary()
 		}
 	case "r":
 		m.services = nil
 		m.containers = nil
 		m.updates = nil
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading resource counts...")
 		return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 	case "esc":
 		m.view = viewHostList
@@ -606,6 +635,7 @@ func (m Model) handleServiceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.services = nil
 		m.sortColumn = 0
 		m.filterText = ""
+		showLoading(&m, "Loading services...")
 		return m, m.fetchServices()
 	case "esc":
 		if m.filterText != "" {
@@ -696,7 +726,7 @@ func (m Model) handleContainerListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.containers = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading containers...")
 		return m, m.fetchContainers()
 	case "esc":
 		if m.filterText != "" {
@@ -738,7 +768,7 @@ func (m Model) handleCronListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.cronJobs = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading cron jobs...")
 		return m, m.fetchCronJobs()
 	case "esc":
 		if m.filterText != "" {
@@ -772,7 +802,7 @@ func (m Model) handleLogLevelPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		m.logLevels = nil
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading log levels...")
 		return m, m.fetchLogLevels()
 	case "esc":
 		m.view = viewResourcePicker
@@ -822,7 +852,7 @@ func (m Model) handleErrorLogListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.errorLogs = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading error logs...")
 		return m, m.fetchErrorLogs()
 	case "esc":
 		if m.filterText != "" {
@@ -899,7 +929,7 @@ func (m Model) handleUpdateListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.updates = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading updates...")
 		return m, m.fetchUpdates()
 	case "esc":
 		if m.filterText != "" {
@@ -966,7 +996,7 @@ func (m Model) handleDiskListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.disks = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading disk info...")
 		return m, m.fetchDisk()
 	case "esc":
 		if m.filterText != "" {
@@ -1050,7 +1080,7 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		m.subscriptions = nil
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading subscription...")
 		return m, m.fetchSubscription()
 	case "esc":
 		m.view = viewResourcePicker
@@ -1099,7 +1129,7 @@ func (m Model) handleAccountListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.accounts = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading accounts...")
 		return m, m.fetchAccounts()
 	case "esc":
 		if m.filterText != "" {
@@ -1153,7 +1183,7 @@ func (m Model) handleNetworkPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.fetchFirewall()
 		}
 	case "r":
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading network info...")
 		return m, m.fetchNetworkInfo()
 	case "esc":
 		m.view = viewResourcePicker
@@ -1190,7 +1220,7 @@ func (m Model) handleInterfaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.interfaces = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading interfaces...")
 		return m, m.fetchInterfaces()
 	case "esc":
 		if m.filterText != "" {
@@ -1234,7 +1264,7 @@ func (m Model) handlePortListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.ports = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading ports...")
 		return m, m.fetchPorts()
 	case "esc":
 		if m.filterText != "" {
@@ -1277,7 +1307,7 @@ func (m Model) handleFirewallListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.firewallRules = nil
 		m.sortColumn = 0
 		m.firewallBackend = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading firewall...")
 		return m, m.fetchFirewall()
 	case "esc":
 		if m.filterText != "" {
@@ -1319,7 +1349,7 @@ func (m Model) handleRouteListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.routes = nil
 		m.sortColumn = 0
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading routes...")
 		return m, m.fetchRoutes()
 	case "esc":
 		if m.filterText != "" {
@@ -1363,7 +1393,7 @@ func (m Model) handleFailedLoginKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.failedLogins = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading failed logins...")
 		return m, m.fetchFailedLogins()
 	case "esc":
 		if m.filterText != "" {
@@ -1407,7 +1437,7 @@ func (m Model) handleSudoKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.sudoEntries = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading sudo activity...")
 		return m, m.fetchSudoActivity()
 	case "esc":
 		if m.filterText != "" {
@@ -1451,7 +1481,7 @@ func (m Model) handleSELinuxKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selinuxDenials = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading SELinux denials...")
 		return m, m.fetchSELinuxDenials()
 	case "esc":
 		if m.filterText != "" {
@@ -1495,7 +1525,7 @@ func (m Model) handleAuditKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.auditEvents = nil
 		m.sortColumn = 0
 		m.filterText = ""
-		m.flash = "Refreshing..."
+		showLoading(&m, "Loading audit summary...")
 		return m, m.fetchAuditSummary()
 	case "esc":
 		if m.filterText != "" {
@@ -1558,6 +1588,7 @@ func (m Model) handleAzureSubListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.azureResourceErr = nil
 			m.azureCountsLoaded = false
 			m.view = viewAzureResourcePicker
+			showLoading(&m, "Loading resource counts...")
 			return m, m.fetchAzureResourceCounts()
 		}
 	case "r":
@@ -1612,6 +1643,7 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureVMList
+			showLoading(&m, "Loading VMs...")
 			return m, m.fetchAzureVMs()
 		case 1: // AKS Clusters
 			m.azureAKSClusters = nil
@@ -1621,12 +1653,14 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureAKSList
+			showLoading(&m, "Loading AKS clusters...")
 			return m, m.fetchAzureAKSClusters()
 		}
 	case "r":
 		m.azureResourceCounts = azure.AzureResourceCounts{}
 		m.azureResourceErr = nil
 		m.azureCountsLoaded = false
+		showLoading(&m, "Loading resource counts...")
 		return m, m.fetchAzureResourceCounts()
 	case "esc":
 		m.view = viewAzureSubList
@@ -1755,6 +1789,7 @@ func (m Model) handleAzureVMListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.azureVMs = nil
 		m.azureVMCursor = 0
+		showLoading(&m, "Loading VMs...")
 		return m, m.fetchAzureVMs()
 	case "esc":
 		m.view = viewAzureResourcePicker
@@ -1907,6 +1942,7 @@ func (m Model) handleAzureAKSListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.azureAKSClusters = nil
 		m.azureAKSCursor = 0
+		showLoading(&m, "Loading AKS clusters...")
 		return m, m.fetchAzureAKSClusters()
 	case "esc":
 		m.view = viewAzureResourcePicker
@@ -1968,6 +2004,7 @@ func (m Model) handleK8sClusterListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.k8sContexts = nil
 			m.k8sContextCursor = 0
 			m.view = viewK8sContextList
+			showLoading(&m, "Loading contexts...")
 			return m, m.fetchK8sContexts(c.Name)
 		}
 	case "r":
@@ -2017,6 +2054,7 @@ func (m Model) handleK8sContextListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.k8sResourceErrors = nil
 			m.k8sCountsLoaded = false
 			m.view = viewK8sResourcePicker
+			showLoading(&m, "Loading resource counts...")
 			return m, m.fetchK8sResourceCounts()
 		}
 	case "d":
@@ -2039,6 +2077,7 @@ func (m Model) handleK8sContextListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sContexts = nil
 		m.k8sContextCursor = 0
+		showLoading(&m, "Loading contexts...")
 		return m, m.fetchK8sContexts(m.k8sClusters[m.selectedK8sCluster].Name)
 	case "/":
 		m.filterActive = true
@@ -2073,6 +2112,7 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sNamespaceList
+			showLoading(&m, "Loading namespaces...")
 			return m, m.fetchK8sNamespaces()
 		case 1:
 			m.k8sNodes = nil
@@ -2081,6 +2121,7 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sNodeList
+			showLoading(&m, "Loading nodes...")
 			return m, m.fetchK8sNodes()
 		case 2:
 			m.flash = "ArgoCD Apps view coming in next PR"
@@ -2090,6 +2131,7 @@ func (m Model) handleK8sResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		m.k8sResourceCounts = k8s.K8sResourceCounts{}
 		m.k8sResourceErrors = nil
 		m.k8sCountsLoaded = false
+		showLoading(&m, "Loading resource counts...")
 		return m, m.fetchK8sResourceCounts()
 	case "esc":
 		m.view = viewK8sContextList
@@ -2142,6 +2184,7 @@ func (m Model) handleK8sNodeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sNodes = nil
 		m.k8sNodeCursor = 0
+		showLoading(&m, "Loading nodes...")
 		return m, m.fetchK8sNodes()
 	case "esc":
 		m.view = viewK8sResourcePicker
@@ -2225,6 +2268,7 @@ func (m Model) handleK8sNamespaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewK8sWorkloadList
+			showLoading(&m, "Loading workloads...")
 			return m, m.fetchK8sWorkloads(filtered[m.k8sNamespaceCursor].Name)
 		}
 	case "/":
@@ -2238,6 +2282,7 @@ func (m Model) handleK8sNamespaceListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.k8sNamespaces = nil
 		m.k8sNamespaceCursor = 0
+		showLoading(&m, "Loading namespaces...")
 		return m, m.fetchK8sNamespaces()
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sNamespaceCursor = 0 } else {
@@ -2270,6 +2315,7 @@ func (m Model) handleK8sWorkloadListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.filterActive = false
 			ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
 			m.view = viewK8sPodList
+			showLoading(&m, "Loading pods...")
 			return m, m.fetchK8sPods(ns, w.Name)
 		}
 	case "/":
@@ -2284,6 +2330,7 @@ func (m Model) handleK8sWorkloadListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.k8sWorkloads = nil
 		m.k8sWorkloadCursor = 0
 		ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
+		showLoading(&m, "Loading workloads...")
 		return m, m.fetchK8sWorkloads(ns)
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sWorkloadCursor = 0 } else {
@@ -2339,7 +2386,7 @@ func (m Model) handleK8sPodListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filterActive = false
 		m.sortColumn = 0
 		wl := m.k8sWorkloads[m.selectedK8sWorkload]
-		m.flash = fmt.Sprintf("Loading logs for %s...", wl.Name)
+		showLoading(&m, fmt.Sprintf("Loading logs for %s...", wl.Name))
 		ns := m.k8sNamespaces[m.selectedK8sNamespace].Name
 		return m, m.fetchK8sPodLogs(ns, podNames)
 	case "d":
@@ -2376,6 +2423,7 @@ func (m Model) handleK8sPodListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.k8sPodCursor = 0
 		ns := m.filteredK8sNamespaces()[m.selectedK8sNamespace].Name
 		w := m.filteredK8sWorkloads()[m.selectedK8sWorkload]
+		showLoading(&m, "Loading pods...")
 		return m, m.fetchK8sPods(ns, w.Name)
 	case "esc":
 		if m.filterActive { m.filterActive = false; m.filterText = ""; m.k8sPodCursor = 0 } else {
@@ -2411,7 +2459,7 @@ func (m Model) handleK8sPodDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.filterText = ""
 				m.filterActive = false
 				m.sortColumn = 0
-				m.flash = fmt.Sprintf("Loading logs for %s...", m.k8sPodDetail.Name)
+				showLoading(&m, fmt.Sprintf("Loading logs for %s...", m.k8sPodDetail.Name))
 				ns := m.k8sPodDetail.Namespace
 				return m, m.fetchK8sPodLogs(ns, []string{m.k8sPodDetail.Name})
 			}

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -415,6 +415,24 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.selectedHost = m.hostCursor
 			m.resourceCursor = 0
+			// Clear stale data from previous host
+			m.services = nil
+			m.containers = nil
+			m.updates = nil
+			m.cronJobs = nil
+			m.logLevels = nil
+			m.errorLogs = nil
+			m.disks = nil
+			m.subscriptions = nil
+			m.accounts = nil
+			m.interfaces = nil
+			m.ports = nil
+			m.routes = nil
+			m.firewallRules = nil
+			m.failedLogins = nil
+			m.sudoEntries = nil
+			m.selinuxDenials = nil
+			m.auditEvents = nil
 			m.view = viewResourcePicker
 			// pre-fetch for accurate counts
 			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())

--- a/internal/app/modal.go
+++ b/internal/app/modal.go
@@ -47,7 +47,30 @@ func NewModalOverlay(title string, steps []ModalStep, onComplete func([]any) tea
 
 // HandleKey processes a key event, returning an optional tea.Cmd.
 func (m *ModalOverlay) HandleKey(msg tea.KeyMsg) tea.Cmd {
+	step := &m.steps[m.current]
+
+	// Let content handle Esc first — LoadingContent swallows it (done=false),
+	// preventing the overlay from dismissing a non-dismissable modal.
 	if msg.Type == tea.KeyEsc {
+		newContent, cmd, done := step.Content.HandleKey(msg)
+		step.Content = newContent
+		if done {
+			// Content accepted Esc as a dismiss signal
+			m.results = append(m.results, step.Content.Result())
+			m.current++
+			if m.current >= len(m.steps) {
+				m.done = true
+				if m.OnComplete != nil {
+					return m.OnComplete(m.results)
+				}
+				return cmd
+			}
+			return cmd
+		}
+		if cmd != nil {
+			return cmd
+		}
+		// Content did not handle Esc — fall through to overlay Esc behavior
 		if m.current == 0 {
 			m.done = true
 			if m.OnCancel != nil {
@@ -63,7 +86,6 @@ func (m *ModalOverlay) HandleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 	}
 
-	step := &m.steps[m.current]
 	newContent, cmd, done := step.Content.HandleKey(msg)
 	step.Content = newContent
 

--- a/internal/app/modal.go
+++ b/internal/app/modal.go
@@ -298,7 +298,7 @@ func (s *StaticContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
 		}
 	case "down", "j":
 		s.scroll++
-	case "enter":
+	case "enter", "?":
 		return s, nil, true
 	}
 	return s, nil, false

--- a/internal/app/modal_about.go
+++ b/internal/app/modal_about.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const repoURL = "github.com/Gaetan-Jaminon/fleetdesk"
+
+// aboutFieldMsg carries an async CLI result back to the model.
+type aboutFieldMsg struct {
+	field string // "azVersion", "azIdentity", "kubectl"
+	value string
+}
+
+// AboutContent implements StepContent for the About modal.
+// Fields are mutable — async goroutines update them via aboutFieldMsg.
+type AboutContent struct {
+	version    string
+	repo       string
+	azVersion  string
+	azIdentity string
+	kubectl    string
+}
+
+// NewAboutContent creates an AboutContent with static fields set and CLI fields loading.
+func NewAboutContent(version, commit string) *AboutContent {
+	ver := version
+	if commit != "" && commit != "none" {
+		ver = fmt.Sprintf("%s (%s)", version, commit)
+	}
+	return &AboutContent{
+		version:    ver,
+		repo:       repoURL,
+		azVersion:  "loading...",
+		azIdentity: "loading...",
+		kubectl:    "loading...",
+	}
+}
+
+// UpdateField sets a CLI field by name.
+func (a *AboutContent) UpdateField(field, value string) {
+	switch field {
+	case "azVersion":
+		a.azVersion = value
+	case "azIdentity":
+		a.azIdentity = value
+	case "kubectl":
+		a.kubectl = value
+	}
+}
+
+func (a *AboutContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.Type {
+	case tea.KeyEnter, tea.KeyEsc:
+		return a, nil, true
+	}
+	return a, nil, false
+}
+
+func (a *AboutContent) View(width int) string {
+	labelW := 16
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("  %-*s %s\n", labelW, "Version", a.version))
+	b.WriteString(fmt.Sprintf("  %-*s %s\n", labelW, "Repository", a.repo))
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  %-*s %s\n", labelW, "Azure CLI", a.azVersion))
+	b.WriteString(fmt.Sprintf("  %-*s %s\n", labelW, "Azure Identity", a.azIdentity))
+	b.WriteString(fmt.Sprintf("  %-*s %s\n", labelW, "kubectl", a.kubectl))
+	return b.String()
+}
+
+func (a *AboutContent) Result() any {
+	return nil
+}
+
+// NewAboutModal creates the About modal with async CLI version fetching.
+func NewAboutModal(version, commit string) (*ModalOverlay, tea.Cmd) {
+	content := NewAboutContent(version, commit)
+	m := NewModalOverlay("About FleetDesk", []ModalStep{
+		{Title: "", Content: content},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+	m.FooterFn = func() string {
+		return modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("close")
+	}
+
+	cmd := tea.Batch(
+		fetchAzVersion(),
+		fetchAzIdentity(),
+		fetchKubectlVersion(),
+	)
+	return m, cmd
+}
+
+func fetchAzVersion() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		out, err := exec.CommandContext(ctx, "az", "version", "--output", "json").Output()
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return aboutFieldMsg{field: "azVersion", value: "timeout"}
+			}
+			return aboutFieldMsg{field: "azVersion", value: "not found"}
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(out, &result); err != nil {
+			return aboutFieldMsg{field: "azVersion", value: "unknown"}
+		}
+		if v, ok := result["azure-cli"].(string); ok {
+			return aboutFieldMsg{field: "azVersion", value: v}
+		}
+		return aboutFieldMsg{field: "azVersion", value: "unknown"}
+	}
+}
+
+func fetchAzIdentity() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		out, err := exec.CommandContext(ctx, "az", "account", "show", "--output", "json").Output()
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return aboutFieldMsg{field: "azIdentity", value: "timeout"}
+			}
+			return aboutFieldMsg{field: "azIdentity", value: "not found"}
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(out, &result); err != nil {
+			return aboutFieldMsg{field: "azIdentity", value: "unknown"}
+		}
+		if user, ok := result["user"].(map[string]any); ok {
+			if name, ok := user["name"].(string); ok {
+				return aboutFieldMsg{field: "azIdentity", value: name}
+			}
+		}
+		return aboutFieldMsg{field: "azIdentity", value: "unknown"}
+	}
+}
+
+func fetchKubectlVersion() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		out, err := exec.CommandContext(ctx, "kubectl", "version", "--client", "-o", "json").Output()
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				return aboutFieldMsg{field: "kubectl", value: "timeout"}
+			}
+			return aboutFieldMsg{field: "kubectl", value: "not found"}
+		}
+
+		var result map[string]any
+		if err := json.Unmarshal(out, &result); err != nil {
+			return aboutFieldMsg{field: "kubectl", value: "unknown"}
+		}
+		if ci, ok := result["clientVersion"].(map[string]any); ok {
+			if v, ok := ci["gitVersion"].(string); ok {
+				return aboutFieldMsg{field: "kubectl", value: v}
+			}
+		}
+		return aboutFieldMsg{field: "kubectl", value: "unknown"}
+	}
+}

--- a/internal/app/modal_about_test.go
+++ b/internal/app/modal_about_test.go
@@ -1,0 +1,146 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestAboutContent_View_ShowsStaticFields(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	view := ac.View(80)
+
+	if !strings.Contains(view, "0.10.0 (abc1234)") {
+		t.Errorf("view should contain version with commit, got:\n%s", view)
+	}
+	if !strings.Contains(view, repoURL) {
+		t.Errorf("view should contain repo URL, got:\n%s", view)
+	}
+}
+
+func TestAboutContent_View_ShowsLoadingInitially(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	view := ac.View(80)
+
+	count := strings.Count(view, "loading...")
+	if count != 3 {
+		t.Errorf("expected 3 'loading...' fields, got %d in:\n%s", count, view)
+	}
+}
+
+func TestAboutContent_View_NoCommitSuffix(t *testing.T) {
+	ac := NewAboutContent("dev", "none")
+	view := ac.View(80)
+
+	if strings.Contains(view, "(none)") {
+		t.Error("should not show (none) when commit is 'none'")
+	}
+	if !strings.Contains(view, "dev") {
+		t.Error("should show version 'dev'")
+	}
+}
+
+func TestAboutContent_UpdateField(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+
+	ac.UpdateField("azVersion", "2.67.0")
+	ac.UpdateField("azIdentity", "gaetan@example.com")
+	ac.UpdateField("kubectl", "v1.31.4")
+
+	view := ac.View(80)
+	if !strings.Contains(view, "2.67.0") {
+		t.Errorf("expected azVersion=2.67.0, got:\n%s", view)
+	}
+	if !strings.Contains(view, "gaetan@example.com") {
+		t.Errorf("expected azIdentity, got:\n%s", view)
+	}
+	if !strings.Contains(view, "v1.31.4") {
+		t.Errorf("expected kubectl version, got:\n%s", view)
+	}
+	if strings.Contains(view, "loading...") {
+		t.Error("should not contain 'loading...' after all fields updated")
+	}
+}
+
+func TestAboutContent_UpdateField_NotFound(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	ac.UpdateField("azVersion", "not found")
+	ac.UpdateField("kubectl", "timeout")
+
+	view := ac.View(80)
+	if !strings.Contains(view, "not found") {
+		t.Error("should show 'not found' for missing CLI")
+	}
+	if !strings.Contains(view, "timeout") {
+		t.Error("should show 'timeout' for timed-out CLI")
+	}
+}
+
+func TestAboutContent_HandleKey_EscDismisses(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	_, _, done := ac.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !done {
+		t.Error("Esc should dismiss AboutContent")
+	}
+}
+
+func TestAboutContent_HandleKey_EnterDismisses(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	_, _, done := ac.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !done {
+		t.Error("Enter should dismiss AboutContent")
+	}
+}
+
+func TestAboutContent_HandleKey_OtherKeyNoOp(t *testing.T) {
+	ac := NewAboutContent("0.10.0", "abc1234")
+	_, _, done := ac.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if done {
+		t.Error("arbitrary key should not dismiss AboutContent")
+	}
+}
+
+func TestNewAboutModal(t *testing.T) {
+	modal, cmd := NewAboutModal("0.10.0", "abc1234")
+	if modal == nil {
+		t.Fatal("NewAboutModal returned nil modal")
+	}
+	if modal.Done() {
+		t.Error("modal should not be done immediately")
+	}
+	if modal.title != "About FleetDesk" {
+		t.Errorf("title = %q, want 'About FleetDesk'", modal.title)
+	}
+	if cmd == nil {
+		t.Error("NewAboutModal should return a batch command for async fetches")
+	}
+}
+
+func TestNewAboutModal_View(t *testing.T) {
+	modal, _ := NewAboutModal("0.10.0", "abc1234")
+	view := modal.View("", 100, 40)
+	if !strings.Contains(view, "About FleetDesk") {
+		t.Error("modal view should contain title")
+	}
+	if !strings.Contains(view, "0.10.0 (abc1234)") {
+		t.Error("modal view should contain version")
+	}
+}
+
+func TestAboutFieldMsg_UpdatesModal(t *testing.T) {
+	// Simulate the Update() logic for aboutFieldMsg
+	modal, _ := NewAboutModal("0.10.0", "abc1234")
+
+	// Simulate receiving an aboutFieldMsg
+	ac, ok := modal.steps[modal.current].Content.(*AboutContent)
+	if !ok {
+		t.Fatal("modal content should be *AboutContent")
+	}
+	ac.UpdateField("azVersion", "2.67.0")
+
+	view := ac.View(80)
+	if !strings.Contains(view, "2.67.0") {
+		t.Errorf("expected updated azVersion in view, got:\n%s", view)
+	}
+}

--- a/internal/app/modal_loading.go
+++ b/internal/app/modal_loading.go
@@ -5,9 +5,10 @@ import (
 )
 
 // LoadingContent is a non-dismissable modal step that shows a loading message.
-// It swallows all key events — only dismissed programmatically via dismissLoading.
+// It swallows all key events — only dismissed programmatically via dismissLoadingFor.
 type LoadingContent struct {
 	message string
+	tag     string // identifies which fetch set this loading modal
 }
 
 func (l *LoadingContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
@@ -24,23 +25,24 @@ func (l *LoadingContent) Result() any {
 	return nil
 }
 
-// showLoading sets a loading modal overlay on the model.
-func showLoading(m *Model, message string) {
+// showLoading sets a loading modal overlay on the model with a tag.
+// The tag identifies the fetch so only the matching dismissLoadingFor clears it.
+func showLoading(m *Model, tag, message string) {
 	m.modal = NewModalOverlay("", []ModalStep{
-		{Title: "", Content: &LoadingContent{message: message}},
+		{Title: "", Content: &LoadingContent{message: message, tag: tag}},
 	}, func(_ []any) tea.Cmd { return nil },
 		func() tea.Cmd { return nil })
 	m.modal.FooterFn = func() string { return "" }
 }
 
-// dismissLoading clears the modal only if it is currently a loading modal.
-// Other modal types (sudo, confirm, about, help) are left untouched.
-func dismissLoading(m *Model) {
+// dismissLoadingFor clears the modal only if it is a loading modal with the given tag.
+// This prevents unrelated fetch results from dismissing another view's loading modal.
+func dismissLoadingFor(m *Model, tag string) {
 	if m.modal == nil || m.modal.Done() {
 		return
 	}
 	if m.modal.current < len(m.modal.steps) {
-		if _, ok := m.modal.steps[m.modal.current].Content.(*LoadingContent); ok {
+		if lc, ok := m.modal.steps[m.modal.current].Content.(*LoadingContent); ok && lc.tag == tag {
 			m.modal = nil
 		}
 	}

--- a/internal/app/modal_loading.go
+++ b/internal/app/modal_loading.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// LoadingContent is a non-dismissable modal step that shows a loading message.
+// It swallows all key events — only dismissed programmatically via dismissLoading.
+type LoadingContent struct {
+	message string
+}
+
+func (l *LoadingContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	return l, nil, false
+}
+
+func (l *LoadingContent) View(width int) string {
+	return "  " + l.message
+}
+
+func (l *LoadingContent) Result() any {
+	return nil
+}
+
+// showLoading sets a loading modal overlay on the model.
+func showLoading(m *Model, message string) {
+	m.modal = NewModalOverlay("", []ModalStep{
+		{Title: "", Content: &LoadingContent{message: message}},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+	m.modal.FooterFn = func() string { return "" }
+}
+
+// dismissLoading clears the modal only if it is currently a loading modal.
+// Other modal types (sudo, confirm, about, help) are left untouched.
+func dismissLoading(m *Model) {
+	if m.modal == nil || m.modal.Done() {
+		return
+	}
+	if m.modal.current < len(m.modal.steps) {
+		if _, ok := m.modal.steps[m.modal.current].Content.(*LoadingContent); ok {
+			m.modal = nil
+		}
+	}
+}

--- a/internal/app/modal_loading.go
+++ b/internal/app/modal_loading.go
@@ -11,7 +11,9 @@ type LoadingContent struct {
 }
 
 func (l *LoadingContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
-	return l, nil, false
+	// Return a no-op cmd to signal that we consumed the key event.
+	// This prevents ModalOverlay from falling through to its own Esc handling.
+	return l, func() tea.Msg { return nil }, false
 }
 
 func (l *LoadingContent) View(width int) string {

--- a/internal/app/modal_loading_test.go
+++ b/internal/app/modal_loading_test.go
@@ -107,6 +107,16 @@ func TestDismissLoading_DoesNotClearStaticContentModal(t *testing.T) {
 	}
 }
 
+func TestLoadingModal_EscDoesNotDismissOverlay(t *testing.T) {
+	m := &Model{}
+	showLoading(m, "Loading services...")
+	// Press Esc through the full ModalOverlay — should NOT dismiss
+	m.modal.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.modal.Done() {
+		t.Error("Esc should not dismiss loading modal through ModalOverlay")
+	}
+}
+
 func TestDismissLoading_NilModalIsNoOp(t *testing.T) {
 	m := &Model{}
 	dismissLoading(m) // should not panic

--- a/internal/app/modal_loading_test.go
+++ b/internal/app/modal_loading_test.go
@@ -48,88 +48,56 @@ func TestLoadingContent_Result(t *testing.T) {
 
 func TestShowLoading(t *testing.T) {
 	m := &Model{}
-	showLoading(m, "Loading services...")
+	showLoading(m, "services", "Loading services...")
 	if m.modal == nil {
 		t.Fatal("showLoading should set m.modal")
-	}
-	if m.modal.Done() {
-		t.Error("modal should not be done")
-	}
-	// Verify content is LoadingContent
-	if m.modal.current >= len(m.modal.steps) {
-		t.Fatal("modal has no steps")
 	}
 	lc, ok := m.modal.steps[m.modal.current].Content.(*LoadingContent)
 	if !ok {
 		t.Fatal("modal content should be *LoadingContent")
 	}
-	if lc.message != "Loading services..." {
-		t.Errorf("message = %q, want %q", lc.message, "Loading services...")
+	if lc.tag != "services" {
+		t.Errorf("tag = %q, want %q", lc.tag, "services")
 	}
 }
 
-func TestDismissLoading_ClearsLoadingModal(t *testing.T) {
+func TestDismissLoadingFor_MatchingTag(t *testing.T) {
 	m := &Model{}
-	showLoading(m, "Loading services...")
-	dismissLoading(m)
+	showLoading(m, "services", "Loading services...")
+	dismissLoadingFor(m, "services")
 	if m.modal != nil {
-		t.Error("dismissLoading should clear loading modal")
+		t.Error("dismissLoadingFor should clear loading modal with matching tag")
 	}
 }
 
-func TestDismissLoading_DoesNotClearConfirmModal(t *testing.T) {
+func TestDismissLoadingFor_WrongTag(t *testing.T) {
+	m := &Model{}
+	showLoading(m, "subscription", "Loading subscription...")
+	dismissLoadingFor(m, "services")
+	if m.modal == nil {
+		t.Error("dismissLoadingFor should NOT clear loading modal with different tag")
+	}
+}
+
+func TestDismissLoadingFor_DoesNotClearConfirmModal(t *testing.T) {
 	m := &Model{}
 	m.modal = NewConfirmModal("Confirm", "Delete? [Y/n]", nil)
-	dismissLoading(m)
+	dismissLoadingFor(m, "services")
 	if m.modal == nil {
-		t.Error("dismissLoading should not clear confirm modal")
+		t.Error("dismissLoadingFor should not clear confirm modal")
 	}
 }
 
-func TestDismissLoading_DoesNotClearAboutModal(t *testing.T) {
+func TestDismissLoadingFor_NilModalIsNoOp(t *testing.T) {
 	m := &Model{}
-	m.modal, _ = NewAboutModal("0.10.0", "abc1234")
-	dismissLoading(m)
-	if m.modal == nil {
-		t.Error("dismissLoading should not clear about modal")
-	}
-}
-
-func TestDismissLoading_DoesNotClearStaticContentModal(t *testing.T) {
-	m := &Model{}
-	m.modal = NewModalOverlay("Help", []ModalStep{
-		{Title: "", Content: NewStaticContent("help text")},
-	}, func(_ []any) tea.Cmd { return nil },
-		func() tea.Cmd { return nil })
-	dismissLoading(m)
-	if m.modal == nil {
-		t.Error("dismissLoading should not clear help modal")
-	}
+	dismissLoadingFor(m, "services") // should not panic
 }
 
 func TestLoadingModal_EscDoesNotDismissOverlay(t *testing.T) {
 	m := &Model{}
-	showLoading(m, "Loading services...")
-	// Press Esc through the full ModalOverlay — should NOT dismiss
+	showLoading(m, "services", "Loading services...")
 	m.modal.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
 	if m.modal.Done() {
 		t.Error("Esc should not dismiss loading modal through ModalOverlay")
-	}
-}
-
-func TestDismissLoading_NilModalIsNoOp(t *testing.T) {
-	m := &Model{}
-	dismissLoading(m) // should not panic
-}
-
-func TestDismissLoading_DoneModalIsNoOp(t *testing.T) {
-	m := &Model{}
-	showLoading(m, "Loading...")
-	// Manually mark done
-	m.modal.done = true
-	dismissLoading(m)
-	// Should not clear a done modal
-	if m.modal == nil {
-		t.Error("dismissLoading should not clear a done modal")
 	}
 }

--- a/internal/app/modal_loading_test.go
+++ b/internal/app/modal_loading_test.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestLoadingContent_HandleKey_EscNotDismissable(t *testing.T) {
+	lc := &LoadingContent{message: "Loading services..."}
+	_, _, done := lc.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if done {
+		t.Error("Esc should not dismiss LoadingContent")
+	}
+}
+
+func TestLoadingContent_HandleKey_EnterNotDismissable(t *testing.T) {
+	lc := &LoadingContent{message: "Loading services..."}
+	_, _, done := lc.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if done {
+		t.Error("Enter should not dismiss LoadingContent")
+	}
+}
+
+func TestLoadingContent_HandleKey_ArbitraryKeyNotDismissable(t *testing.T) {
+	lc := &LoadingContent{message: "Loading services..."}
+	_, _, done := lc.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if done {
+		t.Error("arbitrary key should not dismiss LoadingContent")
+	}
+}
+
+func TestLoadingContent_View(t *testing.T) {
+	lc := &LoadingContent{message: "Loading services..."}
+	view := lc.View(80)
+	if !strings.Contains(view, "Loading services...") {
+		t.Errorf("view should contain message, got: %q", view)
+	}
+}
+
+func TestLoadingContent_Result(t *testing.T) {
+	lc := &LoadingContent{message: "Loading services..."}
+	if lc.Result() != nil {
+		t.Error("Result should be nil")
+	}
+}
+
+func TestShowLoading(t *testing.T) {
+	m := &Model{}
+	showLoading(m, "Loading services...")
+	if m.modal == nil {
+		t.Fatal("showLoading should set m.modal")
+	}
+	if m.modal.Done() {
+		t.Error("modal should not be done")
+	}
+	// Verify content is LoadingContent
+	if m.modal.current >= len(m.modal.steps) {
+		t.Fatal("modal has no steps")
+	}
+	lc, ok := m.modal.steps[m.modal.current].Content.(*LoadingContent)
+	if !ok {
+		t.Fatal("modal content should be *LoadingContent")
+	}
+	if lc.message != "Loading services..." {
+		t.Errorf("message = %q, want %q", lc.message, "Loading services...")
+	}
+}
+
+func TestDismissLoading_ClearsLoadingModal(t *testing.T) {
+	m := &Model{}
+	showLoading(m, "Loading services...")
+	dismissLoading(m)
+	if m.modal != nil {
+		t.Error("dismissLoading should clear loading modal")
+	}
+}
+
+func TestDismissLoading_DoesNotClearConfirmModal(t *testing.T) {
+	m := &Model{}
+	m.modal = NewConfirmModal("Confirm", "Delete? [Y/n]", nil)
+	dismissLoading(m)
+	if m.modal == nil {
+		t.Error("dismissLoading should not clear confirm modal")
+	}
+}
+
+func TestDismissLoading_DoesNotClearAboutModal(t *testing.T) {
+	m := &Model{}
+	m.modal, _ = NewAboutModal("0.10.0", "abc1234")
+	dismissLoading(m)
+	if m.modal == nil {
+		t.Error("dismissLoading should not clear about modal")
+	}
+}
+
+func TestDismissLoading_DoesNotClearStaticContentModal(t *testing.T) {
+	m := &Model{}
+	m.modal = NewModalOverlay("Help", []ModalStep{
+		{Title: "", Content: NewStaticContent("help text")},
+	}, func(_ []any) tea.Cmd { return nil },
+		func() tea.Cmd { return nil })
+	dismissLoading(m)
+	if m.modal == nil {
+		t.Error("dismissLoading should not clear help modal")
+	}
+}
+
+func TestDismissLoading_NilModalIsNoOp(t *testing.T) {
+	m := &Model{}
+	dismissLoading(m) // should not panic
+}
+
+func TestDismissLoading_DoneModalIsNoOp(t *testing.T) {
+	m := &Model{}
+	showLoading(m, "Loading...")
+	// Manually mark done
+	m.modal.done = true
+	dismissLoading(m)
+	// Should not clear a done modal
+	if m.modal == nil {
+		t.Error("dismissLoading should not clear a done modal")
+	}
+}

--- a/internal/app/modal_prompts.go
+++ b/internal/app/modal_prompts.go
@@ -37,6 +37,11 @@ type transitionConfirmedMsg struct {
 // confirmCancelledMsg is sent when any confirm modal is cancelled.
 type confirmCancelledMsg struct{}
 
+// isPasswordModal returns true if the modal is an SSH password prompt.
+func isPasswordModal(m *ModalOverlay) bool {
+	return m != nil && m.title == "SSH Password"
+}
+
 // --- Modal constructors ---
 
 // NewPasswordModal creates a 1-step masked input modal for SSH password.

--- a/internal/app/modal_sudo_wizard.go
+++ b/internal/app/modal_sudo_wizard.go
@@ -8,15 +8,24 @@ import (
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
 )
 
-// sudoWizardResultMsg is sent after the sudo wizard tests the password.
-type sudoWizardResultMsg struct {
-	hostIdx int
-	success bool
+// sudoWizardTestMsg is sent when the user enters a password in the wizard.
+// The model handler shows a loading modal and fires the async test.
+type sudoWizardTestMsg struct {
+	hostIdx  int
+	password string
 }
 
-// NewSudoWizard creates a modal that asks for the sudo password and tests it.
-// On success it sends sudoWizardResultMsg{success: true}.
-// On cancel it sends sudoWizardResultMsg{success: false}.
+// sudoWizardResultMsg is sent after the sudo wizard tests the password.
+type sudoWizardResultMsg struct {
+	hostIdx  int
+	password string
+	success  bool
+}
+
+// NewSudoWizard creates a sudo authentication wizard.
+// Step 1: Enter sudo password (masked input) — user presses Enter.
+// After Enter: modal switches to "Testing sudo..." loading overlay,
+// then async tests the password and sends sudoWizardResultMsg.
 func NewSudoWizard(user, host string, hostIdx int, sshMgr *ssh.Manager) *ModalOverlay {
 	prompt := fmt.Sprintf("Sudo password for %s@%s:", user, host)
 	m := NewModalOverlay("Sudo Authentication", []ModalStep{
@@ -24,18 +33,8 @@ func NewSudoWizard(user, host string, hostIdx int, sshMgr *ssh.Manager) *ModalOv
 	}, func(results []any) tea.Cmd {
 		pw := results[0].(string)
 		idx := hostIdx
-		sm := sshMgr
 		return func() tea.Msg {
-			// Test the password
-			sm.SetSudoPassword(idx, pw)
-			out, err := sm.RunSudoCommand(idx, "sudo true")
-			sm.SetSudoPassword(idx, "") // clear — Update handler sets on success
-			success := err == nil && !ssh.IsSudoOutput(out)
-			if success {
-				return sudoWizardResultMsg{hostIdx: idx, success: true}
-			}
-			// Wrong password — send failure
-			return sudoWizardResultMsg{hostIdx: idx, success: false}
+			return sudoWizardTestMsg{hostIdx: idx, password: pw}
 		}
 	}, func() tea.Cmd {
 		idx := hostIdx

--- a/internal/app/modal_sudo_wizard.go
+++ b/internal/app/modal_sudo_wizard.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
+)
+
+// sudoWizardResultMsg is sent after the sudo wizard tests the password.
+type sudoWizardResultMsg struct {
+	hostIdx int
+	success bool
+}
+
+// NewSudoWizard creates a modal that asks for the sudo password and tests it.
+// On success it sends sudoWizardResultMsg{success: true}.
+// On cancel it sends sudoWizardResultMsg{success: false}.
+func NewSudoWizard(user, host string, hostIdx int, sshMgr *ssh.Manager) *ModalOverlay {
+	prompt := fmt.Sprintf("Sudo password for %s@%s:", user, host)
+	m := NewModalOverlay("Sudo Authentication", []ModalStep{
+		{Title: prompt, Content: NewMaskedTextInputContent(prompt)},
+	}, func(results []any) tea.Cmd {
+		pw := results[0].(string)
+		idx := hostIdx
+		sm := sshMgr
+		return func() tea.Msg {
+			// Test the password
+			sm.SetSudoPassword(idx, pw)
+			out, err := sm.RunSudoCommand(idx, "sudo true")
+			sm.SetSudoPassword(idx, "") // clear — Update handler sets on success
+			success := err == nil && !ssh.IsSudoOutput(out)
+			if success {
+				return sudoWizardResultMsg{hostIdx: idx, success: true}
+			}
+			// Wrong password — send failure
+			return sudoWizardResultMsg{hostIdx: idx, success: false}
+		}
+	}, func() tea.Cmd {
+		idx := hostIdx
+		return func() tea.Msg {
+			return sudoWizardResultMsg{hostIdx: idx, success: false}
+		}
+	})
+	return m
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1150,15 +1150,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fetchUpdatesMsg:
 		dismissLoading(&m)
 		if msg.err != nil {
-			// Only prompt for sudo when the user is on the Updates view —
-			// pre-fetch from resource picker should silently return partial data.
-			if m.view == viewUpdateList {
-				if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
-					return m2, cmd
-				}
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
+				return m2, cmd
 			}
-			m.flash = fmt.Sprintf("Failed: %v", msg.err)
-			m.flashError = true
+			// Only flash non-sudo errors when on the Updates view —
+			// pre-fetch errors are silently ignored.
+			if m.view == viewUpdateList {
+				m.flash = fmt.Sprintf("Failed: %v", msg.err)
+				m.flashError = true
+			}
 		} else {
 			if msg.updates == nil {
 				m.updates = []config.Update{}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1150,6 +1150,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fetchUpdatesMsg:
 		dismissLoading(&m)
 		if msg.err != nil {
+			// Only prompt for sudo when the user is on the Updates view —
+			// pre-fetch from resource picker should silently return partial data.
+			if m.view == viewUpdateList {
+				if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
+					return m2, cmd
+				}
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1154,12 +1154,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
 				return m2, cmd
 			}
-			// Only flash non-sudo errors when on the Updates view —
-			// pre-fetch errors are silently ignored.
-			if m.view == viewUpdateList {
-				m.flash = fmt.Sprintf("Failed: %v", msg.err)
-				m.flashError = true
-			}
+			m.flash = fmt.Sprintf("Failed: %v", msg.err)
+			m.flashError = true
 		} else {
 			if msg.updates == nil {
 				m.updates = []config.Update{}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -593,8 +593,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case sudoProbeMsg:
-		navigateAfter := func() (Model, tea.Cmd) {
-			// After sudo is ready, navigate to resource picker
+		if !msg.needsPw || m.ssh.GetSudoPassword(msg.hostIdx) != "" {
+			// Sudo ready — navigate to resource picker
+			m.logger.Debug("sudo ready, navigating", "host_idx", msg.hostIdx)
+			if msg.hostIdx < len(m.hosts) {
+				m.hosts[msg.hostIdx].SudoReady = true
+			}
 			m.selectedHost = msg.hostIdx
 			m.resourceCursor = 0
 			m.services = nil
@@ -618,22 +622,61 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
 		}
 
-		if !msg.needsPw {
-			m.logger.Debug("sudo ready (no password needed)", "host_idx", msg.hostIdx)
-			if msg.hostIdx < len(m.hosts) {
-				m.hosts[msg.hostIdx].SudoReady = true
+		// Try SSH password silently first
+		idx := msg.hostIdx
+		sshPw := m.ssh.GetCachedPassword()
+		if sshPw != "" {
+			m.logger.Debug("sudo trying SSH password silently", "host_idx", idx)
+			sm := m.ssh
+			return m, func() tea.Msg {
+				sm.SetSudoPassword(idx, sshPw)
+				out, runErr := sm.RunSudoCommand(idx, "sudo true")
+				if runErr == nil && !ssh.IsSudoOutput(out) {
+					// Leave password cached — sudoWizardResultMsg handler will propagate
+					return sudoWizardResultMsg{hostIdx: idx, success: true}
+				}
+				sm.SetSudoPassword(idx, "") // wrong — clear
+				return sudoWizardResultMsg{hostIdx: idx, success: false}
 			}
-			m2, cmd := navigateAfter()
-			return m2, cmd
 		}
-		if m.ssh.GetSudoPassword(msg.hostIdx) != "" {
-			if msg.hostIdx < len(m.hosts) {
-				m.hosts[msg.hostIdx].SudoReady = true
+
+		// No SSH password — show sudo wizard
+		user := ""
+		host := ""
+		if idx < len(m.hosts) {
+			user = m.hosts[idx].Entry.User
+			host = m.hosts[idx].Entry.Name
+		}
+		m.logger.Debug("sudo wizard opening", "host_idx", idx)
+		m.modal = NewSudoWizard(user, host, idx, m.ssh)
+		return m, nil
+
+	case sudoWizardResultMsg:
+		m.modal = nil
+		if msg.success {
+			m.logger.Debug("sudo wizard success", "host_idx", msg.hostIdx)
+			// Password was tested and works — cache for all hosts
+			pw := m.ssh.GetSudoPassword(msg.hostIdx)
+			if pw == "" {
+				// Came from silent SSH password test — cache it
+				sshPw := m.ssh.GetCachedPassword()
+				if sshPw != "" {
+					pw = sshPw
+				}
 			}
-			m2, cmd := navigateAfter()
-			return m2, cmd
+			for i := range m.hosts {
+				m.ssh.SetSudoPassword(i, pw)
+				if m.hosts[i].Status == config.HostOnline {
+					m.hosts[i].SudoReady = true
+				}
+			}
+			// Navigate
+			return m, func() tea.Msg {
+				return sudoProbeMsg{hostIdx: msg.hostIdx, needsPw: false}
+			}
 		}
-		// Try SSH password silently first, then prompt if needed
+		// Failed — show wizard again
+		m.logger.Debug("sudo wizard failed, re-prompting", "host_idx", msg.hostIdx)
 		idx := msg.hostIdx
 		user := ""
 		host := ""
@@ -641,26 +684,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			user = m.hosts[idx].Entry.User
 			host = m.hosts[idx].Entry.Name
 		}
-		m.logger.Debug("sudo probe needs password", "host_idx", idx, "host", host)
-
-		sshPw := m.ssh.GetCachedPassword()
-		if sshPw != "" {
-			m.logger.Debug("sudo probe trying SSH password", "host_idx", idx)
-			sm := m.ssh
-			testCmd := func() tea.Msg {
-				sm.SetSudoPassword(idx, sshPw)
-				out, runErr := sm.RunSudoCommand(idx, "sudo true")
-				sm.SetSudoPassword(idx, "")
-				success := runErr == nil && !ssh.IsSudoOutput(out)
-				return sudoTestMsg{Password: sshPw, Success: success, Retry: nil, HostIdx: idx}
-			}
-			return m, testCmd
-		}
-
-		// No SSH password — show sudo modal, retry navigates after
-		m.logger.Debug("sudo probe showing prompt", "host_idx", idx)
-		retryNavigate := func() tea.Msg { return sudoProbeMsg{hostIdx: idx, needsPw: false} }
-		m.modal = NewSudoModal(user, host, idx, retryNavigate)
+		m.flash = "Wrong sudo password"
+		m.flashError = true
+		m.modal = NewSudoWizard(user, host, idx, m.ssh)
 		return m, nil
 
 	case azure.SubscriptionProbeResult:

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -653,7 +653,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sudoWizardTestMsg:
 		// Step 2: show loading modal while testing sudo
-		showLoading(&m, "Testing sudo...")
+		showLoading(&m, "sudotest", "Testing sudo...")
 		idx := msg.hostIdx
 		pw := msg.password
 		sm := m.ssh
@@ -713,14 +713,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case azureResourceCountsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "resourcecounts")
 		m.azureResourceCounts = msg.counts
 		m.azureResourceErr = msg.err
 		m.azureCountsLoaded = true
 		return m, nil
 
 	case fetchAzureVMsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "vms")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -854,7 +854,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sContextsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "contexts")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -873,14 +873,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case k8sResourceCountsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "resourcecounts")
 		m.k8sResourceCounts = msg.counts
 		m.k8sResourceErrors = msg.errs
 		m.k8sCountsLoaded = true
 		return m, nil
 
 	case fetchK8sNodesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "nodes")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -914,7 +914,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sNamespacesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "namespaces")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -939,7 +939,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sWorkloadsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "workloads")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -950,7 +950,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sPodsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "pods")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -976,7 +976,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sPodLogsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "podlogs")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1023,7 +1023,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAzureAKSMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "aks")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1220,7 +1220,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchServicesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "services")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1249,7 +1249,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchContainersMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "containers")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1270,7 +1270,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchCronMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "cron")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1280,7 +1280,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchLogLevelsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "loglevels")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchLogLevels()); ok {
 				return m2, cmd
@@ -1293,7 +1293,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchErrorLogsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "errorlogs")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchErrorLogs()); ok {
 				return m2, cmd
@@ -1306,7 +1306,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchUpdatesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "updates")
 		if msg.err != nil {
 			m.logger.Debug("fetchUpdates error", "err", msg.err, "view", m.view, "host_idx", m.selectedHost)
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
@@ -1335,7 +1335,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSubscriptionMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "subscription")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSubscription()); ok {
 				return m2, cmd
@@ -1365,7 +1365,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAccountsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "accounts")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1379,7 +1379,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchPortsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "ports")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1393,7 +1393,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchRoutesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "routes")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1409,7 +1409,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchInterfacesMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "interfaces")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1423,7 +1423,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchNetworkInfoMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "network")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchNetworkInfo()); ok {
 				return m2, cmd
@@ -1438,7 +1438,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchFirewallMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "firewall")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFirewall()); ok {
 				return m2, cmd
@@ -1452,7 +1452,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchFailedLoginsMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "failedlogins")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFailedLogins()); ok {
 				return m2, cmd
@@ -1469,7 +1469,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSudoActivityMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "sudo")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSudoActivity()); ok {
 				return m2, cmd
@@ -1486,7 +1486,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSELinuxMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "selinux")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSELinuxDenials()); ok {
 				return m2, cmd
@@ -1503,7 +1503,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAuditSummaryMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "audit")
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchAuditSummary()); ok {
 				return m2, cmd
@@ -1520,7 +1520,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchDiskMsg:
-		dismissLoading(&m)
+		dismissLoadingFor(&m, "disk")
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -479,9 +479,11 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 		user = m.hosts[idx].Entry.User
 		host = m.hosts[idx].Entry.Name
 	}
+	m.logger.Debug("sudo required", "host_idx", idx, "host", host, "user", user)
 
 	// Wrong cached password: it was tried and failed — clear and re-prompt.
 	if m.ssh.GetSudoPassword(idx) != "" {
+		m.logger.Debug("sudo cached password failed, re-prompting", "host_idx", idx)
 		m.ssh.SetSudoPassword(idx, "")
 		m.modal = NewSudoModal(user, host, idx, retry)
 		return m, nil, true
@@ -490,6 +492,7 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 	// Try the SSH connection password silently if available.
 	sshPw := m.ssh.GetCachedPassword()
 	if sshPw != "" {
+		m.logger.Debug("sudo trying SSH password silently", "host_idx", idx)
 		sm := m.ssh
 		r := retry
 		testCmd := func() tea.Msg {
@@ -503,6 +506,7 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 	}
 
 	// No SSH password cached (key auth): show prompt directly.
+	m.logger.Debug("sudo no SSH password cached, showing prompt", "host_idx", idx)
 	m.modal = NewSudoModal(user, host, idx, retry)
 	return m, nil, true
 }
@@ -974,8 +978,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case sudoTestMsg:
+		m.logger.Debug("sudo test result", "success", msg.Success, "host_idx", m.selectedHost)
 		if msg.Success {
 			// Cache sudo password for all hosts — same password across the fleet
+			m.logger.Debug("sudo password cached for all hosts", "host_count", len(m.hosts))
 			for i := range m.hosts {
 				m.ssh.SetSudoPassword(i, msg.Password)
 			}
@@ -1021,6 +1027,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sudoEnteredMsg:
 		m.modal = nil
 		// Cache sudo password for all hosts — same password across the fleet
+		m.logger.Debug("sudo password entered, caching for all hosts", "host_idx", msg.hostIdx, "host_count", len(m.hosts))
 		for i := range m.hosts {
 			m.ssh.SetSudoPassword(i, msg.password)
 		}
@@ -1157,6 +1164,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fetchUpdatesMsg:
 		dismissLoading(&m)
 		if msg.err != nil {
+			m.logger.Debug("fetchUpdates error", "err", msg.err, "view", m.view, "host_idx", m.selectedHost)
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
 				return m2, cmd
 			}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -421,6 +421,7 @@ type Model struct {
 
 	// app info
 	version string
+	commit  string
 
 	// config
 	appCfg config.AppConfig
@@ -431,7 +432,7 @@ type Model struct {
 	wizardExitError error
 }
 
-func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logger, version string) Model {
+func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logger, version, commit string) Model {
 	m := Model{
 		view:    viewFleetPicker,
 		fleets:  fleets,
@@ -441,6 +442,7 @@ func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logge
 		k8s:     k8s.NewManager(logger),
 		logger:  logger,
 		version: version,
+		commit:  commit,
 	}
 	if appCfg.FleetDir == "" {
 		m.modal = NewFirstRunWizard()
@@ -535,6 +537,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.modal = newCustomEditorWizard(msg.fleetDir)
 		return m, nil
 
+	case aboutFieldMsg:
+		if m.modal != nil && !m.modal.Done() && m.modal.current < len(m.modal.steps) {
+			if ac, ok := m.modal.steps[m.modal.current].Content.(*AboutContent); ok {
+				ac.UpdateField(msg.field, msg.value)
+			}
+		}
+		return m, nil
+
 	case ssh.HostProbeResult:
 		if msg.Index < len(m.hosts) {
 			if msg.Err != nil {
@@ -570,12 +580,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case azureResourceCountsMsg:
+		dismissLoading(&m)
 		m.azureResourceCounts = msg.counts
 		m.azureResourceErr = msg.err
 		m.azureCountsLoaded = true
 		return m, nil
 
 	case fetchAzureVMsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -709,6 +721,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sContextsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -727,12 +740,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case k8sResourceCountsMsg:
+		dismissLoading(&m)
 		m.k8sResourceCounts = msg.counts
 		m.k8sResourceErrors = msg.errs
 		m.k8sCountsLoaded = true
 		return m, nil
 
 	case fetchK8sNodesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -766,6 +781,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sNamespacesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -790,6 +806,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sWorkloadsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -800,6 +817,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sPodsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -825,6 +843,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchK8sPodLogsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -871,6 +890,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAzureAKSMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1042,6 +1062,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchServicesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1070,6 +1091,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchContainersMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1090,6 +1112,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchCronMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1099,6 +1122,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchLogLevelsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchLogLevels()); ok {
 				return m2, cmd
@@ -1111,6 +1135,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchErrorLogsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchErrorLogs()); ok {
 				return m2, cmd
@@ -1123,6 +1148,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchUpdatesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1147,6 +1173,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSubscriptionMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSubscription()); ok {
 				return m2, cmd
@@ -1176,6 +1203,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAccountsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1189,6 +1217,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchPortsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1202,6 +1231,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchRoutesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1217,6 +1247,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchInterfacesMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
@@ -1230,6 +1261,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchNetworkInfoMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchNetworkInfo()); ok {
 				return m2, cmd
@@ -1244,6 +1276,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchFirewallMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFirewall()); ok {
 				return m2, cmd
@@ -1257,6 +1290,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchFailedLoginsMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchFailedLogins()); ok {
 				return m2, cmd
@@ -1273,6 +1307,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSudoActivityMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSudoActivity()); ok {
 				return m2, cmd
@@ -1289,6 +1324,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchSELinuxMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchSELinuxDenials()); ok {
 				return m2, cmd
@@ -1305,6 +1341,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchAuditSummaryMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchAuditSummary()); ok {
 				return m2, cmd
@@ -1321,6 +1358,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case fetchDiskMsg:
+		dismissLoading(&m)
 		if msg.err != nil {
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1150,9 +1150,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fetchUpdatesMsg:
 		dismissLoading(&m)
 		if msg.err != nil {
-			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
-				return m2, cmd
-			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -975,7 +975,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sudoTestMsg:
 		if msg.Success {
-			m.ssh.SetSudoPassword(m.selectedHost, msg.Password)
+			// Cache sudo password for all hosts — same password across the fleet
+			for i := range m.hosts {
+				m.ssh.SetSudoPassword(i, msg.Password)
+			}
 			return m, msg.Retry
 		}
 		// SSH password didn't work as sudo password — show prompt.
@@ -1017,7 +1020,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sudoEnteredMsg:
 		m.modal = nil
-		m.ssh.SetSudoPassword(msg.hostIdx, msg.password)
+		// Cache sudo password for all hosts — same password across the fleet
+		for i := range m.hosts {
+			m.ssh.SetSudoPassword(i, msg.password)
+		}
 		return m, msg.retry
 
 	case sudoCancelledMsg:

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -159,6 +159,13 @@ type sudoTestMsg struct {
 	Password string
 	Success  bool
 	Retry    tea.Cmd
+	HostIdx  int
+}
+
+// sudoProbeMsg is sent after testing sudo availability on a host during probe.
+type sudoProbeMsg struct {
+	hostIdx int
+	needsPw bool // true if sudo requires a password
 }
 
 func (m Model) tickCmd() tea.Cmd {
@@ -500,7 +507,7 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 			out, runErr := sm.RunSudoCommand(idx, "sudo true")
 			sm.SetSudoPassword(idx, "") // always clear — model Update sets it on success
 			success := runErr == nil && !ssh.IsSudoOutput(out)
-			return sudoTestMsg{Password: sshPw, Success: success, Retry: r}
+			return sudoTestMsg{Password: sshPw, Success: success, Retry: r, HostIdx: idx}
 		}
 		return m, testCmd, true
 	}
@@ -509,6 +516,18 @@ func (m Model) handleSudoOrFlash(err error, retry tea.Cmd) (Model, tea.Cmd, bool
 	m.logger.Debug("sudo no SSH password cached, showing prompt", "host_idx", idx)
 	m.modal = NewSudoModal(user, host, idx, retry)
 	return m, nil, true
+}
+
+// testSudo fires a goroutine to test if sudo works on the given host.
+func (m Model) testSudo(idx int) tea.Cmd {
+	sm := m.ssh
+	logger := m.logger
+	return func() tea.Msg {
+		out, err := sm.RunCommand(idx, "sudo -n true 2>&1")
+		needsPw := err != nil || ssh.IsSudoOutput(out)
+		logger.Debug("sudo test", "host_idx", idx, "needs_password", needsPw)
+		return sudoProbeMsg{hostIdx: idx, needsPw: needsPw}
+	}
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -571,6 +590,77 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.applyProbeInfo(msg.Index, msg.Info)
 			}
 		}
+		return m, nil
+
+	case sudoProbeMsg:
+		navigateAfter := func() (Model, tea.Cmd) {
+			// After sudo is ready, navigate to resource picker
+			m.selectedHost = msg.hostIdx
+			m.resourceCursor = 0
+			m.services = nil
+			m.containers = nil
+			m.updates = nil
+			m.cronJobs = nil
+			m.logLevels = nil
+			m.errorLogs = nil
+			m.disks = nil
+			m.subscriptions = nil
+			m.accounts = nil
+			m.interfaces = nil
+			m.ports = nil
+			m.routes = nil
+			m.firewallRules = nil
+			m.failedLogins = nil
+			m.sudoEntries = nil
+			m.selinuxDenials = nil
+			m.auditEvents = nil
+			m.view = viewResourcePicker
+			return m, tea.Batch(m.fetchServices(), m.fetchContainers(), m.fetchUpdates())
+		}
+
+		if !msg.needsPw {
+			m.logger.Debug("sudo ready (no password needed)", "host_idx", msg.hostIdx)
+			if msg.hostIdx < len(m.hosts) {
+				m.hosts[msg.hostIdx].SudoReady = true
+			}
+			m2, cmd := navigateAfter()
+			return m2, cmd
+		}
+		if m.ssh.GetSudoPassword(msg.hostIdx) != "" {
+			if msg.hostIdx < len(m.hosts) {
+				m.hosts[msg.hostIdx].SudoReady = true
+			}
+			m2, cmd := navigateAfter()
+			return m2, cmd
+		}
+		// Try SSH password silently first, then prompt if needed
+		idx := msg.hostIdx
+		user := ""
+		host := ""
+		if idx < len(m.hosts) {
+			user = m.hosts[idx].Entry.User
+			host = m.hosts[idx].Entry.Name
+		}
+		m.logger.Debug("sudo probe needs password", "host_idx", idx, "host", host)
+
+		sshPw := m.ssh.GetCachedPassword()
+		if sshPw != "" {
+			m.logger.Debug("sudo probe trying SSH password", "host_idx", idx)
+			sm := m.ssh
+			testCmd := func() tea.Msg {
+				sm.SetSudoPassword(idx, sshPw)
+				out, runErr := sm.RunSudoCommand(idx, "sudo true")
+				sm.SetSudoPassword(idx, "")
+				success := runErr == nil && !ssh.IsSudoOutput(out)
+				return sudoTestMsg{Password: sshPw, Success: success, Retry: nil, HostIdx: idx}
+			}
+			return m, testCmd
+		}
+
+		// No SSH password — show sudo modal, retry navigates after
+		m.logger.Debug("sudo probe showing prompt", "host_idx", idx)
+		retryNavigate := func() tea.Msg { return sudoProbeMsg{hostIdx: idx, needsPw: false} }
+		m.modal = NewSudoModal(user, host, idx, retryNavigate)
 		return m, nil
 
 	case azure.SubscriptionProbeResult:
@@ -978,24 +1068,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case sudoTestMsg:
-		m.logger.Debug("sudo test result", "success", msg.Success, "host_idx", m.selectedHost)
+		m.logger.Debug("sudo test result", "success", msg.Success, "host_idx", msg.HostIdx)
 		if msg.Success {
-			// Cache sudo password for all hosts — same password across the fleet
-			m.logger.Debug("sudo password cached for all hosts", "host_count", len(m.hosts))
+			// Cache sudo password and mark all online hosts as sudo-ready
 			for i := range m.hosts {
 				m.ssh.SetSudoPassword(i, msg.Password)
+				if m.hosts[i].Status == config.HostOnline {
+					m.hosts[i].SudoReady = true
+				}
 			}
-			return m, msg.Retry
+			if msg.Retry != nil {
+				return m, msg.Retry
+			}
+			// From probe flow — trigger navigation
+			idx := msg.HostIdx
+			return m, func() tea.Msg { return sudoProbeMsg{hostIdx: idx, needsPw: false} }
 		}
 		// SSH password didn't work as sudo password — show prompt.
-		idx := m.selectedHost
+		idx := msg.HostIdx
 		user := ""
 		host := ""
 		if idx < len(m.hosts) {
 			user = m.hosts[idx].Entry.User
 			host = m.hosts[idx].Entry.Name
 		}
-		m.modal = NewSudoModal(user, host, idx, msg.Retry)
+		// Retry: re-test sudo after password entry, which will trigger navigation
+		retryNavigate := func() tea.Msg { return sudoProbeMsg{hostIdx: idx, needsPw: false} }
+		m.modal = NewSudoModal(user, host, idx, retryNavigate)
 		return m, nil
 
 	case passwordEnteredMsg:
@@ -1026,10 +1125,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sudoEnteredMsg:
 		m.modal = nil
-		// Cache sudo password for all hosts — same password across the fleet
-		m.logger.Debug("sudo password entered, caching for all hosts", "host_idx", msg.hostIdx, "host_count", len(m.hosts))
+		// Cache sudo password and mark all online hosts as sudo-ready
+		m.logger.Debug("sudo password entered", "host_idx", msg.hostIdx, "host_count", len(m.hosts))
 		for i := range m.hosts {
 			m.ssh.SetSudoPassword(i, msg.password)
+			if m.hosts[i].Status == config.HostOnline {
+				m.hosts[i].SudoReady = true
+			}
 		}
 		return m, msg.retry
 

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1150,6 +1150,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case fetchUpdatesMsg:
 		dismissLoading(&m)
 		if msg.err != nil {
+			if m2, cmd, ok := m.handleSudoOrFlash(msg.err, m.fetchUpdates()); ok {
+				return m2, cmd
+			}
 			m.flash = fmt.Sprintf("Failed: %v", msg.err)
 			m.flashError = true
 		} else {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1125,15 +1125,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sudoEnteredMsg:
 		m.modal = nil
-		// Cache sudo password and mark all online hosts as sudo-ready
-		m.logger.Debug("sudo password entered", "host_idx", msg.hostIdx, "host_count", len(m.hosts))
-		for i := range m.hosts {
-			m.ssh.SetSudoPassword(i, msg.password)
-			if m.hosts[i].Status == config.HostOnline {
-				m.hosts[i].SudoReady = true
-			}
+		// Test the password before caching
+		m.logger.Debug("sudo password entered, testing", "host_idx", msg.hostIdx)
+		idx := msg.hostIdx
+		pw := msg.password
+		retry := msg.retry
+		sm := m.ssh
+		sm.SetSudoPassword(idx, pw)
+		return m, func() tea.Msg {
+			out, runErr := sm.RunSudoCommand(idx, "sudo true")
+			sm.SetSudoPassword(idx, "") // clear — sudoTestMsg sets it on success
+			success := runErr == nil && !ssh.IsSudoOutput(out)
+			return sudoTestMsg{Password: pw, Success: success, Retry: retry, HostIdx: idx}
 		}
-		return m, msg.retry
 
 	case sudoCancelledMsg:
 		m.modal = nil

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -651,21 +651,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.modal = NewSudoWizard(user, host, idx, m.ssh)
 		return m, nil
 
+	case sudoWizardTestMsg:
+		// Step 2: show loading modal while testing sudo
+		showLoading(&m, "Testing sudo...")
+		idx := msg.hostIdx
+		pw := msg.password
+		sm := m.ssh
+		m.logger.Debug("sudo wizard testing password", "host_idx", idx)
+		return m, func() tea.Msg {
+			sm.SetSudoPassword(idx, pw)
+			out, err := sm.RunSudoCommand(idx, "sudo true")
+			sm.SetSudoPassword(idx, "")
+			success := err == nil && !ssh.IsSudoOutput(out)
+			return sudoWizardResultMsg{hostIdx: idx, password: pw, success: success}
+		}
+
 	case sudoWizardResultMsg:
-		m.modal = nil
 		if msg.success {
+			m.modal = nil
 			m.logger.Debug("sudo wizard success", "host_idx", msg.hostIdx)
-			// Password was tested and works — cache for all hosts
-			pw := m.ssh.GetSudoPassword(msg.hostIdx)
-			if pw == "" {
-				// Came from silent SSH password test — cache it
-				sshPw := m.ssh.GetCachedPassword()
-				if sshPw != "" {
-					pw = sshPw
-				}
-			}
+			// Cache password for all hosts
 			for i := range m.hosts {
-				m.ssh.SetSudoPassword(i, pw)
+				m.ssh.SetSudoPassword(i, msg.password)
 				if m.hosts[i].Status == config.HostOnline {
 					m.hosts[i].SudoReady = true
 				}
@@ -675,18 +682,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return sudoProbeMsg{hostIdx: msg.hostIdx, needsPw: false}
 			}
 		}
-		// Failed — show wizard again
-		m.logger.Debug("sudo wizard failed, re-prompting", "host_idx", msg.hostIdx)
-		idx := msg.hostIdx
-		user := ""
-		host := ""
-		if idx < len(m.hosts) {
-			user = m.hosts[idx].Entry.User
-			host = m.hosts[idx].Entry.Name
+		if msg.password != "" {
+			// Password was tested and failed — re-show wizard
+			m.logger.Debug("sudo wizard failed, re-prompting", "host_idx", msg.hostIdx)
+			idx := msg.hostIdx
+			user := ""
+			host := ""
+			if idx < len(m.hosts) {
+				user = m.hosts[idx].Entry.User
+				host = m.hosts[idx].Entry.Name
+			}
+			m.flash = "Wrong sudo password"
+			m.flashError = true
+			m.modal = NewSudoWizard(user, host, idx, m.ssh)
+			return m, nil
 		}
-		m.flash = "Wrong sudo password"
-		m.flashError = true
-		m.modal = NewSudoWizard(user, host, idx, m.ssh)
+		// Cancelled
+		m.modal = nil
 		return m, nil
 
 	case azure.SubscriptionProbeResult:

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -553,8 +553,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.hosts[msg.Index].Status = config.HostUnreachable
 					m.hosts[msg.Index].Error = "password required"
 					m.hosts[msg.Index].NeedsPassword = true
-					// show prompt if not already showing one
-					if m.modal == nil || m.modal.Done() {
+					// show prompt — SSH password takes priority over other modals
+					// (sudo, loading, etc.) but don't replace another password modal
+					if m.modal == nil || m.modal.Done() || !isPasswordModal(m.modal) {
 						h := m.hosts[msg.Index]
 						m.modal = NewPasswordModal(h.Entry.User, h.Entry.Name, msg.Index)
 					}

--- a/internal/app/view_account.go
+++ b/internal/app/view_account.go
@@ -72,9 +72,7 @@ func (m Model) renderAccountList() string {
 		s += borderedRow(fmt.Sprintf("  / %s\u2588", m.filterText), iw, normalRowStyle) + "\n"
 	}
 
-	if accts == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(accts) == 0 {
+	if len(accts) == 0 {
 		s += borderedRow("  No accounts found.", iw, normalRowStyle) + "\n"
 	} else {
 		// compute dynamic column widths

--- a/internal/app/view_account.go
+++ b/internal/app/view_account.go
@@ -162,13 +162,13 @@ func (m Model) renderAccountList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 {"Enter", "Detail"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_azure_aks.go
+++ b/internal/app/view_azure_aks.go
@@ -69,9 +69,7 @@ func (m Model) renderAzureAKSList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.azureAKSCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if m.azureAKSClusters == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_azure_aks.go
+++ b/internal/app/view_azure_aks.go
@@ -228,7 +228,7 @@ func (m Model) renderAzureAKSList() string {
 	} else {
 		maxSortCol := 8 + len(displayTags)
 		sortLabel := fmt.Sprintf("1-%d", maxSortCol)
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
 			{"s", "Start"},
@@ -239,7 +239,7 @@ func (m Model) renderAzureAKSList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }
@@ -378,11 +378,11 @@ func (m Model) renderAzureAKSDetail() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Scroll"},
 		{"a", "Activity Log"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_azure_resource.go
+++ b/internal/app/view_azure_resource.go
@@ -73,12 +73,12 @@ func (m Model) renderAzureResourcePicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_azure_sublist.go
+++ b/internal/app/view_azure_sublist.go
@@ -106,7 +106,7 @@ func (m Model) renderAzureSubList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Drill In"},
 			{"r", "Refresh"},
@@ -114,7 +114,7 @@ func (m Model) renderAzureSubList() string {
 			{"1-3", "Sort"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -37,9 +37,7 @@ func (m Model) renderAzureVMList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.azureVMCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if m.azureVMs == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -151,7 +151,7 @@ func (m Model) renderAzureVMList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
 			{"s", "Start"},
@@ -161,7 +161,7 @@ func (m Model) renderAzureVMList() string {
 			{"1-7", "Sort"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},
-		})
+		}))
 	}
 	return s
 }
@@ -275,12 +275,12 @@ func (m Model) renderAzureVMDetail() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Scroll"},
 		{"a", "Activity Log"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_common.go
+++ b/internal/app/view_common.go
@@ -28,6 +28,11 @@ func (m Model) renderHeader(breadcrumb string, current, total int) string {
 	return left + strings.Repeat(" ", gap) + right
 }
 
+// hintWithHelp appends the "? Help" hint to any hint bar.
+func hintWithHelp(hints [][]string) [][]string {
+	return append(hints, []string{"?", "Help"})
+}
+
 func (m Model) renderHintBar(hints [][]string) string {
 	var parts []string
 	for _, h := range hints {

--- a/internal/app/view_common.go
+++ b/internal/app/view_common.go
@@ -81,9 +81,7 @@ func (m Model) renderActivityLog(iw int) string {
 	s += borderedRow(fmt.Sprintf("  ── Recent Activity (Resource Group, last %dh) ──", hours), iw, colHeaderStyle) + "\n"
 	s += borderedRow("", iw, normalRowStyle) + "\n"
 
-	if m.azureActivityLog == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(m.azureActivityLog) == 0 {
+	if len(m.azureActivityLog) == 0 {
 		s += borderedRow("  No recent activity.", iw, normalRowStyle) + "\n"
 	} else {
 		s += m.renderActivityLogTable(iw, m.azureActivityLog, m.azureActivityCursor)

--- a/internal/app/view_config.go
+++ b/internal/app/view_config.go
@@ -29,11 +29,11 @@ func (m Model) renderConfig() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"e", "Edit config"},
 		{"r", "Reload"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }
 

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -64,10 +64,10 @@ func (m Model) renderContainerList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
-		})
+		}))
 		return s
 	}
 
@@ -147,7 +147,7 @@ func (m Model) renderContainerList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-3", "Sort"},
@@ -157,6 +157,6 @@ func (m Model) renderContainerList() string {
 		{"e", "Exec"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -83,9 +83,7 @@ func (m Model) renderContainerList() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.containers == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No containers found.", iw, normalRowStyle) + "\n"
 	} else {
 		nameCol := len("CONTAINER")

--- a/internal/app/view_cron.go
+++ b/internal/app/view_cron.go
@@ -101,12 +101,12 @@ func (m Model) renderCronList() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"1-3", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_cron.go
+++ b/internal/app/view_cron.go
@@ -28,9 +28,7 @@ func (m Model) renderCronList() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.cronJobs == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No cron jobs found.", iw, normalRowStyle) + "\n"
 	} else {
 		schedCol := len("SCHEDULE")

--- a/internal/app/view_disk.go
+++ b/internal/app/view_disk.go
@@ -76,9 +76,7 @@ func (m Model) renderDiskList() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.disks == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No partitions found.", iw, normalRowStyle) + "\n"
 	} else {
 		fsCol := len("FILESYSTEM")

--- a/internal/app/view_disk.go
+++ b/internal/app/view_disk.go
@@ -59,10 +59,10 @@ func (m Model) renderDiskList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
-		})
+		}))
 		return s
 	}
 
@@ -148,13 +148,13 @@ func (m Model) renderDiskList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-6", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -106,12 +106,13 @@ func (m Model) renderFleetPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"Enter", "Select"},
+		{"a", "About"},
 		{"e", "Edit"},
 		{"c", "Config"},
 		{"r", "Reload"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -44,7 +44,7 @@ func (m Model) renderHostList() string {
 			}
 		}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s", nameCol, "HOST", osCol, "OS", upCol, "UP SINCE")
+		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %s", nameCol, "HOST", osCol, "OS", upCol, "UP SINCE", "UPD")
 		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 
@@ -95,8 +95,12 @@ func (m Model) renderHostList() string {
 				}
 				line = fmt.Sprintf("%s  %-*s  unreachable (%s)", cur, nameCol, h.Entry.Name, reason)
 			default:
-				line = fmt.Sprintf("%s  %-*s  %-*s  %-*s",
-					cur, nameCol, h.Entry.Name, osCol, h.OS, upCol, h.UpSince)
+				updStr := fmt.Sprintf("%d", h.UpdateCount)
+				if h.UpdateCount == 0 {
+					updStr = "—"
+				}
+				line = fmt.Sprintf("%s  %-*s  %-*s  %-*s  %s",
+					cur, nameCol, h.Entry.Name, osCol, h.OS, upCol, h.UpSince, updStr)
 			}
 
 			var style lipgloss.Style

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -114,7 +114,7 @@ func (m Model) renderHostList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Drill In"},
 		{"x", "Shell"},
@@ -124,6 +124,6 @@ func (m Model) renderHostList() string {
 		{"r", "Refresh"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_k8s_clusters.go
+++ b/internal/app/view_k8s_clusters.go
@@ -88,7 +88,7 @@ func (m Model) renderK8sClusterList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Contexts"},
 			{"r", "Refresh"},
@@ -96,7 +96,7 @@ func (m Model) renderK8sClusterList() string {
 			{"1-2", "Sort"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_k8s_contexts.go
+++ b/internal/app/view_k8s_contexts.go
@@ -96,7 +96,7 @@ func (m Model) renderK8sContextList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Resources"},
 			{"d", "Delete Context"},
@@ -104,7 +104,7 @@ func (m Model) renderK8sContextList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_k8s_contexts.go
+++ b/internal/app/view_k8s_contexts.go
@@ -20,9 +20,7 @@ func (m Model) renderK8sContextList() string {
 	breadcrumb := f.Name + " › " + cluster.Name
 	s := m.renderHeader(breadcrumb, m.k8sContextCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
-	if m.k8sContexts == nil {
-		s += borderedRow("  Loading contexts...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No contexts found.", iw, normalRowStyle) + "\n"
 	} else {
 		nameCol := len("CONTEXT")

--- a/internal/app/view_k8s_namespaces.go
+++ b/internal/app/view_k8s_namespaces.go
@@ -25,9 +25,7 @@ func (m Model) renderK8sNamespaceList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sNamespaceCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.k8sNamespaces == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_k8s_namespaces.go
+++ b/internal/app/view_k8s_namespaces.go
@@ -111,7 +111,7 @@ func (m Model) renderK8sNamespaceList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Workloads"},
 			{"/", "Filter"},
@@ -119,7 +119,7 @@ func (m Model) renderK8sNamespaceList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_k8s_nodes.go
+++ b/internal/app/view_k8s_nodes.go
@@ -173,7 +173,7 @@ func (m Model) renderK8sNodeList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
 			{"/", "Filter"},
@@ -181,7 +181,7 @@ func (m Model) renderK8sNodeList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }
@@ -400,14 +400,14 @@ func (m Model) renderK8sNodeDetail() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Scroll Pods"},
 			{"/", "Filter"},
 			{"1-9", "Sort"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_k8s_nodes.go
+++ b/internal/app/view_k8s_nodes.go
@@ -36,9 +36,7 @@ func (m Model) renderK8sNodeList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sNodeCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if m.k8sNodes == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {
@@ -330,8 +328,8 @@ func (m Model) renderK8sNodeDetail() string {
 	}
 	s += borderedRow(fmt.Sprintf("  ── Non-terminated Pods (%d in total) ──", podCount), iw, groupHeaderStyle) + "\n"
 
-	if m.k8sNodePods == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
+	if len(m.k8sNodePods) == 0 {
+		s += borderedRow("  No pods.", iw, normalRowStyle) + "\n"
 	} else {
 		filteredPods := m.filteredK8sNodePods()
 		if len(filteredPods) == 0 {

--- a/internal/app/view_k8s_pod_logs.go
+++ b/internal/app/view_k8s_pod_logs.go
@@ -66,9 +66,7 @@ func (m Model) renderK8sPodLogs() string {
 	s += borderedRow(statusLine, iw+2, colHeaderStyle) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.k8sPodLogs == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_k8s_pod_logs.go
+++ b/internal/app/view_k8s_pod_logs.go
@@ -173,7 +173,7 @@ func (m Model) renderK8sPodLogs() string {
 			containerLabel = "App Only"
 		}
 		levelLabel := "Log Level"
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Detail"},
 			{streamHint, streamLabel},
@@ -182,7 +182,7 @@ func (m Model) renderK8sPodLogs() string {
 			{"g/G", "Top/Bottom"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }
@@ -290,11 +290,11 @@ func (m Model) renderK8sLogDetail(e k8s.K8sLogEntry, fleetName, clusterName, nsN
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Scroll"},
 		{"g", "Top"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }
 

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -43,9 +43,7 @@ func (m Model) renderK8sPodList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sPodCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.k8sPodList == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -140,7 +140,7 @@ func (m Model) renderK8sPodList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Detail"},
 			{"l", "Logs"},
@@ -150,7 +150,7 @@ func (m Model) renderK8sPodList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }
@@ -464,12 +464,12 @@ func (m Model) renderK8sPodDetail() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Scroll"},
 		{"g", "Top"},
 		{"l", "Logs"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_k8s_resource.go
+++ b/internal/app/view_k8s_resource.go
@@ -67,13 +67,13 @@ func (m Model) renderK8sResourcePicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
 		{"q", "Quit"},
-	})
+	}))
 	return s
 }
 

--- a/internal/app/view_k8s_workloads.go
+++ b/internal/app/view_k8s_workloads.go
@@ -26,9 +26,7 @@ func (m Model) renderK8sWorkloadList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sWorkloadCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.k8sWorkloads == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_k8s_workloads.go
+++ b/internal/app/view_k8s_workloads.go
@@ -123,7 +123,7 @@ func (m Model) renderK8sWorkloadList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Pods"},
 			{"/", "Filter"},
@@ -131,7 +131,7 @@ func (m Model) renderK8sWorkloadList() string {
 			{"r", "Refresh"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_logs.go
+++ b/internal/app/view_logs.go
@@ -50,12 +50,12 @@ func (m Model) renderLogLevelPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "View Logs"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }
 
@@ -214,7 +214,7 @@ func (m Model) renderErrorLogList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"1-3", "Sort"},
 			{"Enter", "Detail"},
@@ -222,7 +222,7 @@ func (m Model) renderErrorLogList() string {
 			{"l", "Full Log"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_logs.go
+++ b/internal/app/view_logs.go
@@ -21,7 +21,7 @@ func (m Model) renderLogLevelPicker() string {
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
 	if len(m.logLevels) == 0 {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
+		s += borderedRow("  No log levels.", iw, normalRowStyle) + "\n"
 	} else {
 		nameCol := len("LEVEL") + 6
 
@@ -142,9 +142,7 @@ func (m Model) renderErrorLogList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.errorCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.errorLogs == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_metrics.go
+++ b/internal/app/view_metrics.go
@@ -156,11 +156,11 @@ func (m Model) renderMetrics() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network.go
+++ b/internal/app/view_network.go
@@ -64,11 +64,11 @@ func (m Model) renderNetworkPicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network_firewall.go
+++ b/internal/app/view_network_firewall.go
@@ -133,12 +133,12 @@ func (m Model) renderNetworkFirewall() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network_firewall.go
+++ b/internal/app/view_network_firewall.go
@@ -47,9 +47,7 @@ func (m Model) renderNetworkFirewall() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.firewallRules == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 && m.firewallBackend == "" {
+	if len(filtered) == 0 && m.firewallBackend == "" {
 		s += borderedRow("  No firewall detected", iw, normalRowStyle) + "\n"
 	} else if len(filtered) == 0 {
 		s += borderedRow("  No rules found", iw, normalRowStyle) + "\n"

--- a/internal/app/view_network_interfaces.go
+++ b/internal/app/view_network_interfaces.go
@@ -28,9 +28,7 @@ func (m Model) renderNetworkInterfaces() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.interfaces == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No interfaces found.", iw, normalRowStyle) + "\n"
 	} else {
 		// compute column widths

--- a/internal/app/view_network_interfaces.go
+++ b/internal/app/view_network_interfaces.go
@@ -116,12 +116,12 @@ func (m Model) renderNetworkInterfaces() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network_ports.go
+++ b/internal/app/view_network_ports.go
@@ -28,9 +28,7 @@ func (m Model) renderNetworkPorts() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.ports == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No listening ports found.", iw, normalRowStyle) + "\n"
 	} else {
 		// compute column widths

--- a/internal/app/view_network_ports.go
+++ b/internal/app/view_network_ports.go
@@ -109,12 +109,12 @@ func (m Model) renderNetworkPorts() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network_routes.go
+++ b/internal/app/view_network_routes.go
@@ -118,12 +118,12 @@ func (m Model) renderNetworkRoutes() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_network_routes.go
+++ b/internal/app/view_network_routes.go
@@ -41,9 +41,7 @@ func (m Model) renderNetworkRoutes() string {
 	s += borderedRow(dnsLine, iw, lipgloss.NewStyle().Foreground(colorCyan)) + "\n"
 	s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 
-	if m.routes == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No routes found.", iw, normalRowStyle) + "\n"
 	} else {
 		// compute column widths

--- a/internal/app/view_resource.go
+++ b/internal/app/view_resource.go
@@ -101,11 +101,11 @@ func (m Model) renderResourcePicker() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_security_audit.go
+++ b/internal/app/view_security_audit.go
@@ -102,12 +102,12 @@ func (m Model) renderAuditSummary() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_security_audit.go
+++ b/internal/app/view_security_audit.go
@@ -28,9 +28,7 @@ func (m Model) renderAuditSummary() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.auditEvents == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No audit events found.", iw, normalRowStyle) + "\n"
 	} else {
 		timeCol := len("TIME") + 2

--- a/internal/app/view_security_failed_logins.go
+++ b/internal/app/view_security_failed_logins.go
@@ -28,9 +28,7 @@ func (m Model) renderFailedLogins() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.failedLogins == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No failed logins found.", iw, normalRowStyle) + "\n"
 	} else {
 		timeCol := len("TIME") + 2

--- a/internal/app/view_security_failed_logins.go
+++ b/internal/app/view_security_failed_logins.go
@@ -95,12 +95,12 @@ func (m Model) renderFailedLogins() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_security_selinux.go
+++ b/internal/app/view_security_selinux.go
@@ -99,12 +99,12 @@ func (m Model) renderSELinuxDenials() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-5", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_security_selinux.go
+++ b/internal/app/view_security_selinux.go
@@ -28,9 +28,7 @@ func (m Model) renderSELinuxDenials() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.selinuxDenials == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No SELinux denials found.", iw, normalRowStyle) + "\n"
 	} else {
 		timeCol := len("TIME") + 2

--- a/internal/app/view_security_sudo.go
+++ b/internal/app/view_security_sudo.go
@@ -102,12 +102,12 @@ func (m Model) renderSudoActivity() string {
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"\u2191\u2193", "Navigate"},
 		{"1-4", "Sort"},
 		{"/", "Search"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_security_sudo.go
+++ b/internal/app/view_security_sudo.go
@@ -28,9 +28,7 @@ func (m Model) renderSudoActivity() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.sudoEntries == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No sudo activity found.", iw, normalRowStyle) + "\n"
 	} else {
 		timeCol := len("TIME") + 2

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -159,9 +159,7 @@ func (m Model) renderServiceList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.serviceCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if m.services == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		if m.filterText != "" {
 			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
 		} else {

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -138,7 +138,7 @@ func (m Model) renderServiceList() string {
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"/", "Search"},
 			{"s", "Start"},
@@ -146,7 +146,7 @@ func (m Model) renderServiceList() string {
 			{"t", "Restart"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},
-		})
+		}))
 		return s
 	}
 
@@ -232,14 +232,14 @@ func (m Model) renderServiceList() string {
 	if m.filterActive {
 		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
 	} else {
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"1-4", "Sort"},
 			{"Enter", "Detail"},
 			{"/", "Search"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},
-		})
+		}))
 	}
 	return s
 }

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -21,7 +21,7 @@ func (m Model) renderSubscription() string {
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
 	if len(m.subscriptions) == 0 {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
+		s += borderedRow("  No subscription info.", iw, normalRowStyle) + "\n"
 	} else {
 		fieldCol := len("FIELD")
 		for _, sub := range m.subscriptions {

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -77,13 +77,13 @@ func (m Model) renderSubscription() string {
 	if h.Entry.SatelliteURL != "" {
 		regTarget = "Register Satellite"
 	}
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"u", "Unregister"},
 		{"g", regTarget},
 		{"d", "Disable Repo"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_updates.go
+++ b/internal/app/view_updates.go
@@ -59,10 +59,10 @@ func (m Model) renderUpdateList() string {
 
 		s = m.padToBottom(s, iw)
 		s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
-		s += m.renderHintBar([][]string{
+		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Scroll"},
 			{"Esc", "Back"},
-		})
+		}))
 		return s
 	}
 
@@ -149,7 +149,7 @@ func (m Model) renderUpdateList() string {
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 
-	s += m.renderHintBar([][]string{
+	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
 		{"1-3", "Sort"},
@@ -158,6 +158,6 @@ func (m Model) renderUpdateList() string {
 		{"p", "Security Only"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
-	})
+	}))
 	return s
 }

--- a/internal/app/view_updates.go
+++ b/internal/app/view_updates.go
@@ -76,9 +76,7 @@ func (m Model) renderUpdateList() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if m.updates == nil {
-		s += borderedRow("  Loading...", iw, normalRowStyle) + "\n"
-	} else if len(filtered) == 0 {
+	if len(filtered) == 0 {
 		s += borderedRow("  No pending updates.", iw, normalRowStyle) + "\n"
 	} else {
 		pkgCol := len("PACKAGE")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -69,6 +69,7 @@ type Host struct {
 	InterfacesUp    int
 	InterfacesTotal int
 	ListeningPorts  int
+	UpdateCount     int
 	Error           string
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -70,6 +70,7 @@ type Host struct {
 	InterfacesTotal int
 	ListeningPorts  int
 	UpdateCount     int
+	SudoReady       bool
 	Error           string
 }
 

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -305,7 +305,8 @@ func Probe(client *gossh.Client, systemdMode string, errorLogSince string) (Prob
 		`(getent passwd | awk -F: '$3 >= 1000 && $3 != 65534 {print $1}'; for d in /home/*/; do u=$(basename "$d"); getent passwd "$u" >/dev/null 2>&1 && echo "$u"; done) | sort -u | wc -l && ` +
 		`(ip -br link | grep -c UP || echo 0) && ` +
 		`ip -br link | wc -l && ` +
-		`(ss -tlnp 2>/dev/null | tail -n +2 | wc -l || echo 0)`
+		`(ss -tlnp 2>/dev/null | tail -n +2 | wc -l || echo 0) && ` +
+		`(sudo dnf check-update --quiet 2>/dev/null | grep -c '^\S' || echo 0)`
 
 	out, err := session.CombinedOutput(cmd)
 	if err != nil {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -131,7 +131,25 @@ func (sm *Manager) RunSudoCommand(idx int, cmd string) (string, error) {
 	if pw != "" {
 		cmd = rewriteSudoCmd(cmd, pw)
 	}
-	return sm.RunCommand(idx, cmd)
+	out, err := sm.RunCommand(idx, cmd)
+	if pw != "" {
+		out = stripSudoPrompt(out)
+	}
+	return out, err
+}
+
+// stripSudoPrompt removes "[sudo] password for ..." lines from output.
+// These leak into stdout when commands use 2>&1 with sudo -S.
+func stripSudoPrompt(s string) string {
+	var clean []string
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[sudo] password for") {
+			continue
+		}
+		clean = append(clean, line)
+	}
+	return strings.Join(clean, "\n")
 }
 
 // rewriteSudoCmd rewrites every "sudo " occurrence in cmd to pipe the password

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -306,7 +306,7 @@ func Probe(client *gossh.Client, systemdMode string, errorLogSince string) (Prob
 		`(ip -br link | grep -c UP || echo 0) && ` +
 		`ip -br link | wc -l && ` +
 		`(ss -tlnp 2>/dev/null | tail -n +2 | wc -l || echo 0) && ` +
-		`(sudo dnf check-update --quiet 2>/dev/null | grep -c '^\S' || echo 0)`
+		`(dnf check-update --quiet 2>/dev/null | grep -c '^\S' || echo 0)`
 
 	out, err := session.CombinedOutput(cmd)
 	if err != nil {

--- a/internal/ssh/probe.go
+++ b/internal/ssh/probe.go
@@ -20,6 +20,7 @@ type ProbeInfo struct {
 	InterfacesUp    int
 	InterfacesTotal int
 	ListeningPorts  int
+	UpdateCount     int
 	SystemdMode     string
 }
 
@@ -55,6 +56,7 @@ func FormatDateEU(s string) string {
 //	8: interfaces up
 //	9: interfaces total
 //	10: listening ports
+//	11: update count (dnf check-update)
 func ParseProbeOutput(output string, systemdMode string) (ProbeInfo, error) {
 	// Strip any shell warnings (e.g., "Could not chdir to home directory")
 	// that appear before the probe sentinel marker.
@@ -86,6 +88,7 @@ func ParseProbeOutput(output string, systemdMode string) (ProbeInfo, error) {
 		InterfacesUp:    getInt(8),
 		InterfacesTotal: getInt(9),
 		ListeningPorts:  getInt(10),
+		UpdateCount:     getInt(11),
 		SystemdMode:     systemdMode,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	defer logging.CloseAll()
 	logger.Info("fleetdesk starting", "version", version, "debug", debug, "fleets", len(fleets))
 
-	m := app.NewModel(fleets, appCfg, logger, version)
+	m := app.NewModel(fleets, appCfg, logger, version, commit)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	finalModel, err := p.Run()
 	if err != nil {


### PR DESCRIPTION
## Summary

- **FLE-66**: `?` keybind on all views shows a context-sensitive help overlay listing all keybinds grouped by Navigation/Actions/Global. Reuses existing `ModalOverlay` + `StaticContent`. All hint bars now end with `? Help`.
- **FLE-72**: `a` keybind on Fleet Picker opens an About modal showing version, commit hash, repository URL, and async-fetched CLI versions (Azure CLI, Azure identity, kubectl) with 5s timeout per command.
- **FLE-70**: All list-level fetch operations (services, containers, accounts, network, security, cron, disk, updates, subscription, Azure, K8s) now show a non-dismissable loading modal that auto-dismisses when data arrives. Type-safe `dismissLoading` only clears `LoadingContent` modals — sudo/confirm/about/help modals are unaffected.

## Files

- **New**: `help.go`, `modal_about.go`, `modal_loading.go` + tests
- **Modified**: `keys.go`, `modal.go`, `model.go`, `view_common.go`, `main.go`, all 34 `view_*.go`

## Test plan

- [x] Build passes
- [x] All 150+ unit tests pass (32 new)
- [ ] Manual: press `?` on various views — overlay shows, `Esc`/`?` dismiss
- [ ] Manual: press `a` on Fleet Picker — About modal with async CLI versions
- [ ] Manual: enter any resource view — loading modal appears, auto-dismisses on data
- [ ] Manual: `r` refresh on list views — loading modal with dimmed background
- [ ] Manual: sudo-protected views (firewall) — loading → sudo prompt sequence