### PR TITLE
feat: update options modal with multi-select content type (FLE-73)

### DIFF
--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -914,14 +914,38 @@ func (m Model) handleUpdateListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateCursor = 0
 	case "u":
 		h := m.hosts[m.selectedHost]
-		m.modal = NewConfirmModal("Confirm",
-			fmt.Sprintf("Apply ALL updates on %s? [Y/n]", h.Entry.Name),
-			sshHandover(h, []string{`sudo dnf update -y --setopt=skip_if_unavailable=1; echo ''; echo 'Update complete. Press Enter to return...'`}, fmt.Sprintf("full update on %s", h.Entry.Name)))
+		dnfOpts := []MultiSelectOption{
+			{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+			{Key: "--skip-broken", Label: "--skip-broken", Description: "skip failures"},
+			{Key: "--nobest", Label: "--nobest", Description: "allow older versions"},
+		}
+		banner := fmt.Sprintf("full update on %s", h.Entry.Name)
+		hh := h
+		m.modal = NewOptionsConfirmModal(
+			"Update Options",
+			fmt.Sprintf("Select flags for dnf update on %s:", h.Entry.Name),
+			dnfOpts,
+			func(keys []string) string { return buildDnfCommand("sudo dnf update", keys) },
+			func(cmd string) tea.Cmd { return sshHandover(hh, []string{cmd}, banner) },
+			func() tea.Cmd { return func() tea.Msg { return confirmCancelledMsg{} } },
+		)
 	case "p":
 		h := m.hosts[m.selectedHost]
-		m.modal = NewConfirmModal("Confirm",
-			fmt.Sprintf("Apply SECURITY updates on %s? [Y/n]", h.Entry.Name),
-			sshHandover(h, []string{`sudo dnf update --security -y --setopt=skip_if_unavailable=1; echo ''; echo 'Security update complete. Press Enter to return...'`}, fmt.Sprintf("security update on %s", h.Entry.Name)))
+		dnfOpts := []MultiSelectOption{
+			{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+			{Key: "--skip-broken", Label: "--skip-broken", Description: "skip failures"},
+			{Key: "--nobest", Label: "--nobest", Description: "allow older versions"},
+		}
+		banner := fmt.Sprintf("security update on %s", h.Entry.Name)
+		hh := h
+		m.modal = NewOptionsConfirmModal(
+			"Security Update Options",
+			fmt.Sprintf("Select flags for dnf update --security on %s:", h.Entry.Name),
+			dnfOpts,
+			func(keys []string) string { return buildDnfCommand("sudo dnf update --security", keys) },
+			func(cmd string) tea.Cmd { return sshHandover(hh, []string{cmd}, banner) },
+			func() tea.Cmd { return func() tea.Msg { return confirmCancelledMsg{} } },
+		)
 	case "1", "2", "3":
 		col := int(msg.Runes[0] - '0')
 		if col >= 1 && col <= 3 {

--- a/internal/app/modal.go
+++ b/internal/app/modal.go
@@ -377,3 +377,8 @@ func (c *ConfirmContent) View(width int) string {
 func (c *ConfirmContent) Result() any {
 	return c.confirmed
 }
+
+// SetMessage updates the confirmation message (used by multi-step wizards).
+func (c *ConfirmContent) SetMessage(s string) {
+	c.message = s
+}

--- a/internal/app/modal_multiselect.go
+++ b/internal/app/modal_multiselect.go
@@ -1,0 +1,88 @@
+package app
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// MultiSelectOption is one toggleable option in a MultiSelectContent step.
+type MultiSelectOption struct {
+	Key         string // returned in Result when selected
+	Label       string // short display name
+	Description string // shown dimmed after label
+}
+
+// MultiSelectContent is a checkbox-style multi-select modal step.
+type MultiSelectContent struct {
+	options  []MultiSelectOption
+	selected map[int]bool
+	cursor   int
+}
+
+// NewMultiSelectContent creates a multi-select step with the given options.
+func NewMultiSelectContent(options []MultiSelectOption) StepContent {
+	return &MultiSelectContent{
+		options:  options,
+		selected: make(map[int]bool),
+	}
+}
+
+func (ms *MultiSelectContent) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	switch msg.String() {
+	case "up", "k":
+		if ms.cursor > 0 {
+			ms.cursor--
+		}
+	case "down", "j":
+		if ms.cursor < len(ms.options)-1 {
+			ms.cursor++
+		}
+	case " ":
+		ms.selected[ms.cursor] = !ms.selected[ms.cursor]
+		if !ms.selected[ms.cursor] {
+			delete(ms.selected, ms.cursor)
+		}
+	case "enter":
+		return ms, nil, true
+	}
+	return ms, nil, false
+}
+
+func (ms *MultiSelectContent) View(width int) string {
+	var lines []string
+	for i, opt := range ms.options {
+		check := "[ ]"
+		if ms.selected[i] {
+			check = "\033[32m[x]\033[0m" // green
+		}
+
+		label := opt.Label
+		desc := ""
+		if opt.Description != "" {
+			desc = "  \033[38;5;241m" + opt.Description + "\033[0m" // dimmed
+		}
+
+		row := check + " " + label + desc
+
+		style := normalRowStyle
+		if i == ms.cursor {
+			style = selectedRowStyle
+		}
+		lines = append(lines, style.Render(row))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (ms *MultiSelectContent) Result() any {
+	var keys []string
+	for i, opt := range ms.options {
+		if ms.selected[i] {
+			keys = append(keys, opt.Key)
+		}
+	}
+	if keys == nil {
+		return []string{}
+	}
+	return keys
+}

--- a/internal/app/modal_multiselect_test.go
+++ b/internal/app/modal_multiselect_test.go
@@ -1,0 +1,249 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestMultiSelectContent_InitialState(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+		{Key: "--skip-broken", Label: "--skip-broken", Description: "skip failures"},
+	}
+	ms := NewMultiSelectContent(opts)
+	result := ms.Result().([]string)
+	if len(result) != 0 {
+		t.Errorf("initial Result() should be empty, got %v", result)
+	}
+}
+
+func TestMultiSelectContent_SpaceToggles(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+		{Key: "--skip-broken", Label: "--skip-broken", Description: "skip failures"},
+	}
+	ms := NewMultiSelectContent(opts)
+	// Space toggles first item
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	result := ms.Result().([]string)
+	if len(result) != 1 || result[0] != "--allowerasing" {
+		t.Errorf("after Space, Result() = %v, want [--allowerasing]", result)
+	}
+}
+
+func TestMultiSelectContent_SpaceUntoggles(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+	}
+	ms := NewMultiSelectContent(opts)
+	// Toggle on then off
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	result := ms.Result().([]string)
+	if len(result) != 0 {
+		t.Errorf("after double Space, Result() should be empty, got %v", result)
+	}
+}
+
+func TestMultiSelectContent_CursorDown(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+		{Key: "c", Label: "c", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	if ms.(*MultiSelectContent).cursor != 1 {
+		t.Errorf("cursor = %d, want 1", ms.(*MultiSelectContent).cursor)
+	}
+}
+
+func TestMultiSelectContent_CursorDownAtEnd(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown}) // past end
+	if ms.(*MultiSelectContent).cursor != 1 {
+		t.Errorf("cursor = %d, want 1 (clamped)", ms.(*MultiSelectContent).cursor)
+	}
+}
+
+func TestMultiSelectContent_CursorUpWithK(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if ms.(*MultiSelectContent).cursor != 0 {
+		t.Errorf("cursor = %d, want 0", ms.(*MultiSelectContent).cursor)
+	}
+}
+
+func TestMultiSelectContent_CursorUpAtZero(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if ms.(*MultiSelectContent).cursor != 0 {
+		t.Errorf("cursor = %d, want 0", ms.(*MultiSelectContent).cursor)
+	}
+}
+
+func TestMultiSelectContent_EnterDone(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	_, _, done := ms.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !done {
+		t.Error("Enter should return done=true")
+	}
+}
+
+func TestMultiSelectContent_EnterWithNoneSelected(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, done := ms.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if !done {
+		t.Error("Enter with 0 selected should still return done=true")
+	}
+	result := ms.Result().([]string)
+	if len(result) != 0 {
+		t.Errorf("Result() should be empty, got %v", result)
+	}
+}
+
+func TestMultiSelectContent_ResultOrder(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "first", Label: "first", Description: ""},
+		{Key: "second", Label: "second", Description: ""},
+		{Key: "third", Label: "third", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	// Select third, then first (out of order)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}}) // third
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}}) // first
+
+	result := ms.Result().([]string)
+	if len(result) != 2 {
+		t.Fatalf("len(Result()) = %d, want 2", len(result))
+	}
+	if result[0] != "first" {
+		t.Errorf("result[0] = %q, want %q", result[0], "first")
+	}
+	if result[1] != "third" {
+		t.Errorf("result[1] = %q, want %q", result[1], "third")
+	}
+}
+
+func TestMultiSelectContent_MultipleSelected(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+		{Key: "c", Label: "c", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	// Select all three
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	result := ms.Result().([]string)
+	if len(result) != 3 {
+		t.Errorf("len(Result()) = %d, want 3", len(result))
+	}
+}
+
+func TestMultiSelectContent_EscNotDone(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	_, cmd, done := ms.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if done {
+		t.Error("Esc should return done=false")
+	}
+	if cmd != nil {
+		t.Error("Esc should return cmd=nil")
+	}
+}
+
+func TestMultiSelectContent_ViewContainsLabels(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "Alpha", Description: "first letter"},
+		{Key: "b", Label: "Beta", Description: "second letter"},
+	}
+	ms := NewMultiSelectContent(opts)
+	view := ms.View(80)
+	if !strings.Contains(view, "Alpha") {
+		t.Error("View should contain label Alpha")
+	}
+	if !strings.Contains(view, "Beta") {
+		t.Error("View should contain label Beta")
+	}
+	if !strings.Contains(view, "first letter") {
+		t.Error("View should contain description")
+	}
+}
+
+func TestMultiSelectContent_ViewCheckedMarker(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "Alpha", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	view := ms.View(80)
+	if !strings.Contains(view, "[x]") {
+		t.Error("checked item should show [x]")
+	}
+}
+
+func TestMultiSelectContent_ViewUncheckedMarker(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "Alpha", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	view := ms.View(80)
+	if !strings.Contains(view, "[ ]") {
+		t.Error("unchecked item should show [ ]")
+	}
+}
+
+func TestMultiSelectContent_JKNavigation(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+		{Key: "c", Label: "c", Description: ""},
+	}
+	ms := NewMultiSelectContent(opts)
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if ms.(*MultiSelectContent).cursor != 1 {
+		t.Errorf("j: cursor = %d, want 1", ms.(*MultiSelectContent).cursor)
+	}
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if ms.(*MultiSelectContent).cursor != 2 {
+		t.Errorf("j: cursor = %d, want 2", ms.(*MultiSelectContent).cursor)
+	}
+	ms, _, _ = ms.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if ms.(*MultiSelectContent).cursor != 1 {
+		t.Errorf("k: cursor = %d, want 1", ms.(*MultiSelectContent).cursor)
+	}
+}

--- a/internal/app/modal_options_confirm.go
+++ b/internal/app/modal_options_confirm.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// optionsStep wraps a MultiSelectContent and mutates a ConfirmContent's message
+// when the user confirms their selection. This bridges step 1 → step 2 in a
+// 2-step ModalOverlay without modifying the overlay core.
+type optionsStep struct {
+	inner      *MultiSelectContent
+	confirmRef *ConfirmContent
+	cmdBuilder func([]string) string
+}
+
+func (o *optionsStep) HandleKey(msg tea.KeyMsg) (StepContent, tea.Cmd, bool) {
+	newInner, cmd, done := o.inner.HandleKey(msg)
+	o.inner = newInner.(*MultiSelectContent)
+	if done {
+		keys := o.inner.Result().([]string)
+		resolved := o.cmdBuilder(keys)
+		o.confirmRef.SetMessage(resolved)
+	}
+	return o, cmd, done
+}
+
+func (o *optionsStep) View(width int) string {
+	return o.inner.View(width)
+}
+
+func (o *optionsStep) Result() any {
+	return o.inner.Result()
+}
+
+// buildDnfCommand assembles a dnf command from a base and selected flags.
+// The base includes the dnf verb (e.g. "sudo dnf update" or "sudo dnf update --security").
+// Flags are inserted in order. --setopt=skip_if_unavailable=1 and -y are always appended.
+func buildDnfCommand(base string, flags []string) string {
+	parts := []string{base}
+	for _, f := range flags {
+		parts = append(parts, f)
+	}
+	parts = append(parts, "--setopt=skip_if_unavailable=1", "-y")
+	cmd := strings.Join(parts, " ")
+	cmd += "; echo ''; echo 'Done. Press Enter to return...'"
+	return cmd
+}
+
+// NewOptionsConfirmModal creates a 2-step modal: MultiSelect options → Confirm resolved command.
+//
+// Parameters:
+//   - title: modal title
+//   - step1Title: title shown above the options list
+//   - options: toggleable options for step 1
+//   - cmdBuilder: builds the resolved command string from selected keys
+//   - onConfirmFn: called with resolved command on confirmation, returns the tea.Cmd to execute
+//   - onCancel: called when the user cancels at step 1 or presses N at step 2
+func NewOptionsConfirmModal(
+	title string,
+	step1Title string,
+	options []MultiSelectOption,
+	cmdBuilder func([]string) string,
+	onConfirmFn func(string) tea.Cmd,
+	onCancel func() tea.Cmd,
+) *ModalOverlay {
+	confirm := &ConfirmContent{}
+	inner := NewMultiSelectContent(options).(*MultiSelectContent)
+
+	adapter := &optionsStep{
+		inner:      inner,
+		confirmRef: confirm,
+		cmdBuilder: cmdBuilder,
+	}
+
+	m := NewModalOverlay(title, []ModalStep{
+		{Title: step1Title, Content: adapter},
+		{Title: "", Content: confirm},
+	}, func(results []any) tea.Cmd {
+		confirmed := results[1].(bool)
+		if confirmed {
+			keys := results[0].([]string)
+			resolved := cmdBuilder(keys)
+			return onConfirmFn(resolved)
+		}
+		return func() tea.Msg {
+			return confirmCancelledMsg{}
+		}
+	}, onCancel)
+
+	m.FooterFn = func() string {
+		if m.current == 0 {
+			return modalKeyStyle.Render("Space") + " " + modalDimStyle.Render("toggle") +
+				"  " + modalKeyStyle.Render("Enter") + " " + modalDimStyle.Render("confirm") +
+				"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("cancel")
+		}
+		return modalKeyStyle.Render("Y/Enter") + " " + modalDimStyle.Render("confirm") +
+			"  " + modalKeyStyle.Render("N") + " " + modalDimStyle.Render("cancel") +
+			"  " + modalKeyStyle.Render("Esc") + " " + modalDimStyle.Render("back")
+	}
+
+	return m
+}

--- a/internal/app/modal_options_confirm_test.go
+++ b/internal/app/modal_options_confirm_test.go
@@ -1,0 +1,302 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestBuildDnfCommand_NoFlags(t *testing.T) {
+	cmd := buildDnfCommand("sudo dnf update", nil)
+	if !strings.Contains(cmd, "sudo dnf update") {
+		t.Error("should contain base command")
+	}
+	if !strings.Contains(cmd, "-y") {
+		t.Error("should always contain -y")
+	}
+	if !strings.Contains(cmd, "--setopt=skip_if_unavailable=1") {
+		t.Error("should always contain --setopt=skip_if_unavailable=1")
+	}
+	if !strings.Contains(cmd, "Press Enter to return") {
+		t.Error("should always contain echo suffix")
+	}
+}
+
+func TestBuildDnfCommand_OneFlag(t *testing.T) {
+	cmd := buildDnfCommand("sudo dnf update", []string{"--allowerasing"})
+	if !strings.Contains(cmd, "--allowerasing") {
+		t.Error("should contain the flag")
+	}
+	// Flag should appear before -y
+	flagIdx := strings.Index(cmd, "--allowerasing")
+	yIdx := strings.Index(cmd, "-y")
+	if flagIdx > yIdx {
+		t.Error("flag should appear before -y")
+	}
+}
+
+func TestBuildDnfCommand_MultipleFlags(t *testing.T) {
+	cmd := buildDnfCommand("sudo dnf update", []string{"--allowerasing", "--skip-broken", "--nobest"})
+	if !strings.Contains(cmd, "--allowerasing") {
+		t.Error("should contain --allowerasing")
+	}
+	if !strings.Contains(cmd, "--skip-broken") {
+		t.Error("should contain --skip-broken")
+	}
+	if !strings.Contains(cmd, "--nobest") {
+		t.Error("should contain --nobest")
+	}
+	// Order should be deterministic: allowerasing before skip-broken before nobest
+	i1 := strings.Index(cmd, "--allowerasing")
+	i2 := strings.Index(cmd, "--skip-broken")
+	i3 := strings.Index(cmd, "--nobest")
+	if i1 > i2 || i2 > i3 {
+		t.Errorf("flags out of order: allowerasing@%d, skip-broken@%d, nobest@%d", i1, i2, i3)
+	}
+}
+
+func TestBuildDnfCommand_SecurityBase(t *testing.T) {
+	cmd := buildDnfCommand("sudo dnf update --security", []string{"--nobest"})
+	if !strings.Contains(cmd, "sudo dnf update --security") {
+		t.Error("should contain security base")
+	}
+	if !strings.Contains(cmd, "--nobest") {
+		t.Error("should contain --nobest")
+	}
+}
+
+func TestBuildDnfCommand_EmptyFlags(t *testing.T) {
+	cmd := buildDnfCommand("sudo dnf update", []string{})
+	// Should not have double spaces
+	if strings.Contains(cmd, "  ") {
+		t.Error("empty flags should not produce double spaces")
+	}
+}
+
+// --- Full flow tests for NewOptionsConfirmModal ---
+
+func TestNewOptionsConfirmModal_ConfirmPath(t *testing.T) {
+	var gotCmd string
+	opts := []MultiSelectOption{
+		{Key: "--allowerasing", Label: "--allowerasing", Description: "replace conflicts"},
+		{Key: "--skip-broken", Label: "--skip-broken", Description: "skip failures"},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Update Options",
+		"Select flags",
+		opts,
+		func(keys []string) string {
+			return buildDnfCommand("sudo dnf update", keys)
+		},
+		func(cmd string) tea.Cmd {
+			return func() tea.Msg {
+				gotCmd = cmd
+				return confirmCancelledMsg{} // dummy msg for test
+			}
+		},
+		func() tea.Cmd { return nil },
+	)
+
+	// Step 1: toggle first option, then Enter
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}}) // toggle --allowerasing
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})                     // advance to step 2
+
+	if m.current != 1 {
+		t.Fatalf("expected step 1 (confirm), got step %d", m.current)
+	}
+
+	// Step 2: confirm with Y
+	cmd := m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
+	if cmd == nil {
+		t.Fatal("Y on step 2 should return a cmd")
+	}
+	// Execute the cmd to capture gotCmd
+	cmd()
+	if !strings.Contains(gotCmd, "--allowerasing") {
+		t.Errorf("resolved cmd should contain --allowerasing, got %q", gotCmd)
+	}
+}
+
+func TestNewOptionsConfirmModal_NCancels(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "--nobest", Label: "--nobest", Description: "allow older"},
+	}
+
+	cancelled := false
+	m := NewOptionsConfirmModal(
+		"Update Options",
+		"Select flags",
+		opts,
+		func(keys []string) string { return "test cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd {
+			cancelled = true
+			return nil
+		},
+	)
+
+	// Step 1: Enter (no flags selected)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	// Step 2: N to cancel
+	cmd := m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+
+	if m.Done() != true {
+		t.Error("modal should be done after N")
+	}
+	// The cmd should produce confirmCancelledMsg
+	if cmd != nil {
+		msg := cmd()
+		if _, ok := msg.(confirmCancelledMsg); !ok {
+			t.Errorf("N should produce confirmCancelledMsg, got %T", msg)
+		}
+	}
+	_ = cancelled
+}
+
+func TestNewOptionsConfirmModal_EscStep2GoesBack(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string { return "cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd { return nil },
+	)
+
+	// Step 1: toggle and Enter
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	if m.current != 1 {
+		t.Fatalf("expected step 1, got %d", m.current)
+	}
+
+	// Esc from step 2 should go back to step 1
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.current != 0 {
+		t.Errorf("expected step 0 after Esc, got %d", m.current)
+	}
+}
+
+func TestNewOptionsConfirmModal_SelectionPreservedOnBack(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+		{Key: "b", Label: "b", Description: ""},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string { return "cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd { return nil },
+	)
+
+	// Step 1: toggle first, Enter
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Esc back to step 1
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+
+	// Check selection is preserved via the optionsStep adapter
+	step := m.steps[0].Content.(*optionsStep)
+	result := step.inner.Result().([]string)
+	if len(result) != 1 || result[0] != "a" {
+		t.Errorf("selection should be preserved after Esc-back, got %v", result)
+	}
+}
+
+func TestNewOptionsConfirmModal_EscStep1Cancels(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+
+	cancelled := false
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string { return "cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd {
+			cancelled = true
+			return nil
+		},
+	)
+
+	// Esc at step 0
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !cancelled {
+		t.Error("Esc at step 0 should call onCancel")
+	}
+}
+
+func TestNewOptionsConfirmModal_Step2MessageContainsCmd(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "--nobest", Label: "--nobest", Description: ""},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string {
+			return buildDnfCommand("sudo dnf update", keys)
+		},
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd { return nil },
+	)
+
+	// Toggle --nobest, advance
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Step 2 view should contain the resolved command
+	view := m.steps[1].Content.View(80)
+	if !strings.Contains(view, "--nobest") {
+		t.Errorf("step 2 view should contain --nobest, got %q", view)
+	}
+}
+
+func TestNewOptionsConfirmModal_FooterStep1(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string { return "cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd { return nil },
+	)
+
+	footer := m.FooterFn()
+	if !strings.Contains(footer, "Space") {
+		t.Error("step 1 footer should contain Space")
+	}
+	if !strings.Contains(footer, "toggle") {
+		t.Error("step 1 footer should contain toggle")
+	}
+}
+
+func TestNewOptionsConfirmModal_FooterStep2(t *testing.T) {
+	opts := []MultiSelectOption{
+		{Key: "a", Label: "a", Description: ""},
+	}
+
+	m := NewOptionsConfirmModal(
+		"Test", "Pick", opts,
+		func(keys []string) string { return "cmd" },
+		func(cmd string) tea.Cmd { return nil },
+		func() tea.Cmd { return nil },
+	)
+
+	// Advance to step 2
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyEnter})
+	footer := m.FooterFn()
+	if !strings.Contains(footer, "Y/Enter") {
+		t.Error("step 2 footer should contain Y/Enter")
+	}
+	if !strings.Contains(footer, "back") {
+		t.Error("step 2 footer should contain back")
+	}
+}


### PR DESCRIPTION
## Summary

- Add reusable `MultiSelectContent` content type to the Modal Overlay Pattern (checkbox-style toggle with j/k/Space/Enter)
- Add `NewOptionsConfirmModal` — 2-step modal: flag picker → confirm with full resolved command
- Replace direct confirm modal on `u`/`p` keys with options modal for `--allowerasing`, `--skip-broken`, `--nobest` flag selection
- 29 new unit tests covering MultiSelectContent, buildDnfCommand, and full 2-step flow

Closes FLE-73