### PR TITLE
fix: show loading overlay when entering Azure VM and AKS list views

### DIFF
--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1682,6 +1682,7 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureVMList
+			showLoading(&m, "vms", "Loading VMs...")
 			return m, m.fetchAzureVMs()
 		case 1: // AKS Clusters
 			m.azureAKSClusters = nil
@@ -1691,6 +1692,7 @@ func (m Model) handleAzureResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd
 			m.filterText = ""
 			m.filterActive = false
 			m.view = viewAzureAKSList
+			showLoading(&m, "aks", "Loading AKS clusters...")
 			return m, m.fetchAzureAKSClusters()
 		}
 	case "r":


### PR DESCRIPTION
## Summary

- Add loading overlay when navigating from Azure resource picker to VM list and AKS list
- Previously showed "No VMs in subscription" while data was still loading in the background