### PR TITLE
feat: per-probe insecure_skip_verify and JSON body preview fix

### DIFF
--- a/internal/app/view_probe_detail.go
+++ b/internal/app/view_probe_detail.go
@@ -37,8 +37,12 @@ func (m Model) renderProbeDetail() string {
 
 	statusStr, statusColor := probeStatusDisplay(r.Status)
 
+	skipVerify := m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify
+	if p.Entry.InsecureSkipVerify != nil {
+		skipVerify = *p.Entry.InsecureSkipVerify
+	}
 	tlsVerify := "Yes"
-	if m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify {
+	if skipVerify {
 		tlsVerify = ansiColor("Skipped", "33")
 	}
 

--- a/internal/app/view_probe_list.go
+++ b/internal/app/view_probe_list.go
@@ -145,9 +145,13 @@ func (m Model) renderProbeList() string {
 				urlStr = urlStr[:urlCol-1] + "…"
 			}
 
-			// TLS verify indicator (pre-padded — ANSI codes break %-Ns)
+			// TLS verify indicator — resolve per-probe override
+			skipVerify := m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify
+			if p.Entry.InsecureSkipVerify != nil {
+				skipVerify = *p.Entry.InsecureSkipVerify
+			}
 			tlsStr := "✓         "
-			if m.fleets[m.selectedFleet].ProbeFleet.Defaults.InsecureSkipVerify {
+			if skipVerify {
 				tlsStr = ansiColor("Skipped", "33") + "   "
 			}
 

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -77,11 +77,12 @@ type probeGroupFile struct {
 }
 
 type probeEntryFile struct {
-	Name         string `yaml:"name"`
-	URL          string `yaml:"url"`
-	Protocol     string `yaml:"protocol"`
-	ExpectedCode int    `yaml:"expected_code"`
-	Interval     string `yaml:"interval"`
+	Name               string `yaml:"name"`
+	URL                string `yaml:"url"`
+	Protocol           string `yaml:"protocol"`
+	ExpectedCode       int    `yaml:"expected_code"`
+	Interval           string `yaml:"interval"`
+	InsecureSkipVerify *bool  `yaml:"insecure_skip_verify"`
 }
 
 // ParseFleetFile reads and parses a single fleet YAML file.
@@ -376,11 +377,12 @@ func parseProbeEntries(raw []probeEntryFile) ([]ProbeEntry, error) {
 		}
 
 		entries = append(entries, ProbeEntry{
-			Name:         r.Name,
-			URL:          r.URL,
-			Protocol:     protocol,
-			ExpectedCode: expectedCode,
-			Interval:     interval,
+			Name:               r.Name,
+			URL:                r.URL,
+			Protocol:           protocol,
+			ExpectedCode:       expectedCode,
+			Interval:           interval,
+			InsecureSkipVerify: r.InsecureSkipVerify,
 		})
 	}
 	return entries, nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -270,11 +270,12 @@ type ProbeGroup struct {
 
 // ProbeEntry represents a single probe configuration.
 type ProbeEntry struct {
-	Name         string
-	URL          string
-	Protocol     string        // "http" only in v1
-	ExpectedCode int           // default 200
-	Interval     time.Duration // 0 = use fleet default
+	Name               string
+	URL                string
+	Protocol           string        // "http" only in v1
+	ExpectedCode       int           // default 200
+	Interval           time.Duration // 0 = use fleet default
+	InsecureSkipVerify *bool         // nil = use fleet default, true/false = per-probe override
 }
 
 // ServiceStatus holds parsed systemctl show output for a service.

--- a/internal/probes/manager.go
+++ b/internal/probes/manager.go
@@ -74,10 +74,16 @@ func (m *Manager) probeLoop(ctx context.Context, idx int, entry config.ProbeEntr
 		}
 	}
 
-	client := buildHTTPClient(timeout, defaults.ProxyURL, defaults.InsecureSkipVerify)
+	// Resolve per-probe insecure_skip_verify: probe override → fleet default
+	skipVerify := defaults.InsecureSkipVerify
+	if entry.InsecureSkipVerify != nil {
+		skipVerify = *entry.InsecureSkipVerify
+	}
+
+	client := buildHTTPClient(timeout, defaults.ProxyURL, skipVerify)
 
 	// Probe immediately on start.
-	result := runProbe(ctx, client, entry, idx, defaults.ProxyURL, defaults.InsecureSkipVerify)
+	result := runProbe(ctx, client, entry, idx, defaults.ProxyURL, skipVerify)
 	m.logger.Debug("probe complete", "name", entry.Name, "status", result.Status.String(), "latency", result.Latency, "code", result.Code)
 	select {
 	case ch <- result:
@@ -91,7 +97,7 @@ func (m *Manager) probeLoop(ctx context.Context, idx int, entry config.ProbeEntr
 	for {
 		select {
 		case <-ticker.C:
-			result := runProbe(ctx, client, entry, idx, defaults.ProxyURL, defaults.InsecureSkipVerify)
+			result := runProbe(ctx, client, entry, idx, defaults.ProxyURL, skipVerify)
 			m.logger.Debug("probe complete", "name", entry.Name, "status", result.Status.String(), "latency", result.Latency, "code", result.Code)
 			select {
 			case ch <- result:
@@ -294,14 +300,10 @@ func readBodyPreview(resp *http.Response) string {
 		return "(binary — skipped)"
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyPreview+1))
+	// Read up to 64KB for JSON pretty-printing, then truncate the formatted output.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
 		return fmt.Sprintf("(read error: %v)", err)
-	}
-
-	truncated := len(body) > maxBodyPreview
-	if truncated {
-		body = body[:maxBodyPreview]
 	}
 
 	s := string(body)
@@ -313,8 +315,8 @@ func readBodyPreview(resp *http.Response) string {
 		}
 	}
 
-	if truncated {
-		s += "\n... (truncated)"
+	if len(s) > maxBodyPreview {
+		s = s[:maxBodyPreview] + "\n... (truncated)"
 	}
 
 	return sanitizeBodyPreview(s)


### PR DESCRIPTION
## Summary

- Per-probe `insecure_skip_verify` field that overrides fleet default (nil = inherit from defaults)
- TLS VERIFY column and detail view show the resolved per-probe value
- JSON body now pretty-printed from full response (up to 64KB) before truncating the formatted output to 2KB for display — fixes truncated JSON falling back to raw single-line