### PR TITLE
feat: add insecure_skip_verify, interval column, live probe indicator

### DIFF
--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -1436,6 +1436,8 @@ func (m *Model) sortProbeItems() {
 			less = m.probeItems[i].Result.Code < m.probeItems[j].Result.Code
 		case 5:
 			less = m.probeItems[i].Result.Latency < m.probeItems[j].Result.Latency
+		case 6:
+			less = m.probeItems[i].Entry.Interval < m.probeItems[j].Entry.Interval
 		default:
 			return false
 		}

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -2676,7 +2676,7 @@ func (m Model) handleProbeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Force re-probe: stop and restart
 		m.stopProbing()
 		return m, m.startProbing()
-	case "1", "2", "3", "4", "5":
+	case "1", "2", "3", "4", "5", "6":
 		col := int(msg.String()[0] - '0')
 		if col == m.sortColumn {
 			m.sortAsc = !m.sortAsc

--- a/internal/app/view_probe_detail.go
+++ b/internal/app/view_probe_detail.go
@@ -37,11 +37,17 @@ func (m Model) renderProbeDetail() string {
 
 	statusStr, statusColor := probeStatusDisplay(r.Status)
 
+	tlsVerify := "Yes"
+	if m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify {
+		tlsVerify = ansiColor("Skipped", "33")
+	}
+
 	kvSummary := []struct{ k, v string }{
 		{"Name", p.Entry.Name},
 		{"URL", p.Entry.URL},
 		{"Protocol", p.Entry.Protocol},
 		{"Expected Code", fmt.Sprintf("%d", p.Entry.ExpectedCode)},
+		{"TLS Verify", tlsVerify},
 		{"Status", statusColor(statusStr)},
 	}
 	if !r.ProbeTime.IsZero() {

--- a/internal/app/view_probe_list.go
+++ b/internal/app/view_probe_list.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -30,9 +31,6 @@ func (m Model) renderProbeList() string {
 	s := m.renderHeader(f.Name+filterInfo, cur, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	// Live status indicator
-	s += borderedRow("  "+ansiColor("● LIVE", "32"), iw, normalRowStyle) + "\n"
-
 	if len(filtered) == 0 {
 		msg := "  No probes"
 		if m.filterText != "" {
@@ -52,8 +50,8 @@ func (m Model) renderProbeList() string {
 			}
 		}
 		nameCol += 2
-		// Cap URL column to leave room for status/code/latency
-		maxURL := iw - nameCol - 35
+		// Cap URL column to leave room for status/code/interval/latency
+		maxURL := iw - nameCol - 58
 		if maxURL < 10 {
 			maxURL = 10
 		}
@@ -61,11 +59,13 @@ func (m Model) renderProbeList() string {
 			urlCol = maxURL
 		}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-8s  %-4s  %s",
+		hdr := fmt.Sprintf("     %-*s  %-*s  %-8s  %-4s  %-10s  %-8s  %s",
 			nameCol, "NAME"+m.sortIndicator(1),
 			urlCol, "URL"+m.sortIndicator(2),
 			"STATUS"+m.sortIndicator(3),
 			"CODE"+m.sortIndicator(4),
+			"TLS VERIFY",
+			"INTERVAL"+m.sortIndicator(6),
 			"LATENCY"+m.sortIndicator(5),
 		)
 		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
@@ -122,18 +122,43 @@ func (m Model) renderProbeList() string {
 				latencyStr = formatLatency(p.Result.Latency)
 			}
 
+			// Interval (resolved: per-probe or fleet default)
+			interval := p.Entry.Interval
+			if interval == 0 {
+				interval = m.fleets[m.selectedFleet].ProbeFleet.Defaults.Interval
+			}
+			intervalStr := fmt.Sprintf("%ds", int(interval.Seconds()))
+
+			// Live indicator — green steady, green ring during probe, white pending
+			live := ansiColor("●", "97") // white: pending
+			if p.Result.Status != probes.ProbeStatusPending {
+				if time.Since(p.Result.ProbeTime) < 2*time.Second {
+					live = ansiColor("◉", "32") // green ring: just probed
+				} else {
+					live = ansiColor("●", "32") // green filled: steady
+				}
+			}
+
 			// Truncate URL if needed
 			urlStr := p.Entry.URL
 			if len(urlStr) > urlCol {
 				urlStr = urlStr[:urlCol-1] + "…"
 			}
 
-			line := fmt.Sprintf("%s  %-*s  %-*s  %s  %-4s  %s",
-				cursor,
+			// TLS verify indicator (pre-padded — ANSI codes break %-Ns)
+			tlsStr := "✓         "
+			if m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify {
+				tlsStr = ansiColor("Skipped", "33") + "   "
+			}
+
+			line := fmt.Sprintf("%s%s %-*s  %-*s  %s  %-4s  %s  %-8s  %s",
+				cursor, live,
 				nameCol, p.Entry.Name,
 				urlCol, urlStr,
 				statusColor(fmt.Sprintf("%-8s", statusStr)),
 				codeStr,
+				tlsStr,
+				intervalStr,
 				latencyStr,
 			)
 
@@ -160,7 +185,7 @@ func (m Model) renderProbeList() string {
 			{"Enter", "Detail"},
 			{"r", "Refresh"},
 			{"/", "Filter"},
-			{"1-5", "Sort"},
+			{"1-6", "Sort"},
 			{"Esc", "Back"},
 			{"q", "Quit"},
 		}))

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -65,9 +65,10 @@ type probeFleetFile struct {
 }
 
 type probeDefaultsFile struct {
-	Interval string `yaml:"interval"`
-	Proxy    string `yaml:"proxy"`
-	Timeout  string `yaml:"timeout"`
+	Interval           string `yaml:"interval"`
+	Proxy              string `yaml:"proxy"`
+	Timeout            string `yaml:"timeout"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
 }
 
 type probeGroupFile struct {
@@ -293,6 +294,7 @@ func parseProbeFleetFile(data []byte, name, path string) (Fleet, error) {
 		}
 		defaults.ProxyURL = raw.Defaults.Proxy
 	}
+	defaults.InsecureSkipVerify = raw.Defaults.InsecureSkipVerify
 
 	// parse groups
 	var groups []ProbeGroup

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -256,9 +256,10 @@ type ProbeFleet struct {
 
 // ProbeDefaults holds fleet-wide probe settings.
 type ProbeDefaults struct {
-	Interval time.Duration // default probe interval (minimum 5s, default 30s)
-	ProxyURL string        // raw proxy URL — only passed into http.Transport closure, never logged
-	Timeout  time.Duration // HTTP client timeout (default 10s)
+	Interval           time.Duration // default probe interval (minimum 5s, default 30s)
+	ProxyURL           string        // raw proxy URL — only passed into http.Transport closure, never logged
+	Timeout            time.Duration // HTTP client timeout (default 10s)
+	InsecureSkipVerify bool          // skip TLS certificate verification
 }
 
 // ProbeGroup provides visual grouping of probes.

--- a/internal/probes/manager.go
+++ b/internal/probes/manager.go
@@ -74,7 +74,7 @@ func (m *Manager) probeLoop(ctx context.Context, idx int, entry config.ProbeEntr
 		}
 	}
 
-	client := buildHTTPClient(timeout, defaults.ProxyURL)
+	client := buildHTTPClient(timeout, defaults.ProxyURL, defaults.InsecureSkipVerify)
 
 	// Probe immediately on start.
 	result := runProbe(ctx, client, entry, idx, defaults.ProxyURL)
@@ -104,10 +104,11 @@ func (m *Manager) probeLoop(ctx context.Context, idx int, entry config.ProbeEntr
 	}
 }
 
-func buildHTTPClient(timeout time.Duration, proxyURL string) *http.Client {
+func buildHTTPClient(timeout time.Duration, proxyURL string, insecureSkipVerify bool) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecureSkipVerify,
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fleet-level `insecure_skip_verify: true` option in probes YAML defaults to skip TLS certificate verification
- New `TLS VERIFY` and `INTERVAL` columns in Probe List view
- `TLS Verify` field in Probe Detail summary section
- Per-row live indicator: white ● (pending), green ◉ (just probed), green ● (steady)