### PR TITLE
feat: add probes fleet type for HTTP endpoint monitoring (FLE-74)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
 )
 
@@ -1942,4 +1943,71 @@ func parseStreamLine(line string) k8s.K8sLogEntry {
 		return k8s.K8sLogEntry{}
 	}
 	return entry
+}
+
+// startProbing launches all probe goroutines and returns the first listenForProbeResults cmd.
+func (m *Model) startProbing() tea.Cmd {
+	if m.probesStreaming {
+		m.stopProbing()
+	}
+
+	f := m.fleets[m.selectedFleet]
+	if f.ProbeFleet == nil {
+		return nil
+	}
+
+	m.probesGeneration++
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.probesCancel = cancel
+
+	ch := make(chan probes.ProbeResult, 200)
+	m.probesChan = ch
+	m.probesStreaming = true
+
+	entries := m.probeEntries()
+	defaults := f.ProbeFleet.Defaults
+	mgr := m.probesManager
+	mgr.Start(ctx, entries, defaults, ch)
+
+	return m.listenForProbeResults()
+}
+
+// stopProbing cancels all probe goroutines and clears channel state.
+func (m *Model) stopProbing() {
+	if m.probesCancel != nil {
+		m.probesCancel()
+		m.probesCancel = nil
+	}
+	m.probesChan = nil
+	m.probesStreaming = false
+}
+
+// listenForProbeResults blocks on the probe channel, batches up to 50 results, returns probeResultBatchMsg.
+func (m Model) listenForProbeResults() tea.Cmd {
+	ch := m.probesChan
+	if ch == nil {
+		return nil
+	}
+	gen := m.probesGeneration
+	return func() tea.Msg {
+		first, ok := <-ch
+		if !ok {
+			return probesDoneMsg{generation: gen}
+		}
+		batch := []probes.ProbeResult{first}
+		// Drain buffered results non-blocking, up to 50
+		for len(batch) < 50 {
+			select {
+			case r, ok := <-ch:
+				if !ok {
+					return probeResultBatchMsg{results: batch, generation: gen}
+				}
+				batch = append(batch, r)
+			default:
+				return probeResultBatchMsg{results: batch, generation: gen}
+			}
+		}
+		return probeResultBatchMsg{results: batch, generation: gen}
+	}
 }

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
 )
 
@@ -1328,4 +1329,128 @@ func (m *Model) sortK8sPodLogs() {
 		}
 		return !less
 	})
+}
+
+// ProbeItem is the runtime representation of a probe with its last result.
+type ProbeItem struct {
+	Entry  config.ProbeEntry
+	Group  string
+	Result probes.ProbeResult
+}
+
+// buildProbeList creates the initial ProbeItem list from a ProbeFleet.
+func buildProbeList(pf *config.ProbeFleet) []ProbeItem {
+	var items []ProbeItem
+	idx := 0
+	for _, g := range pf.Groups {
+		for _, p := range g.Probes {
+			items = append(items, ProbeItem{
+				Entry: p,
+				Group: g.Name,
+				Result: probes.ProbeResult{
+					ProbeIndex: idx,
+					Status:     probes.ProbeStatusPending,
+					Error:      probes.ErrorClassNone,
+				},
+			})
+			idx++
+		}
+	}
+	for _, p := range pf.Probes {
+		items = append(items, ProbeItem{
+			Entry: p,
+			Group: "",
+			Result: probes.ProbeResult{
+				ProbeIndex: idx,
+				Status:     probes.ProbeStatusPending,
+				Error:      probes.ErrorClassNone,
+			},
+		})
+		idx++
+	}
+	return items
+}
+
+// fleetProbeCount returns the total number of probe entries in a probes fleet.
+func fleetProbeCount(f config.Fleet) int {
+	if f.ProbeFleet == nil {
+		return 0
+	}
+	count := len(f.ProbeFleet.Probes)
+	for _, g := range f.ProbeFleet.Groups {
+		count += len(g.Probes)
+	}
+	return count
+}
+
+// filteredProbeItems returns probe items matching the filter text (name or URL).
+func (m Model) filteredProbeItems() []ProbeItem {
+	if m.filterText == "" {
+		return m.probeItems
+	}
+	f := strings.ToLower(m.filterText)
+	var result []ProbeItem
+	for _, p := range m.probeItems {
+		if strings.Contains(strings.ToLower(p.Entry.Name), f) ||
+			strings.Contains(strings.ToLower(p.Entry.URL), f) ||
+			strings.Contains(strings.ToLower(p.Result.Status.String()), f) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// sortProbeItems sorts the probe list: down first, then degraded, then up, then pending.
+func (m *Model) sortProbeItems() {
+	statusOrder := func(s probes.ProbeStatus) int {
+		switch s {
+		case probes.ProbeStatusDown:
+			return 0
+		case probes.ProbeStatusDegraded:
+			return 1
+		case probes.ProbeStatusUp:
+			return 2
+		default: // Pending
+			return 3
+		}
+	}
+
+	sort.Slice(m.probeItems, func(i, j int) bool {
+		si := statusOrder(m.probeItems[i].Result.Status)
+		sj := statusOrder(m.probeItems[j].Result.Status)
+		if m.sortColumn == 0 {
+			if si != sj {
+				return si < sj
+			}
+			return strings.ToLower(m.probeItems[i].Entry.Name) < strings.ToLower(m.probeItems[j].Entry.Name)
+		}
+		var less bool
+		switch m.sortColumn {
+		case 1:
+			less = strings.ToLower(m.probeItems[i].Entry.Name) < strings.ToLower(m.probeItems[j].Entry.Name)
+		case 2:
+			less = strings.ToLower(m.probeItems[i].Entry.URL) < strings.ToLower(m.probeItems[j].Entry.URL)
+		case 3:
+			less = si < sj
+		case 4:
+			less = m.probeItems[i].Result.Code < m.probeItems[j].Result.Code
+		case 5:
+			less = m.probeItems[i].Result.Latency < m.probeItems[j].Result.Latency
+		default:
+			return false
+		}
+		if m.sortAsc {
+			return less
+		}
+		return !less
+	})
+}
+
+// probeEntries returns a flat list of ProbeEntry from the current probeItems.
+func (m Model) probeEntries() []config.ProbeEntry {
+	entries := make([]config.ProbeEntry, len(m.probeItems))
+	for i, p := range m.probeItems {
+		entries[i] = p.Entry
+	}
+	return entries
 }

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -244,6 +244,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleK8sPodDetailKeys(msg)
 	case viewK8sPodLogs:
 		return m.handleK8sPodLogKeys(msg)
+	case viewProbeList:
+		return m.handleProbeListKeys(msg)
+	case viewProbeDetail:
+		return m.handleProbeDetailKeys(msg)
 	case viewConfig:
 		return m.handleConfigKeys(msg)
 	}
@@ -325,6 +329,15 @@ func (m Model) handleFleetPickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.k8sClusterCursor = 0
 				m.view = viewK8sClusterList
 				return m, m.startK8sProbe()
+			case "probes":
+				m.selectedFleet = m.fleetCursor
+				m.probeItems = buildProbeList(f.ProbeFleet)
+				m.probeCursor = 0
+				m.sortColumn = 0
+				m.filterText = ""
+				m.filterActive = false
+				m.view = viewProbeList
+				return m, m.startProbing()
 			default:
 				m.flash = "Unsupported fleet type"
 				m.flashError = false
@@ -2607,6 +2620,94 @@ func (m Model) handleK8sPodLogKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.k8sPodLogCancel != nil {
 			m.k8sPodLogCancel()
 		}
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleProbeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	filtered := m.filteredProbeItems()
+
+	if m.filterActive {
+		switch msg.String() {
+		case "enter":
+			m.filterActive = false
+			m.probeCursor = 0
+		case "esc":
+			m.filterActive = false
+			m.filterText = ""
+			m.probeCursor = 0
+		case "backspace":
+			if len(m.filterText) > 0 {
+				m.filterText = m.filterText[:len(m.filterText)-1]
+				m.probeCursor = 0
+			}
+		default:
+			if len(msg.String()) == 1 {
+				m.filterText += msg.String()
+				m.probeCursor = 0
+			}
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.probeCursor > 0 {
+			m.probeCursor--
+		}
+	case "down", "j":
+		if m.probeCursor < len(filtered)-1 {
+			m.probeCursor++
+		}
+	case "enter":
+		if len(filtered) > 0 {
+			m.selectedProbe = m.probeCursor
+			m.probeDetailScroll = 0
+			m.view = viewProbeDetail
+		}
+	case "esc":
+		m.stopProbing()
+		m.view = viewFleetPicker
+	case "/":
+		m.filterActive = true
+		m.filterText = ""
+	case "r":
+		// Force re-probe: stop and restart
+		m.stopProbing()
+		return m, m.startProbing()
+	case "1", "2", "3", "4", "5":
+		col := int(msg.String()[0] - '0')
+		if col == m.sortColumn {
+			m.sortAsc = !m.sortAsc
+		} else {
+			m.sortColumn = col
+			m.sortAsc = true
+		}
+		m.sortProbeItems()
+	case "q":
+		m.stopProbing()
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleProbeDetailKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.view = viewProbeList
+	case "up", "k":
+		if m.probeDetailScroll > 0 {
+			m.probeDetailScroll--
+		}
+	case "down", "j":
+		m.probeDetailScroll++
+	case "r":
+		// Force re-probe: stop and restart
+		m.stopProbing()
+		return m, m.startProbing()
+	case "q":
+		m.stopProbing()
 		return m, tea.Quit
 	}
 	return m, nil

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -11,8 +11,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
-	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
 )
 
@@ -69,6 +70,15 @@ type pollResultMsg struct {
 
 type transitionExpireMsg struct {
 	key string
+}
+
+type probeResultBatchMsg struct {
+	results    []probes.ProbeResult
+	generation int
+}
+
+type probesDoneMsg struct {
+	generation int
 }
 
 type fetchAzureAKSMsg struct {
@@ -219,6 +229,8 @@ const (
 	viewK8sPodList
 	viewK8sPodDetail
 	viewK8sPodLogs
+	viewProbeList
+	viewProbeDetail
 	viewConfig
 )
 
@@ -311,6 +323,17 @@ type Model struct {
 	k8sLogDetailScroll    int  // scroll offset for log detail view
 	k8sLogDetailWasStreaming bool // resume streaming after closing detail
 	k8sPodLogFromDetail   bool // true when logs opened from pod detail (Esc returns to detail)
+
+	// probes fleet
+	probesManager     *probes.Manager
+	probeItems        []ProbeItem
+	probeCursor       int
+	selectedProbe     int
+	probeDetailScroll int
+	probesCancel      context.CancelFunc
+	probesChan        chan probes.ProbeResult
+	probesStreaming   bool
+	probesGeneration  int // incremented on each startProbing, used to discard stale messages
 
 	// metrics dashboard
 	metrics          map[int]config.HostMetrics
@@ -446,8 +469,9 @@ func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logge
 		appCfg:  appCfg,
 		ssh:     ssh.NewManager(logger),
 		azure:   azure.NewManager(logger),
-		k8s:     k8s.NewManager(logger),
-		logger:  logger,
+		k8s:           k8s.NewManager(logger),
+		probesManager: probes.NewManager(logger),
+		logger:        logger,
 		version: version,
 		commit:  commit,
 	}
@@ -1020,6 +1044,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case k8sPodLogDoneMsg:
 		m.k8sPodLogChan = nil
 		m.k8sPodLogStreaming = false
+		return m, nil
+
+	case probeResultBatchMsg:
+		if msg.generation != m.probesGeneration {
+			return m, nil // stale message from previous session
+		}
+		for _, r := range msg.results {
+			// Look up by ProbeIndex identity, not by slice position (sort reorders the slice).
+			for i := range m.probeItems {
+				if m.probeItems[i].Result.ProbeIndex == r.ProbeIndex {
+					m.probeItems[i].Result = r
+					break
+				}
+			}
+		}
+		if m.probesChan != nil {
+			return m, m.listenForProbeResults()
+		}
+		return m, nil
+
+	case probesDoneMsg:
+		if msg.generation != m.probesGeneration {
+			return m, nil // stale done from previous session
+		}
+		m.probesChan = nil
+		m.probesStreaming = false
 		return m, nil
 
 	case fetchAzureAKSMsg:
@@ -1722,6 +1772,10 @@ func (m Model) renderCurrentView() string {
 		return m.renderK8sPodDetail()
 	case viewK8sPodLogs:
 		return m.renderK8sPodLogs()
+	case viewProbeList:
+		return m.renderProbeList()
+	case viewProbeDetail:
+		return m.renderProbeDetail()
 	}
 	return ""
 }

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -59,6 +59,8 @@ func (m Model) renderFleetPicker() string {
 					label = "Kubernetes"
 				} else if label == "azure" {
 					label = "Azure"
+				} else if label == "probes" {
+					label = "Probes"
 				} else {
 					label = "VM"
 				}
@@ -85,9 +87,12 @@ func (m Model) renderFleetPicker() string {
 				ftype = "k8s"
 			}
 			var targetCount int
-			if f.Type == "vm" {
+			switch f.Type {
+			case "vm":
 				targetCount = m.fleetHostCount(f)
-			} else {
+			case "probes":
+				targetCount = fleetProbeCount(f)
+			default:
 				targetCount = len(f.Groups)
 			}
 			line := fmt.Sprintf("%s  %-*s  %-6s  %d", cur, nameCol, f.Name, ftype, targetCount)

--- a/internal/app/view_probe_detail.go
+++ b/internal/app/view_probe_detail.go
@@ -1,0 +1,176 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
+)
+
+func (m Model) renderProbeDetail() string {
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	filtered := m.filteredProbeItems()
+	if m.selectedProbe >= len(filtered) || len(filtered) == 0 {
+		return m.renderProbeList()
+	}
+	p := filtered[m.selectedProbe]
+	r := p.Result
+
+	f := m.fleets[m.selectedFleet]
+	breadcrumb := fmt.Sprintf("%s › %s", f.Name, p.Entry.Name)
+	s := m.renderHeader(breadcrumb, 0, 0) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	// Build content lines
+	var content strings.Builder
+
+	// Summary section
+	content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+	content.WriteString(borderedRow("  ── Summary ──", iw, colHeaderStyle) + "\n")
+	content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+
+	statusStr, statusColor := probeStatusDisplay(r.Status)
+
+	kvSummary := []struct{ k, v string }{
+		{"Name", p.Entry.Name},
+		{"URL", p.Entry.URL},
+		{"Protocol", p.Entry.Protocol},
+		{"Expected Code", fmt.Sprintf("%d", p.Entry.ExpectedCode)},
+		{"Status", statusColor(statusStr)},
+	}
+	if !r.ProbeTime.IsZero() {
+		kvSummary = append(kvSummary, struct{ k, v string }{"Last Check", r.ProbeTime.Format(time.TimeOnly)})
+	}
+	keyWidth := 0
+	for _, kv := range kvSummary {
+		if len(kv.k) > keyWidth {
+			keyWidth = len(kv.k)
+		}
+	}
+	for _, kv := range kvSummary {
+		line := fmt.Sprintf("    %-*s  %s", keyWidth, kv.k, kv.v)
+		content.WriteString(borderedRow(line, iw, normalRowStyle) + "\n")
+	}
+
+	// Timing section
+	content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+	content.WriteString(borderedRow("  ── Timing ──", iw, colHeaderStyle) + "\n")
+	content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+
+	latencyStr := "---"
+	if r.Latency > 0 {
+		latencyStr = formatLatency(r.Latency)
+	}
+	ttfbStr := "---"
+	if r.TTFB > 0 {
+		ttfbStr = formatLatency(r.TTFB)
+	}
+	kvTiming := []struct{ k, v string }{
+		{"Latency", latencyStr},
+		{"TTFB", ttfbStr},
+	}
+	for _, kv := range kvTiming {
+		line := fmt.Sprintf("    %-*s  %s", keyWidth, kv.k, kv.v)
+		content.WriteString(borderedRow(line, iw, normalRowStyle) + "\n")
+	}
+
+	// TLS section (conditional — hidden on plain HTTP)
+	if r.TLS != nil {
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+		content.WriteString(borderedRow("  ── TLS ──", iw, colHeaderStyle) + "\n")
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+
+		expiryStr := r.TLS.Expiry.Format("2006-01-02")
+		daysStr := fmt.Sprintf("%d days", r.TLS.DaysToExpiry)
+		if r.TLS.DaysToExpiry < probes.CertWarnDays {
+			daysStr = "\033[33m" + daysStr + "\033[0m" // yellow warning
+		}
+
+		kvTLS := []struct{ k, v string }{
+			{"Version", r.TLS.Version},
+			{"Issuer", r.TLS.Issuer},
+			{"Subject", r.TLS.Subject},
+			{"Expires", fmt.Sprintf("%s (%s)", expiryStr, daysStr)},
+		}
+		for _, kv := range kvTLS {
+			line := fmt.Sprintf("    %-*s  %s", keyWidth, kv.k, kv.v)
+			content.WriteString(borderedRow(line, iw, normalRowStyle) + "\n")
+		}
+	}
+
+	// Response section
+	if r.Code > 0 || r.BodyPreview != "" {
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+		content.WriteString(borderedRow("  ── Response ──", iw, colHeaderStyle) + "\n")
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+
+		if r.Code > 0 {
+			codeLine := fmt.Sprintf("    %-*s  %d", keyWidth, "Status Code", r.Code)
+			content.WriteString(borderedRow(codeLine, iw, normalRowStyle) + "\n")
+		}
+
+		if r.BodyPreview != "" {
+			content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+			bodyLines := strings.Split(r.BodyPreview, "\n")
+			for _, bl := range bodyLines {
+				content.WriteString(borderedRow("    "+bl, iw, normalRowStyle) + "\n")
+			}
+		}
+	}
+
+	// Error section (conditional)
+	if r.Error != probes.ErrorClassNone && r.ErrorMsg != "" {
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+		content.WriteString(borderedRow("  ── Error ──", iw, colHeaderStyle) + "\n")
+		content.WriteString(borderedRow("", iw, normalRowStyle) + "\n")
+
+		kvErr := []struct{ k, v string }{
+			{"Class", string(r.Error)},
+			{"Detail", r.ErrorMsg},
+		}
+		for _, kv := range kvErr {
+			line := fmt.Sprintf("    %-*s  %s", keyWidth, kv.k, kv.v)
+			content.WriteString(borderedRow(line, iw, normalRowStyle) + "\n")
+		}
+	}
+
+	// Apply scroll
+	contentStr := content.String()
+	contentLines := strings.Split(contentStr, "\n")
+	if len(contentLines) > 0 && contentLines[len(contentLines)-1] == "" {
+		contentLines = contentLines[:len(contentLines)-1]
+	}
+
+	maxVisible := m.height - 4
+	if maxVisible < 3 {
+		maxVisible = 3
+	}
+	startLine := m.probeDetailScroll
+	if startLine >= len(contentLines) {
+		startLine = max(0, len(contentLines)-1)
+	}
+	endLine := startLine + maxVisible
+	if endLine > len(contentLines) {
+		endLine = len(contentLines)
+	}
+
+	for _, line := range contentLines[startLine:endLine] {
+		s += line + "\n"
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
+	s += m.renderHintBar(hintWithHelp([][]string{
+		{"↑↓", "Scroll"},
+		{"r", "Refresh"},
+		{"Esc", "Back"},
+		{"q", "Quit"},
+	}))
+	return s
+}

--- a/internal/app/view_probe_list.go
+++ b/internal/app/view_probe_list.go
@@ -1,0 +1,190 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
+)
+
+func (m Model) renderProbeList() string {
+	f := m.fleets[m.selectedFleet]
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	filtered := m.filteredProbeItems()
+	filterInfo := ""
+	if m.filterText != "" {
+		filterInfo = fmt.Sprintf(" [filter: %s]", m.filterText)
+	}
+
+	cur := 0
+	if len(filtered) > 0 {
+		cur = m.probeCursor + 1
+	}
+	s := m.renderHeader(f.Name+filterInfo, cur, len(filtered)) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	// Live status indicator
+	s += borderedRow("  "+ansiColor("● LIVE", "32"), iw, normalRowStyle) + "\n"
+
+	if len(filtered) == 0 {
+		msg := "  No probes"
+		if m.filterText != "" {
+			msg += " matching filter"
+		}
+		s += borderedRow(msg, iw, normalRowStyle) + "\n"
+	} else {
+		// Compute column widths
+		nameCol := len("NAME")
+		urlCol := len("URL")
+		for _, p := range filtered {
+			if len(p.Entry.Name) > nameCol {
+				nameCol = len(p.Entry.Name)
+			}
+			if len(p.Entry.URL) > urlCol {
+				urlCol = len(p.Entry.URL)
+			}
+		}
+		nameCol += 2
+		// Cap URL column to leave room for status/code/latency
+		maxURL := iw - nameCol - 35
+		if maxURL < 10 {
+			maxURL = 10
+		}
+		if urlCol > maxURL {
+			urlCol = maxURL
+		}
+
+		hdr := fmt.Sprintf("     %-*s  %-*s  %-8s  %-4s  %s",
+			nameCol, "NAME"+m.sortIndicator(1),
+			urlCol, "URL"+m.sortIndicator(2),
+			"STATUS"+m.sortIndicator(3),
+			"CODE"+m.sortIndicator(4),
+			"LATENCY"+m.sortIndicator(5),
+		)
+		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
+		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+
+		maxVisible := m.height - 8
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+		offset := 0
+		if m.probeCursor >= offset+maxVisible {
+			offset = m.probeCursor - maxVisible + 1
+		}
+		end := offset + maxVisible
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+
+		// Build group start map
+		groupStarts := make(map[int]string)
+		lastGroup := ""
+		for i, p := range filtered {
+			if p.Group != "" && p.Group != lastGroup {
+				groupStarts[i] = p.Group
+				lastGroup = p.Group
+			}
+		}
+
+		for i := offset; i < end; i++ {
+			// Group header
+			if groupName, ok := groupStarts[i]; ok {
+				groupLine := fmt.Sprintf("  ── %s ──", groupName)
+				s += borderedRow(groupLine, iw, groupHeaderStyle) + "\n"
+			}
+
+			p := filtered[i]
+			cursor := "   "
+			if i == m.probeCursor {
+				cursor = " ▸ "
+			}
+
+			// Status display
+			statusStr, statusColor := probeStatusDisplay(p.Result.Status)
+
+			// Code
+			codeStr := "---"
+			if p.Result.Code > 0 {
+				codeStr = fmt.Sprintf("%d", p.Result.Code)
+			}
+
+			// Latency
+			latencyStr := "---"
+			if p.Result.Status != probes.ProbeStatusPending && p.Result.Latency > 0 {
+				latencyStr = formatLatency(p.Result.Latency)
+			}
+
+			// Truncate URL if needed
+			urlStr := p.Entry.URL
+			if len(urlStr) > urlCol {
+				urlStr = urlStr[:urlCol-1] + "…"
+			}
+
+			line := fmt.Sprintf("%s  %-*s  %-*s  %s  %-4s  %s",
+				cursor,
+				nameCol, p.Entry.Name,
+				urlCol, urlStr,
+				statusColor(fmt.Sprintf("%-8s", statusStr)),
+				codeStr,
+				latencyStr,
+			)
+
+			var style lipgloss.Style
+			if i == m.probeCursor {
+				style = selectedRowStyle
+			} else if i%2 == 0 {
+				style = altRowStyle
+			} else {
+				style = normalRowStyle
+			}
+			s += borderedRow(line, iw, style) + "\n"
+		}
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
+
+	if m.filterActive {
+		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
+	} else {
+		s += m.renderHintBar(hintWithHelp([][]string{
+			{"↑↓", "Navigate"},
+			{"Enter", "Detail"},
+			{"r", "Refresh"},
+			{"/", "Filter"},
+			{"1-5", "Sort"},
+			{"Esc", "Back"},
+			{"q", "Quit"},
+		}))
+	}
+	return s
+}
+
+func probeStatusDisplay(status probes.ProbeStatus) (string, func(string) string) {
+	switch status {
+	case probes.ProbeStatusUp:
+		return "UP", func(s string) string { return "\033[32m" + s + "\033[0m" }
+	case probes.ProbeStatusDown:
+		return "DOWN", func(s string) string { return "\033[31m" + s + "\033[0m" }
+	case probes.ProbeStatusDegraded:
+		return "DEGRADED", func(s string) string { return "\033[33m" + s + "\033[0m" }
+	default:
+		return "---", func(s string) string { return "\033[90m" + s + "\033[0m" }
+	}
+}
+
+func formatLatency(d interface{ Milliseconds() int64 }) string {
+	ms := d.Milliseconds()
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	return fmt.Sprintf("%.1fs", float64(ms)/1000)
+}

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,6 +55,34 @@ type hostEntryFile struct {
 	SatelliteURL    string   `yaml:"satellite_url"`
 }
 
+// probeFleetFile is the raw YAML structure for a probes fleet file.
+type probeFleetFile struct {
+	Name     string              `yaml:"name"`
+	Type     string              `yaml:"type"`
+	Defaults probeDefaultsFile   `yaml:"defaults"`
+	Groups   []probeGroupFile    `yaml:"groups"`
+	Probes   []probeEntryFile    `yaml:"probes"`
+}
+
+type probeDefaultsFile struct {
+	Interval string `yaml:"interval"`
+	Proxy    string `yaml:"proxy"`
+	Timeout  string `yaml:"timeout"`
+}
+
+type probeGroupFile struct {
+	Name   string           `yaml:"name"`
+	Probes []probeEntryFile `yaml:"probes"`
+}
+
+type probeEntryFile struct {
+	Name         string `yaml:"name"`
+	URL          string `yaml:"url"`
+	Protocol     string `yaml:"protocol"`
+	ExpectedCode int    `yaml:"expected_code"`
+	Interval     string `yaml:"interval"`
+}
+
 // ParseFleetFile reads and parses a single fleet YAML file.
 func ParseFleetFile(path string) (Fleet, error) {
 	data, err := os.ReadFile(path)
@@ -76,11 +105,13 @@ func ParseFleetFile(path string) (Fleet, error) {
 	// validate type
 	switch raw.Type {
 	case "vm", "azure", "kubernetes":
-		// valid
+		// valid — parsed below
+	case "probes":
+		return parseProbeFleetFile(data, name, path)
 	case "":
 		return Fleet{}, fmt.Errorf("missing required field 'type' in %s", path)
 	default:
-		return Fleet{}, fmt.Errorf("unknown fleet type %q in %s (must be vm, azure, or kubernetes)", raw.Type, path)
+		return Fleet{}, fmt.Errorf("unknown fleet type %q in %s (must be vm, azure, kubernetes, or probes)", raw.Type, path)
 	}
 
 	// parse defaults
@@ -221,4 +252,134 @@ func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string
 		hosts = append(hosts, h)
 	}
 	return hosts, nil
+}
+
+// parseProbeFleetFile parses a probes fleet YAML file into a Fleet with ProbeFleet set.
+func parseProbeFleetFile(data []byte, name, path string) (Fleet, error) {
+	var raw probeFleetFile
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return Fleet{}, fmt.Errorf("parsing probes YAML: %w", err)
+	}
+
+	if raw.Name != "" {
+		name = raw.Name
+	}
+
+	// parse defaults
+	defaults := ProbeDefaults{
+		Interval: 30 * time.Second,
+		Timeout:  10 * time.Second,
+	}
+	if raw.Defaults.Interval != "" {
+		d, err := time.ParseDuration(raw.Defaults.Interval)
+		if err != nil {
+			return Fleet{}, fmt.Errorf("invalid default interval %q: %w", raw.Defaults.Interval, err)
+		}
+		if d < 5*time.Second {
+			return Fleet{}, fmt.Errorf("default interval %v must be >= 5s", d)
+		}
+		defaults.Interval = d
+	}
+	if raw.Defaults.Timeout != "" {
+		d, err := time.ParseDuration(raw.Defaults.Timeout)
+		if err != nil {
+			return Fleet{}, fmt.Errorf("invalid default timeout %q: %w", raw.Defaults.Timeout, err)
+		}
+		defaults.Timeout = d
+	}
+	if raw.Defaults.Proxy != "" {
+		if _, err := url.Parse(raw.Defaults.Proxy); err != nil {
+			return Fleet{}, fmt.Errorf("invalid proxy URL %q: %w", raw.Defaults.Proxy, err)
+		}
+		defaults.ProxyURL = raw.Defaults.Proxy
+	}
+
+	// parse groups
+	var groups []ProbeGroup
+	for _, g := range raw.Groups {
+		if g.Name == "" {
+			return Fleet{}, fmt.Errorf("probe group missing required field 'name'")
+		}
+		probes, err := parseProbeEntries(g.Probes)
+		if err != nil {
+			return Fleet{}, fmt.Errorf("group %q: %w", g.Name, err)
+		}
+		groups = append(groups, ProbeGroup{
+			Name:   g.Name,
+			Probes: probes,
+		})
+	}
+
+	// parse ungrouped probes
+	ungrouped, err := parseProbeEntries(raw.Probes)
+	if err != nil {
+		return Fleet{}, fmt.Errorf("probes: %w", err)
+	}
+
+	pf := &ProbeFleet{
+		Defaults: defaults,
+		Groups:   groups,
+		Probes:   ungrouped,
+	}
+
+	return Fleet{
+		Name:       name,
+		Type:       "probes",
+		Path:       path,
+		ProbeFleet: pf,
+	}, nil
+}
+
+// parseProbeEntries converts raw probe entries, applying defaults where needed.
+func parseProbeEntries(raw []probeEntryFile) ([]ProbeEntry, error) {
+	var entries []ProbeEntry
+	for _, r := range raw {
+		if r.Name == "" {
+			return nil, fmt.Errorf("probe missing required field 'name'")
+		}
+		if r.URL == "" {
+			return nil, fmt.Errorf("probe %q missing required field 'url'", r.Name)
+		}
+		u, err := url.Parse(r.URL)
+		if err != nil {
+			return nil, fmt.Errorf("probe %q invalid URL: %w", r.Name, err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return nil, fmt.Errorf("probe %q URL scheme must be http or https, got %q", r.Name, u.Scheme)
+		}
+
+		protocol := r.Protocol
+		if protocol == "" {
+			protocol = "http"
+		}
+		if protocol != "http" {
+			return nil, fmt.Errorf("probe %q unsupported protocol %q (v1 supports http only)", r.Name, protocol)
+		}
+
+		expectedCode := r.ExpectedCode
+		if expectedCode == 0 {
+			expectedCode = 200
+		}
+
+		var interval time.Duration
+		if r.Interval != "" {
+			d, err := time.ParseDuration(r.Interval)
+			if err != nil {
+				return nil, fmt.Errorf("probe %q invalid interval: %w", r.Name, err)
+			}
+			if d < 5*time.Second {
+				return nil, fmt.Errorf("probe %q interval %v must be >= 5s", r.Name, d)
+			}
+			interval = d
+		}
+
+		entries = append(entries, ProbeEntry{
+			Name:         r.Name,
+			URL:          r.URL,
+			Protocol:     protocol,
+			ExpectedCode: expectedCode,
+			Interval:     interval,
+		})
+	}
+	return entries, nil
 }

--- a/internal/config/parser_probes_test.go
+++ b/internal/config/parser_probes_test.go
@@ -1,0 +1,295 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseProbeFleet_Valid(t *testing.T) {
+	yaml := `
+name: Platform Endpoints
+type: probes
+defaults:
+  interval: 30s
+  timeout: 15s
+  proxy: http://proxy.corp:8080
+groups:
+  - name: API Gateway
+    probes:
+      - name: health
+        url: https://api.example.com/health
+        expected_code: 200
+      - name: metrics
+        url: https://api.example.com/metrics
+        expected_code: 200
+        interval: 60s
+  - name: Auth
+    probes:
+      - name: oidc
+        url: https://auth.example.com/.well-known/openid-configuration
+probes:
+  - name: dashboard
+    url: http://dashboard.internal/
+    interval: 10s
+`
+	path := writeTempYAML(t, yaml)
+	f, err := ParseFleetFile(path)
+	if err != nil {
+		t.Fatalf("ParseFleetFile() error = %v", err)
+	}
+
+	if f.Name != "Platform Endpoints" {
+		t.Errorf("Name = %q, want %q", f.Name, "Platform Endpoints")
+	}
+	if f.Type != "probes" {
+		t.Errorf("Type = %q, want %q", f.Type, "probes")
+	}
+	if f.ProbeFleet == nil {
+		t.Fatal("ProbeFleet is nil")
+	}
+
+	pf := f.ProbeFleet
+
+	// defaults
+	if pf.Defaults.Interval != 30*time.Second {
+		t.Errorf("Defaults.Interval = %v, want 30s", pf.Defaults.Interval)
+	}
+	if pf.Defaults.Timeout != 15*time.Second {
+		t.Errorf("Defaults.Timeout = %v, want 15s", pf.Defaults.Timeout)
+	}
+	if pf.Defaults.ProxyURL != "http://proxy.corp:8080" {
+		t.Errorf("Defaults.ProxyURL = %q, want %q", pf.Defaults.ProxyURL, "http://proxy.corp:8080")
+	}
+
+	// groups
+	if len(pf.Groups) != 2 {
+		t.Fatalf("len(Groups) = %d, want 2", len(pf.Groups))
+	}
+	if pf.Groups[0].Name != "API Gateway" {
+		t.Errorf("Groups[0].Name = %q, want %q", pf.Groups[0].Name, "API Gateway")
+	}
+	if len(pf.Groups[0].Probes) != 2 {
+		t.Fatalf("len(Groups[0].Probes) = %d, want 2", len(pf.Groups[0].Probes))
+	}
+
+	// probe fields
+	health := pf.Groups[0].Probes[0]
+	if health.Name != "health" {
+		t.Errorf("health.Name = %q", health.Name)
+	}
+	if health.URL != "https://api.example.com/health" {
+		t.Errorf("health.URL = %q", health.URL)
+	}
+	if health.ExpectedCode != 200 {
+		t.Errorf("health.ExpectedCode = %d, want 200", health.ExpectedCode)
+	}
+	if health.Protocol != "http" {
+		t.Errorf("health.Protocol = %q, want %q", health.Protocol, "http")
+	}
+	if health.Interval != 0 {
+		t.Errorf("health.Interval = %v, want 0 (use fleet default)", health.Interval)
+	}
+
+	// per-probe interval override
+	metrics := pf.Groups[0].Probes[1]
+	if metrics.Interval != 60*time.Second {
+		t.Errorf("metrics.Interval = %v, want 60s", metrics.Interval)
+	}
+
+	// ungrouped probes
+	if len(pf.Probes) != 1 {
+		t.Fatalf("len(Probes) = %d, want 1", len(pf.Probes))
+	}
+	if pf.Probes[0].Name != "dashboard" {
+		t.Errorf("Probes[0].Name = %q, want %q", pf.Probes[0].Name, "dashboard")
+	}
+	if pf.Probes[0].Interval != 10*time.Second {
+		t.Errorf("Probes[0].Interval = %v, want 10s", pf.Probes[0].Interval)
+	}
+}
+
+func TestParseProbeFleet_DefaultExpectedCode(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+    url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	f, err := ParseFleetFile(path)
+	if err != nil {
+		t.Fatalf("ParseFleetFile() error = %v", err)
+	}
+	if f.ProbeFleet.Probes[0].ExpectedCode != 200 {
+		t.Errorf("ExpectedCode = %d, want 200", f.ProbeFleet.Probes[0].ExpectedCode)
+	}
+}
+
+func TestParseProbeFleet_DefaultInterval(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+    url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	f, err := ParseFleetFile(path)
+	if err != nil {
+		t.Fatalf("ParseFleetFile() error = %v", err)
+	}
+	if f.ProbeFleet.Defaults.Interval != 30*time.Second {
+		t.Errorf("Defaults.Interval = %v, want 30s", f.ProbeFleet.Defaults.Interval)
+	}
+	if f.ProbeFleet.Defaults.Timeout != 10*time.Second {
+		t.Errorf("Defaults.Timeout = %v, want 10s", f.ProbeFleet.Defaults.Timeout)
+	}
+}
+
+func TestParseProbeFleet_MissingURL(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing URL")
+	}
+	if !strings.Contains(err.Error(), "missing required field 'url'") {
+		t.Errorf("error = %q, want to contain 'missing required field url'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_MissingName(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "missing required field 'name'") {
+		t.Errorf("error = %q, want to contain 'missing required field name'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_InvalidURLScheme(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+    url: ftp://example.com/file
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for invalid URL scheme")
+	}
+	if !strings.Contains(err.Error(), "scheme must be http or https") {
+		t.Errorf("error = %q, want to contain 'scheme must be http or https'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_IntervalTooShort(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+    url: https://example.com/health
+    interval: 2s
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for short interval")
+	}
+	if !strings.Contains(err.Error(), ">= 5s") {
+		t.Errorf("error = %q, want to contain '>= 5s'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_DefaultIntervalTooShort(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+defaults:
+  interval: 3s
+probes:
+  - name: p1
+    url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for short default interval")
+	}
+	if !strings.Contains(err.Error(), ">= 5s") {
+		t.Errorf("error = %q, want to contain '>= 5s'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_UnsupportedProtocol(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+probes:
+  - name: p1
+    url: https://example.com/health
+    protocol: tcp
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for unsupported protocol")
+	}
+	if !strings.Contains(err.Error(), "unsupported protocol") {
+		t.Errorf("error = %q, want to contain 'unsupported protocol'", err.Error())
+	}
+}
+
+func TestParseProbeFleet_NameFromFilename(t *testing.T) {
+	yaml := `
+type: probes
+probes:
+  - name: p1
+    url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	f, err := ParseFleetFile(path)
+	if err != nil {
+		t.Fatalf("ParseFleetFile() error = %v", err)
+	}
+	if f.Name != "test" {
+		t.Errorf("Name = %q, want %q (from filename)", f.Name, "test")
+	}
+}
+
+func TestParseProbeFleet_GroupMissingName(t *testing.T) {
+	yaml := `
+name: test
+type: probes
+groups:
+  - probes:
+      - name: p1
+        url: https://example.com/health
+`
+	path := writeTempYAML(t, yaml)
+	_, err := ParseFleetFile(path)
+	if err == nil {
+		t.Fatal("expected error for group missing name")
+	}
+	if !strings.Contains(err.Error(), "group missing required field 'name'") {
+		t.Errorf("error = %q, want to contain 'group missing required field name'", err.Error())
+	}
+}

--- a/internal/config/scanner.go
+++ b/internal/config/scanner.go
@@ -17,8 +17,10 @@ func fleetTypeOrder(t string) int {
 		return 1
 	case "kubernetes":
 		return 2
-	default:
+	case "probes":
 		return 3
+	default:
+		return 4
 	}
 }
 

--- a/internal/config/scanner_test.go
+++ b/internal/config/scanner_test.go
@@ -14,8 +14,9 @@ func TestFleetTypeOrder(t *testing.T) {
 		{"vm", 0},
 		{"azure", 1},
 		{"kubernetes", 2},
-		{"unknown", 3},
-		{"", 3},
+		{"probes", 3},
+		{"unknown", 4},
+		{"", 4},
 	}
 
 	for _, tt := range tests {
@@ -33,6 +34,9 @@ func TestFleetTypeOrder(t *testing.T) {
 	}
 	if fleetTypeOrder("azure") >= fleetTypeOrder("kubernetes") {
 		t.Error("azure should sort before kubernetes")
+	}
+	if fleetTypeOrder("kubernetes") >= fleetTypeOrder("probes") {
+		t.Error("kubernetes should sort before probes")
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -13,6 +13,7 @@ type Fleet struct {
 	Defaults         HostDefaults `yaml:"defaults"`
 	Groups           []HostGroup  `yaml:"groups"`
 	Hosts            []HostEntry  `yaml:"hosts"`
+	ProbeFleet       *ProbeFleet  `yaml:"-"` // non-nil only when Type == "probes"
 }
 
 // HostDefaults holds default values applied to all hosts in a fleet.
@@ -244,6 +245,35 @@ type ContainerDetail struct {
 	Env     []string
 	Mounts  []string // "source:destination" format
 	Ports   []string // "hostPort:containerPort/proto" format
+}
+
+// ProbeFleet holds the probes-fleet-specific config parsed from YAML.
+type ProbeFleet struct {
+	Defaults ProbeDefaults
+	Groups   []ProbeGroup
+	Probes   []ProbeEntry // ungrouped probes
+}
+
+// ProbeDefaults holds fleet-wide probe settings.
+type ProbeDefaults struct {
+	Interval time.Duration // default probe interval (minimum 5s, default 30s)
+	ProxyURL string        // raw proxy URL — only passed into http.Transport closure, never logged
+	Timeout  time.Duration // HTTP client timeout (default 10s)
+}
+
+// ProbeGroup provides visual grouping of probes.
+type ProbeGroup struct {
+	Name   string
+	Probes []ProbeEntry
+}
+
+// ProbeEntry represents a single probe configuration.
+type ProbeEntry struct {
+	Name         string
+	URL          string
+	Protocol     string        // "http" only in v1
+	ExpectedCode int           // default 200
+	Interval     time.Duration // 0 = use fleet default
 }
 
 // ServiceStatus holds parsed systemctl show output for a service.

--- a/internal/probes/manager.go
+++ b/internal/probes/manager.go
@@ -1,0 +1,334 @@
+package probes
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+const (
+	maxBodyPreview   = 2048
+	CertWarnDays     = 7
+	defaultUserAgent = "fleetdesk-probe/1.0"
+)
+
+// Manager coordinates HTTP endpoint probing.
+type Manager struct {
+	logger *slog.Logger
+}
+
+// NewManager creates a new probe manager.
+func NewManager(logger *slog.Logger) *Manager {
+	return &Manager{logger: logger}
+}
+
+// Start launches one goroutine per probe entry. Results are sent to ch.
+// When ctx is cancelled, all goroutines exit and ch is closed.
+// The caller must allocate ch (buffered recommended).
+func (m *Manager) Start(ctx context.Context, entries []config.ProbeEntry, defaults config.ProbeDefaults, ch chan<- ProbeResult) {
+	var wg sync.WaitGroup
+
+	for i, entry := range entries {
+		wg.Add(1)
+		go func(idx int, e config.ProbeEntry) {
+			defer wg.Done()
+			m.probeLoop(ctx, idx, e, defaults, ch)
+		}(i, entry)
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+}
+
+func (m *Manager) probeLoop(ctx context.Context, idx int, entry config.ProbeEntry, defaults config.ProbeDefaults, ch chan<- ProbeResult) {
+	interval := entry.Interval
+	if interval == 0 {
+		interval = defaults.Interval
+	}
+
+	timeout := defaults.Timeout
+	if timeout >= interval {
+		timeout = interval - time.Second
+		if timeout < time.Second {
+			timeout = time.Second
+		}
+	}
+
+	client := buildHTTPClient(timeout, defaults.ProxyURL)
+
+	// Probe immediately on start.
+	result := runProbe(ctx, client, entry, idx, defaults.ProxyURL)
+	m.logger.Debug("probe complete", "name", entry.Name, "status", result.Status.String(), "latency", result.Latency, "code", result.Code)
+	select {
+	case ch <- result:
+	case <-ctx.Done():
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			result := runProbe(ctx, client, entry, idx, defaults.ProxyURL)
+			m.logger.Debug("probe complete", "name", entry.Name, "status", result.Status.String(), "latency", result.Latency, "code", result.Code)
+			select {
+			case ch <- result:
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func buildHTTPClient(timeout time.Duration, proxyURL string) *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+
+	if proxyURL != "" {
+		parsed, err := url.Parse(proxyURL)
+		if err == nil {
+			transport.Proxy = func(*http.Request) (*url.URL, error) {
+				return parsed, nil
+			}
+		}
+	}
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
+}
+
+func runProbe(ctx context.Context, client *http.Client, entry config.ProbeEntry, idx int, proxyURL string) ProbeResult {
+	result := ProbeResult{
+		ProbeIndex: idx,
+		ProbeTime:  time.Now(),
+		Error:      ErrorClassNone,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, entry.URL, nil)
+	if err != nil {
+		result.Status = ProbeStatusDown
+		result.Error = ErrorClassConnect
+		result.ErrorMsg = RedactError(err, proxyURL)
+		return result
+	}
+	req.Header.Set("User-Agent", defaultUserAgent)
+
+	var ttfb time.Time
+	trace := &httptrace.ClientTrace{
+		GotFirstResponseByte: func() {
+			ttfb = time.Now()
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	result.Latency = time.Since(start)
+
+	if !ttfb.IsZero() {
+		result.TTFB = ttfb.Sub(start)
+	}
+
+	if err != nil {
+		result.Status = ProbeStatusDown
+		result.Error = classifyError(err)
+		result.ErrorMsg = RedactError(err, proxyURL)
+		return result
+	}
+	defer resp.Body.Close()
+
+	result.Code = resp.StatusCode
+
+	// Extract TLS info
+	if resp.TLS != nil && len(resp.TLS.PeerCertificates) > 0 {
+		cert := resp.TLS.PeerCertificates[0]
+		daysLeft := int(math.Floor(time.Until(cert.NotAfter).Hours() / 24))
+		result.TLS = &TLSInfo{
+			Version:      tlsVersionString(resp.TLS.Version),
+			Issuer:       cert.Issuer.CommonName,
+			Subject:      cert.Subject.CommonName,
+			Expiry:       cert.NotAfter,
+			DaysToExpiry: daysLeft,
+		}
+	}
+
+	// Read body preview
+	result.BodyPreview = readBodyPreview(resp)
+
+	// Derive status
+	result.Status = deriveStatus(entry.ExpectedCode, result.Code, result.TLS)
+	if result.Status == ProbeStatusDown && result.Error == ErrorClassNone {
+		result.Error = ErrorClassHTTPStatus
+		result.ErrorMsg = fmt.Sprintf("expected %d, got %d", entry.ExpectedCode, result.Code)
+	}
+
+	return result
+}
+
+func classifyError(err error) ErrorClass {
+	if err == nil {
+		return ErrorClassNone
+	}
+
+	// Timeout — check first because timed-out connects wrap both deadline and OpError
+	if errors.Is(err, context.DeadlineExceeded) || isTimeoutError(err) {
+		return ErrorClassTimeout
+	}
+
+	// DNS
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return ErrorClassDNS
+	}
+
+	// TLS
+	var x509Unknown x509.UnknownAuthorityError
+	if errors.As(err, &x509Unknown) {
+		return ErrorClassTLS
+	}
+	var x509Hostname x509.HostnameError
+	if errors.As(err, &x509Hostname) {
+		return ErrorClassTLS
+	}
+	var certInvalid x509.CertificateInvalidError
+	if errors.As(err, &certInvalid) {
+		return ErrorClassTLS
+	}
+	// Check for "certificate" in error string as fallback for wrapped TLS errors
+	if strings.Contains(strings.ToLower(err.Error()), "certificate") {
+		return ErrorClassTLS
+	}
+
+	// Connect
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return ErrorClassConnect
+	}
+
+	return ErrorClassConnect
+}
+
+func isTimeoutError(err error) bool {
+	type timeouter interface {
+		Timeout() bool
+	}
+	var t timeouter
+	if errors.As(err, &t) {
+		return t.Timeout()
+	}
+	return false
+}
+
+func deriveStatus(expectedCode, actualCode int, tlsInfo *TLSInfo) ProbeStatus {
+	if actualCode != expectedCode {
+		return ProbeStatusDown
+	}
+	if tlsInfo != nil && tlsInfo.DaysToExpiry < CertWarnDays {
+		return ProbeStatusDegraded
+	}
+	return ProbeStatusUp
+}
+
+func tlsVersionString(v uint16) string {
+	switch v {
+	case tls.VersionTLS10:
+		return "TLS 1.0"
+	case tls.VersionTLS11:
+		return "TLS 1.1"
+	case tls.VersionTLS12:
+		return "TLS 1.2"
+	case tls.VersionTLS13:
+		return "TLS 1.3"
+	default:
+		return fmt.Sprintf("TLS 0x%04x", v)
+	}
+}
+
+func readBodyPreview(resp *http.Response) string {
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	ct = strings.ToLower(ct)
+
+	isText := strings.HasPrefix(ct, "text/")
+	isJSON := strings.Contains(ct, "application/json")
+
+	if !isText && !isJSON {
+		return "(binary — skipped)"
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyPreview+1))
+	if err != nil {
+		return fmt.Sprintf("(read error: %v)", err)
+	}
+
+	truncated := len(body) > maxBodyPreview
+	if truncated {
+		body = body[:maxBodyPreview]
+	}
+
+	s := string(body)
+
+	if isJSON {
+		var buf bytes.Buffer
+		if err := json.Indent(&buf, body, "", "  "); err == nil {
+			s = buf.String()
+		}
+	}
+
+	if truncated {
+		s += "\n... (truncated)"
+	}
+
+	return sanitizeBodyPreview(s)
+}
+
+var ansiEscapeRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+// sanitizeBodyPreview strips ANSI escape sequences and non-printable characters
+// from the body preview to prevent TUI rendering corruption.
+func sanitizeBodyPreview(s string) string {
+	s = ansiEscapeRe.ReplaceAllString(s, "")
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' || unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, s)
+}

--- a/internal/probes/manager_test.go
+++ b/internal/probes/manager_test.go
@@ -1,0 +1,319 @@
+package probes
+
+import (
+	"context"
+	"bytes"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestClassifyError_DNS(t *testing.T) {
+	err := &net.DNSError{Err: "no such host", Name: "bad.example.com"}
+	if got := classifyError(err); got != ErrorClassDNS {
+		t.Errorf("classifyError(DNSError) = %q, want %q", got, ErrorClassDNS)
+	}
+}
+
+func TestClassifyError_Connect(t *testing.T) {
+	err := &net.OpError{Op: "connect", Err: fmt.Errorf("connection refused")}
+	if got := classifyError(err); got != ErrorClassConnect {
+		t.Errorf("classifyError(OpError) = %q, want %q", got, ErrorClassConnect)
+	}
+}
+
+func TestClassifyError_Timeout(t *testing.T) {
+	err := context.DeadlineExceeded
+	if got := classifyError(err); got != ErrorClassTimeout {
+		t.Errorf("classifyError(DeadlineExceeded) = %q, want %q", got, ErrorClassTimeout)
+	}
+}
+
+func TestClassifyError_TLS_UnknownAuthority(t *testing.T) {
+	err := x509.UnknownAuthorityError{Cert: &x509.Certificate{}}
+	wrapped := fmt.Errorf("tls: %w", &err)
+	if got := classifyError(wrapped); got != ErrorClassTLS {
+		t.Errorf("classifyError(UnknownAuthority) = %q, want %q", got, ErrorClassTLS)
+	}
+}
+
+func TestClassifyError_TLS_HostnameError(t *testing.T) {
+	err := x509.HostnameError{Host: "wrong.com", Certificate: &x509.Certificate{}}
+	wrapped := fmt.Errorf("tls: %w", &err)
+	if got := classifyError(wrapped); got != ErrorClassTLS {
+		t.Errorf("classifyError(HostnameError) = %q, want %q", got, ErrorClassTLS)
+	}
+}
+
+func TestClassifyError_TLS_CertificateInvalid(t *testing.T) {
+	err := x509.CertificateInvalidError{Reason: x509.Expired}
+	wrapped := fmt.Errorf("tls: %w", &err)
+	if got := classifyError(wrapped); got != ErrorClassTLS {
+		t.Errorf("classifyError(CertificateInvalid) = %q, want %q", got, ErrorClassTLS)
+	}
+}
+
+func TestClassifyError_Nil(t *testing.T) {
+	if got := classifyError(nil); got != ErrorClassNone {
+		t.Errorf("classifyError(nil) = %q, want %q", got, ErrorClassNone)
+	}
+}
+
+func TestDeriveStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedCode int
+		actualCode   int
+		tls          *TLSInfo
+		want         ProbeStatus
+	}{
+		{"code match no TLS", 200, 200, nil, ProbeStatusUp},
+		{"code match cert OK", 200, 200, &TLSInfo{DaysToExpiry: 30}, ProbeStatusUp},
+		{"code match cert expiring", 200, 200, &TLSInfo{DaysToExpiry: 6}, ProbeStatusDegraded},
+		{"code match cert at boundary", 200, 200, &TLSInfo{DaysToExpiry: 7}, ProbeStatusUp},
+		{"code mismatch", 200, 500, nil, ProbeStatusDown},
+		{"code mismatch with TLS", 200, 404, &TLSInfo{DaysToExpiry: 30}, ProbeStatusDown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveStatus(tt.expectedCode, tt.actualCode, tt.tls)
+			if got != tt.want {
+				t.Errorf("deriveStatus(%d, %d, tls) = %v, want %v", tt.expectedCode, tt.actualCode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadBodyPreview_JSON(t *testing.T) {
+	data := `{"status":"ok","version":"1.2.3"}`
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   io.NopCloser(strings.NewReader(data)),
+	}
+	got := readBodyPreview(resp)
+	// Should be pretty-printed
+	var buf bytes.Buffer
+	json.Indent(&buf, []byte(data), "", "  ")
+	want := buf.String()
+	if got != want {
+		t.Errorf("readBodyPreview(json) =\n%s\nwant\n%s", got, want)
+	}
+}
+
+func TestReadBodyPreview_Text(t *testing.T) {
+	data := "Hello, World!"
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/plain"}},
+		Body:   io.NopCloser(strings.NewReader(data)),
+	}
+	got := readBodyPreview(resp)
+	if got != data {
+		t.Errorf("readBodyPreview(text) = %q, want %q", got, data)
+	}
+}
+
+func TestReadBodyPreview_Binary(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"image/png"}},
+		Body:   io.NopCloser(strings.NewReader("PNG binary data")),
+	}
+	got := readBodyPreview(resp)
+	if got != "(binary — skipped)" {
+		t.Errorf("readBodyPreview(binary) = %q, want %q", got, "(binary — skipped)")
+	}
+}
+
+func TestReadBodyPreview_InvalidJSON(t *testing.T) {
+	data := `{"broken": json`
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"application/json"}},
+		Body:   io.NopCloser(strings.NewReader(data)),
+	}
+	got := readBodyPreview(resp)
+	if got != data {
+		t.Errorf("readBodyPreview(invalid json) = %q, want raw %q", got, data)
+	}
+}
+
+func TestReadBodyPreview_Truncation(t *testing.T) {
+	data := strings.Repeat("x", maxBodyPreview+100)
+	resp := &http.Response{
+		Header: http.Header{"Content-Type": []string{"text/plain"}},
+		Body:   io.NopCloser(strings.NewReader(data)),
+	}
+	got := readBodyPreview(resp)
+	if !strings.HasSuffix(got, "... (truncated)") {
+		t.Errorf("readBodyPreview(large) should end with truncation marker, got suffix: %q", got[len(got)-30:])
+	}
+}
+
+func TestManagerStartStop(t *testing.T) {
+	// Start a test HTTP server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		fmt.Fprintf(w, `{"status":"ok"}`)
+	}))
+	defer ts.Close()
+
+	entries := []config.ProbeEntry{
+		{Name: "test", URL: ts.URL, ExpectedCode: 200, Interval: 0},
+	}
+	defaults := config.ProbeDefaults{
+		Interval: 5 * time.Second,
+		Timeout:  5 * time.Second,
+	}
+
+	ch := make(chan ProbeResult, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := NewManager(testLogger())
+	mgr.Start(ctx, entries, defaults, ch)
+
+	// Should receive at least one result (immediate probe)
+	select {
+	case result := <-ch:
+		if result.Status != ProbeStatusUp {
+			t.Errorf("Status = %v, want Up", result.Status)
+		}
+		if result.Code != 200 {
+			t.Errorf("Code = %d, want 200", result.Code)
+		}
+		if result.Latency <= 0 {
+			t.Errorf("Latency = %v, want > 0", result.Latency)
+		}
+		if result.ProbeIndex != 0 {
+			t.Errorf("ProbeIndex = %d, want 0", result.ProbeIndex)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for probe result")
+	}
+
+	// Cancel should stop goroutines and close channel
+	cancel()
+	// Drain remaining results
+	for range ch {
+	}
+}
+
+func TestManagerHTTPStatusMismatch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	entries := []config.ProbeEntry{
+		{Name: "test", URL: ts.URL, ExpectedCode: 200, Interval: 0},
+	}
+	defaults := config.ProbeDefaults{
+		Interval: 5 * time.Second,
+		Timeout:  5 * time.Second,
+	}
+
+	ch := make(chan ProbeResult, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := NewManager(testLogger())
+	mgr.Start(ctx, entries, defaults, ch)
+
+	select {
+	case result := <-ch:
+		if result.Status != ProbeStatusDown {
+			t.Errorf("Status = %v, want Down", result.Status)
+		}
+		if result.Error != ErrorClassHTTPStatus {
+			t.Errorf("Error = %q, want %q", result.Error, ErrorClassHTTPStatus)
+		}
+		if result.Code != 500 {
+			t.Errorf("Code = %d, want 500", result.Code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for probe result")
+	}
+
+	cancel()
+	for range ch {
+	}
+}
+
+func TestManagerDNSError(t *testing.T) {
+	entries := []config.ProbeEntry{
+		{Name: "test", URL: "http://this-host-does-not-exist.invalid/health", ExpectedCode: 200, Interval: 0},
+	}
+	defaults := config.ProbeDefaults{
+		Interval: 5 * time.Second,
+		Timeout:  5 * time.Second,
+	}
+
+	ch := make(chan ProbeResult, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mgr := NewManager(testLogger())
+	mgr.Start(ctx, entries, defaults, ch)
+
+	select {
+	case result := <-ch:
+		if result.Status != ProbeStatusDown {
+			t.Errorf("Status = %v, want Down", result.Status)
+		}
+		if result.Error != ErrorClassDNS {
+			t.Errorf("Error = %q, want %q", result.Error, ErrorClassDNS)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for probe result")
+	}
+
+	cancel()
+	for range ch {
+	}
+}
+
+func TestProbeStatusString(t *testing.T) {
+	tests := []struct {
+		status ProbeStatus
+		want   string
+	}{
+		{ProbeStatusPending, "PENDING"},
+		{ProbeStatusUp, "UP"},
+		{ProbeStatusDown, "DOWN"},
+		{ProbeStatusDegraded, "DEGRADED"},
+	}
+	for _, tt := range tests {
+		if got := tt.status.String(); got != tt.want {
+			t.Errorf("ProbeStatus(%d).String() = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+// classifyError is not exported but is in the same package, so we can test it directly.
+func TestClassifyError_WrappedTimeout(t *testing.T) {
+	inner := &net.OpError{
+		Op:  "connect",
+		Err: errors.New("i/o timeout"),
+	}
+	// Wrap with context deadline
+	err := fmt.Errorf("Get: %w", context.DeadlineExceeded)
+	_ = inner // just to show the scenario
+	if got := classifyError(err); got != ErrorClassTimeout {
+		t.Errorf("classifyError(wrapped deadline) = %q, want %q", got, ErrorClassTimeout)
+	}
+}

--- a/internal/probes/redact.go
+++ b/internal/probes/redact.go
@@ -1,0 +1,71 @@
+package probes
+
+import (
+	"net/url"
+	"strings"
+)
+
+// RedactProxyURL returns the proxy URL with the password replaced by "***".
+// Returns the input unchanged if there is no password or the URL is empty.
+func RedactProxyURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "(invalid proxy URL)"
+	}
+	if u.User == nil {
+		return raw
+	}
+	_, hasPw := u.User.Password()
+	if !hasPw {
+		return raw
+	}
+	// Replace the raw userinfo section to avoid URL re-encoding artifacts.
+	// URL format: scheme://userinfo@host/...
+	// Extract raw userinfo from the original string.
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd < 0 {
+		return raw
+	}
+	afterScheme := raw[schemeEnd+3:]
+	atIdx := strings.Index(afterScheme, "@")
+	if atIdx < 0 {
+		return raw
+	}
+	rawUserinfo := afterScheme[:atIdx]
+	colonIdx := strings.Index(rawUserinfo, ":")
+	if colonIdx < 0 {
+		return raw
+	}
+	redactedUserinfo := rawUserinfo[:colonIdx] + ":***"
+	return raw[:schemeEnd+3] + redactedUserinfo + raw[schemeEnd+3+atIdx:]
+}
+
+// RedactError returns the error message with any proxy password replaced by "***".
+// Returns empty string for nil errors. Safe to call with empty proxyURL.
+func RedactError(err error, proxyURL string) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	pw := extractPassword(proxyURL)
+	if pw == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, pw, "***")
+}
+
+// extractPassword extracts the raw password from a proxy URL string.
+func extractPassword(proxyURL string) string {
+	if proxyURL == "" {
+		return ""
+	}
+	u, err := url.Parse(proxyURL)
+	if err != nil || u.User == nil {
+		return ""
+	}
+	pw, _ := u.User.Password()
+	return pw
+}

--- a/internal/probes/redact_test.go
+++ b/internal/probes/redact_test.go
@@ -1,0 +1,93 @@
+package probes
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRedactProxyURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"with credentials", "http://user:secret@proxy.corp:8080", "http://user:***@proxy.corp:8080"},
+		{"user only no password", "http://user@proxy.corp:8080", "http://user@proxy.corp:8080"},
+		{"no userinfo", "http://proxy.corp:8080", "http://proxy.corp:8080"},
+		{"empty string", "", ""},
+		{"https with credentials", "https://admin:p4ss@proxy.corp:3128", "https://admin:***@proxy.corp:3128"},
+		{"special chars in password", "http://user:p%40ss%21@proxy.corp:8080", "http://user:***@proxy.corp:8080"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactProxyURL(tt.raw)
+			if got != tt.want {
+				t.Errorf("RedactProxyURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		proxyURL string
+		wantSafe bool // true = output must not contain the password
+	}{
+		{
+			"error with proxy password",
+			fmt.Errorf("proxyconnect tcp: dial tcp user:secret@proxy.corp:8080: connection refused"),
+			"http://user:secret@proxy.corp:8080",
+			true,
+		},
+		{
+			"error without password",
+			fmt.Errorf("connection refused"),
+			"http://proxy.corp:8080",
+			true,
+		},
+		{
+			"empty proxy URL",
+			fmt.Errorf("connection refused"),
+			"",
+			true,
+		},
+		{
+			"nil error",
+			nil,
+			"http://user:secret@proxy.corp:8080",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactError(tt.err, tt.proxyURL)
+			if tt.wantSafe && tt.proxyURL != "" {
+				if pw := extractPassword(tt.proxyURL); pw != "" {
+					if contains(got, pw) {
+						t.Errorf("RedactError() = %q, still contains password %q", got, pw)
+					}
+				}
+			}
+			if tt.err == nil && got != "" {
+				t.Errorf("RedactError(nil, ...) = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(substr) > 0 && len(s) >= len(substr) && (s == substr || findSubstring(s, substr))
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/probes/types.go
+++ b/internal/probes/types.go
@@ -1,0 +1,62 @@
+package probes
+
+import "time"
+
+// ProbeStatus represents the health state of a probed endpoint.
+type ProbeStatus int
+
+const (
+	ProbeStatusPending ProbeStatus = iota
+	ProbeStatusUp
+	ProbeStatusDown
+	ProbeStatusDegraded
+)
+
+func (s ProbeStatus) String() string {
+	switch s {
+	case ProbeStatusUp:
+		return "UP"
+	case ProbeStatusDown:
+		return "DOWN"
+	case ProbeStatusDegraded:
+		return "DEGRADED"
+	default:
+		return "PENDING"
+	}
+}
+
+// ErrorClass is a closed enum of probe failure categories.
+// Raw Go error strings must never leak to the UI.
+type ErrorClass string
+
+const (
+	ErrorClassNone       ErrorClass = "none"
+	ErrorClassDNS        ErrorClass = "dns"
+	ErrorClassConnect    ErrorClass = "connect"
+	ErrorClassTimeout    ErrorClass = "timeout"
+	ErrorClassTLS        ErrorClass = "tls"
+	ErrorClassHTTPStatus ErrorClass = "http_status"
+)
+
+// TLSInfo holds TLS certificate details for an HTTPS probe.
+type TLSInfo struct {
+	Version      string
+	Issuer       string
+	Subject      string
+	Expiry       time.Time
+	DaysToExpiry int
+}
+
+// ProbeResult is the per-probe result returned from the connector to the view layer.
+type ProbeResult struct {
+	ProbeIndex  int
+	Status      ProbeStatus
+	Error       ErrorClass
+	ErrorMsg    string // redacted — no proxy credentials
+	Code        int
+	Latency     time.Duration
+	TTFB        time.Duration
+	TLS         *TLSInfo // nil on plain HTTP
+	BodyPreview string   // up to 2KB, JSON pretty-printed if applicable
+	ProbeTime   time.Time
+}


### PR DESCRIPTION
## Summary

- New `probes` fleet type with native Go stdlib HTTP probing — goroutine-per-probe with live TUI updates
- Probe List view with LIVE indicator, group headers, down-first sort, filter, and Probe Detail view with conditional TLS/Error/Response sections
- Proxy credential redaction across all error surfaces, JSON body pretty-print, TLS certificate expiry warnings
- 37 unit tests covering parser, error classification, redaction, status derivation, and httptest integration

## Files

- **New package:** `internal/probes/` (types, manager, redact + tests)
- **New views:** `internal/app/view_probe_list.go`, `view_probe_detail.go`
- **Modified:** config types/parser/scanner, app model/keys/commands/helpers/view_fleet