### PR TITLE
feat: Log Tail view, Processes view, and generic SSH stream (FLE-75)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -2011,3 +2012,132 @@ func (m Model) listenForProbeResults() tea.Cmd {
 		return probeResultBatchMsg{results: batch, generation: gen}
 	}
 }
+
+// Old streamLogTail, stopLogTail, listenForLogTailLines removed — replaced by generic sshstream.go
+
+// fetchProcesses fetches supervisord process list via sudo supervisorctl status.
+func (m Model) fetchProcesses() tea.Cmd {
+	idx := m.selectedHost
+	sm := m.ssh
+	logger := m.logger
+	return func() tea.Msg {
+		logger.Debug("fetch processes start", "host_idx", idx)
+		out, err := sm.RunSudoCommand(idx, "sudo supervisorctl status 2>&1 || true")
+		if err != nil {
+			return fetchProcessesMsg{err: err}
+		}
+		procs := ssh.ParseSupervisordStatus(out)
+		// Sort: failures first
+		sort.Slice(procs, func(i, j int) bool {
+			oi := ssh.ProcessStateOrder(procs[i].State)
+			oj := ssh.ProcessStateOrder(procs[j].State)
+			if oi != oj {
+				return oi < oj
+			}
+			return procs[i].Name < procs[j].Name
+		})
+		logger.Debug("fetch processes complete", "host_idx", idx, "count", len(procs))
+		return fetchProcessesMsg{processes: procs}
+	}
+}
+
+// fetchLogFileStats fetches file size and mtime for configured log files via stat.
+func (m Model) fetchLogFileStats() tea.Cmd {
+	idx := m.selectedHost
+	sm := m.ssh
+	logger := m.logger
+	// Read from host entry directly — m.logFileEntries may not be set yet when captured in closure
+	entries := m.hosts[m.selectedHost].Entry.Logs
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Build stat command for all paths
+	var paths []string
+	needsSudo := false
+	for _, e := range entries {
+		paths = append(paths, shellQuote(e.Path))
+		if e.Sudo {
+			needsSudo = true
+		}
+	}
+	cmd := fmt.Sprintf("stat --printf='%%n\\t%%s\\t%%Y\\n' %s 2>/dev/null || true", strings.Join(paths, " "))
+	if needsSudo {
+		cmd = "sudo " + cmd
+	}
+
+	return func() tea.Msg {
+		logger.Debug("fetch log stats start", "host_idx", idx, "count", len(entries))
+		var out string
+		var err error
+		if needsSudo {
+			out, err = sm.RunSudoCommand(idx, cmd)
+		} else {
+			out, err = sm.RunCommand(idx, cmd)
+		}
+		if err != nil {
+			return fetchLogFileStatMsg{err: err}
+		}
+
+		stats := make(map[int]logFileStat)
+		for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+			parts := strings.SplitN(line, "\t", 3)
+			if len(parts) < 3 {
+				continue
+			}
+			path := parts[0]
+			size := parts[1]
+			epoch := parts[2]
+			// Find matching entry index
+			for i, e := range entries {
+				if e.Path == path {
+					mtime := epoch // raw epoch, format later if needed
+					if len(epoch) > 0 {
+						if t, err := strconv.ParseInt(epoch, 10, 64); err == nil {
+							mtime = time.Unix(t, 0).Format("2006-01-02 15:04")
+						}
+					}
+					sizeInt, _ := strconv.ParseInt(size, 10, 64)
+					sizeStr := formatByteSize(sizeInt)
+					stats[i] = logFileStat{Size: sizeStr, ModTime: mtime}
+					break
+				}
+			}
+		}
+		logger.Debug("fetch log stats complete", "host_idx", idx, "stats", len(stats))
+		return fetchLogFileStatMsg{stats: stats}
+	}
+}
+
+// formatByteSize formats a byte count to human-readable form.
+func formatByteSize(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1fG", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1fM", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1fK", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}
+
+// confirmProcessAction shows a [Y/n] confirm modal for a supervisord action.
+// On confirm, shows a loading overlay, runs the command via SSH, then refreshes.
+func (m Model) confirmProcessAction(processName, action string) (Model, tea.Cmd) {
+	pName := processName
+	pAction := action
+	m.modal = NewConfirmModal(
+		"Confirm",
+		fmt.Sprintf("%s %s? [Y/n]", action, processName),
+		func() tea.Msg {
+			// Return a signal to start the streamed action view
+			return startProcessActionViewMsg{action: pAction, process: pName}
+		},
+	)
+	return m, nil
+}
+
+// Old streamProcessAction and listenForProcessActionLines removed — replaced by generic sshstream.go
+

--- a/internal/app/helpers.go
+++ b/internal/app/helpers.go
@@ -718,6 +718,7 @@ func (m *Model) applyProbeInfo(idx int, info ssh.ProbeInfo) {
 	m.hosts[idx].InterfacesTotal = info.InterfacesTotal
 	m.hosts[idx].ListeningPorts = info.ListeningPorts
 	m.hosts[idx].UpdateCount = info.UpdateCount
+	m.hosts[idx].SupervisorctlPresent = info.SupervisorctlPresent
 }
 
 // startProbe launches parallel SSH connections and probes for all hosts.

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -244,6 +244,12 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleK8sPodDetailKeys(msg)
 	case viewK8sPodLogs:
 		return m.handleK8sPodLogKeys(msg)
+	case viewProcessList:
+		return m.handleProcessListKeys(msg)
+	case viewLogFileList:
+		return m.handleLogFileListKeys(msg)
+	case viewSSHStream:
+		return m.handleSSHStreamKeys(msg)
 	case viewProbeList:
 		return m.handleProbeListKeys(msg)
 	case viewProbeDetail:
@@ -463,100 +469,42 @@ func (m Model) handleHostListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleResourcePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	rows := m.visibleResourceRows()
+	maxIdx := len(rows) - 1
+	if m.resourceCursor > maxIdx {
+		m.resourceCursor = maxIdx
+	}
+
 	switch msg.String() {
 	case "up", "k":
 		if m.resourceCursor > 0 {
 			m.resourceCursor--
 		}
 	case "down", "j":
-		if m.resourceCursor < resourceCount-1 {
+		if m.resourceCursor < maxIdx {
 			m.resourceCursor++
 		}
 	case "enter":
-		switch m.resourceCursor {
-		case 0: // Services
-			m.serviceCursor = 0
-			m.sortColumn = 0
-			m.view = viewServiceList
-			showLoading(&m, "services", "Loading services...")
-			return m, m.fetchServices()
-		case 1: // Containers
-			m.containerCursor = 0
-			m.sortColumn = 0
-			m.view = viewContainerList
-			showLoading(&m, "containers", "Loading containers...")
-			return m, m.fetchContainers()
-		case 2: // Cron Jobs
-			m.cronCursor = 0
-			m.sortColumn = 0
-			m.view = viewCronList
-			showLoading(&m, "cron", "Loading cron jobs...")
-			return m, m.fetchCronJobs()
-		case 3: // Error Logs -> Log Level Picker
-			m.logLevelCursor = 0
-			m.sortColumn = 0
-			m.view = viewLogLevelPicker
-			showLoading(&m, "loglevels", "Loading log levels...")
-			return m, m.fetchLogLevels()
-		case 4: // Updates
-			m.updateCursor = 0
-			m.sortColumn = 0
-			m.view = viewUpdateList
-			showLoading(&m, "updates", "Loading updates...")
-			return m, m.fetchUpdates()
-		case 5: // Disk
-			m.diskCursor = 0
-			m.sortColumn = 0
-			m.view = viewDiskList
-			showLoading(&m, "disk", "Loading disk info...")
-			return m, m.fetchDisk()
-		case 6: // Subscription
-			m.subscriptionCursor = 0
-			m.sortColumn = 0
-			m.view = viewSubscription
-			showLoading(&m, "subscription", "Loading subscription...")
-			return m, m.fetchSubscription()
-		case 7: // Accounts
-			m.accountCursor = 0
-			m.sortColumn = 0
-			m.view = viewAccountList
-			showLoading(&m, "accounts", "Loading accounts...")
-			return m, m.fetchAccounts()
-		case 8: // Network
-			m.networkCursor = 0
-			m.sortColumn = 0
-			m.view = viewNetworkPicker
-			showLoading(&m, "network", "Loading network info...")
-			return m, m.fetchNetworkInfo()
-		case 9: // Failed Logins
-			m.failedLoginCursor = 0
-			m.filterText = ""
-			m.sortColumn = 0
-			m.view = viewSecurityFailedLogins
-			showLoading(&m, "failedlogins", "Loading failed logins...")
-			return m, m.fetchFailedLogins()
-		case 10: // Sudo Activity
-			m.sudoCursor = 0
-			m.filterText = ""
-			m.sortColumn = 0
-			m.view = viewSecuritySudo
-			showLoading(&m, "sudo", "Loading sudo activity...")
-			return m, m.fetchSudoActivity()
-		case 11: // SELinux Denials
-			m.selinuxCursor = 0
-			m.filterText = ""
-			m.sortColumn = 0
-			m.view = viewSecuritySELinux
-			showLoading(&m, "selinux", "Loading SELinux denials...")
-			return m, m.fetchSELinuxDenials()
-		case 12: // Audit Summary
-			m.auditCursor = 0
-			m.filterText = ""
-			m.sortColumn = 0
-			m.view = viewSecurityAudit
-			showLoading(&m, "audit", "Loading audit summary...")
-			return m, m.fetchAuditSummary()
+		targetView, fetchFn, loadKey := m.resourcePickerEnter()
+		if fetchFn == nil {
+			return m, nil
 		}
+		m.sortColumn = 0
+		m.filterText = ""
+		m.filterActive = false
+		// Reset view-specific cursors
+		switch targetView {
+		case viewProcessList:
+			m.processCursor = 0
+		case viewLogFileList:
+			m.logFileCursor = 0
+			m.logFileEntries = m.hosts[m.selectedHost].Entry.Logs
+			m.logFileStats = nil
+			m.logFileStatDone = false
+		}
+		m.view = targetView
+		showLoading(&m, loadKey, fmt.Sprintf("Loading %s...", loadKey))
+		return m, fetchFn()
 	case "r":
 		m.services = nil
 		m.containers = nil
@@ -2689,6 +2637,226 @@ func (m Model) handleProbeListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.sortProbeItems()
 	case "q":
 		m.stopProbing()
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleProcessListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	filtered := m.filteredProcesses()
+
+	if m.filterActive {
+		switch msg.String() {
+		case "enter":
+			m.filterActive = false
+			m.processCursor = 0
+		case "esc":
+			m.filterActive = false
+			m.filterText = ""
+			m.processCursor = 0
+		case "backspace":
+			if len(m.filterText) > 0 {
+				m.filterText = m.filterText[:len(m.filterText)-1]
+				m.processCursor = 0
+			}
+		default:
+			if len(msg.String()) == 1 {
+				m.filterText += msg.String()
+				m.processCursor = 0
+			}
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.processCursor > 0 {
+			m.processCursor--
+		}
+	case "down", "j":
+		if m.processCursor < len(filtered)-1 {
+			m.processCursor++
+		}
+	case "s":
+		if len(filtered) > 0 {
+			p := filtered[m.processCursor]
+			return m.confirmProcessAction(p.Name, "start")
+		}
+	case "o":
+		if len(filtered) > 0 {
+			p := filtered[m.processCursor]
+			return m.confirmProcessAction(p.Name, "stop")
+		}
+	case "t":
+		if len(filtered) > 0 {
+			p := filtered[m.processCursor]
+			return m.confirmProcessAction(p.Name, "restart")
+		}
+	case "l":
+		if len(filtered) > 0 {
+			p := filtered[m.processCursor]
+			basename := p.Name
+			if idx := strings.LastIndex(p.Name, ":"); idx >= 0 {
+				basename = p.Name[idx+1:]
+			}
+			cmd := fmt.Sprintf("sudo tail -n 200 -f /var/log/supervisor/%s.log", shellQuote(basename))
+			return m, m.startSSHStream(SSHStreamConfig{
+				Command:     cmd,
+				Title:       "Processes › " + p.Name + " log",
+				SourceName:  basename + "-log",
+				ReturnView:  viewProcessList,
+				HostIdx:     m.selectedHost,
+				NewestFirst: true,
+				AutoDone:    false,
+			})
+		}
+	case "/":
+		m.filterActive = true
+		m.filterText = ""
+	case "r":
+		m.processes = nil
+		showLoading(&m, "processes", "Loading processes...")
+		return m, m.fetchProcesses()
+	case "1", "2", "3", "4":
+		col := int(msg.String()[0] - '0')
+		if col == m.sortColumn {
+			m.sortAsc = !m.sortAsc
+		} else {
+			m.sortColumn = col
+			m.sortAsc = true
+		}
+		m.sortProcesses()
+	case "esc":
+		m.view = viewResourcePicker
+	case "q":
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleSSHStreamKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		if m.streamNewestFirst && m.streamCursor > 0 {
+			m.streamCursor--
+		}
+	case "down", "j":
+		if m.streamNewestFirst && m.streamCursor < len(m.streamLines)-1 {
+			m.streamCursor++
+		}
+	case " ":
+		if m.streamNewestFirst {
+			if m.streamStreaming {
+				m.stopSSHStream()
+			} else if m.streamLastConfig != nil {
+				// Resume: restart the stream with the same config, keep existing lines
+				cfg := *m.streamLastConfig
+				existingLines := m.streamLines
+				cmd := m.startSSHStream(cfg)
+				m.streamLines = existingLines
+				return m, cmd
+			}
+		}
+	case "w":
+		if m.streamNewestFirst && len(m.streamLines) > 0 {
+			f := m.fleets[m.selectedFleet]
+			h := m.hosts[m.selectedHost]
+			lw := newLogWriter(m.appCfg.FleetDir, f.Name, h.Entry.Name, m.streamSourceName)
+			if lw != nil {
+				lw.WriteLines(m.streamLines)
+				m.flash = fmt.Sprintf("Saved %d lines to %s", len(m.streamLines), lw.Path())
+				m.flashError = false
+				lw.Close()
+			} else {
+				m.flash = "Failed to save log file"
+				m.flashError = true
+			}
+		}
+	case "G":
+		if m.streamNewestFirst {
+			m.streamCursor = 0
+		}
+	case "esc":
+		m.stopSSHStream()
+		retView := m.streamReturnView
+		m.view = retView
+		// Refresh the return view
+		switch retView {
+		case viewProcessList:
+			return m, m.fetchProcesses()
+		case viewLogFileList:
+			return m, m.fetchLogFileStats()
+		}
+	case "q":
+		m.stopSSHStream()
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleLogFileListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	filtered := m.filteredLogFiles()
+
+	if m.filterActive {
+		switch msg.String() {
+		case "enter":
+			m.filterActive = false
+			m.logFileCursor = 0
+		case "esc":
+			m.filterActive = false
+			m.filterText = ""
+			m.logFileCursor = 0
+		case "backspace":
+			if len(m.filterText) > 0 {
+				m.filterText = m.filterText[:len(m.filterText)-1]
+				m.logFileCursor = 0
+			}
+		default:
+			if len(msg.String()) == 1 {
+				m.filterText += msg.String()
+				m.logFileCursor = 0
+			}
+		}
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.logFileCursor > 0 {
+			m.logFileCursor--
+		}
+	case "down", "j":
+		if m.logFileCursor < len(filtered)-1 {
+			m.logFileCursor++
+		}
+	case "enter":
+		if len(filtered) > 0 {
+			item := filtered[m.logFileCursor]
+			cmd := fmt.Sprintf("tail -n 200 -f %s", shellQuote(item.entry.Path))
+			if item.entry.Sudo {
+				cmd = "sudo " + cmd
+			}
+			return m, m.startSSHStream(SSHStreamConfig{
+				Command:     cmd,
+				Title:       "Logs › " + item.entry.Name,
+				SourceName:  item.entry.Name,
+				ReturnView:  viewLogFileList,
+				HostIdx:     m.selectedHost,
+				NewestFirst: true,
+				AutoDone:    false,
+			})
+		}
+	case "/":
+		m.filterActive = true
+		m.filterText = ""
+	case "r":
+		m.logFileStats = nil
+		m.logFileStatDone = false
+		showLoading(&m, "logfiles", "Loading log file stats...")
+		return m, m.fetchLogFileStats()
+	case "esc":
+		m.view = viewResourcePicker
+	case "q":
 		return m, tea.Quit
 	}
 	return m, nil

--- a/internal/app/logwriter.go
+++ b/internal/app/logwriter.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// logWriter manages saving streamed log output to a file.
+// Usage: create with newLogWriter, write lines with WriteLine, close with Close.
+type logWriter struct {
+	file *os.File
+}
+
+// newLogWriter creates a log save file at:
+//
+//	<fleetDir>/logs/<fleet>/<host>/<source>-<datetime>.log
+//
+// Returns nil (no error) if the file cannot be created — log saving is best-effort.
+func newLogWriter(fleetDir, fleetName, hostName, sourceName string) *logWriter {
+	dir := filepath.Join(fleetDir, "logs", sanitizePathComponent(fleetName), sanitizePathComponent(hostName))
+	os.MkdirAll(dir, 0755)
+
+	fileName := fmt.Sprintf("%s-%s.log", sanitizePathComponent(sourceName), time.Now().Format("2006-01-02_150405"))
+	f, err := os.Create(filepath.Join(dir, fileName))
+	if err != nil {
+		return nil
+	}
+	return &logWriter{file: f}
+}
+
+// WriteLine writes a single line to the log file.
+func (lw *logWriter) WriteLine(line string) {
+	if lw == nil || lw.file == nil {
+		return
+	}
+	lw.file.WriteString(line + "\n")
+}
+
+// WriteLines writes multiple lines to the log file.
+func (lw *logWriter) WriteLines(lines []string) {
+	if lw == nil || lw.file == nil {
+		return
+	}
+	for _, line := range lines {
+		lw.file.WriteString(line + "\n")
+	}
+}
+
+// Close closes the log file. Safe to call on nil.
+func (lw *logWriter) Close() {
+	if lw == nil || lw.file == nil {
+		return
+	}
+	lw.file.Close()
+	lw.file = nil
+}
+
+// Path returns the file path, or empty if no file is open.
+func (lw *logWriter) Path() string {
+	if lw == nil || lw.file == nil {
+		return ""
+	}
+	return lw.file.Name()
+}
+
+// sanitizePathComponent replaces characters unsafe for directory/file names.
+func sanitizePathComponent(s string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", " ", "-", ":", "_")
+	return r.Replace(s)
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -72,6 +72,29 @@ type transitionExpireMsg struct {
 	key string
 }
 
+// logFileStat holds stat metadata for a log file.
+type logFileStat struct {
+	Size    string
+	ModTime string
+}
+
+type fetchProcessesMsg struct {
+	processes []config.Process
+	err       error
+}
+
+type fetchLogFileStatMsg struct {
+	stats map[int]logFileStat
+	err   error
+}
+
+// sshStreamBatchMsg and sshStreamDoneMsg are defined in sshstream.go
+
+type startProcessActionViewMsg struct {
+	action  string
+	process string
+}
+
 type probeResultBatchMsg struct {
 	results    []probes.ProbeResult
 	generation int
@@ -229,13 +252,15 @@ const (
 	viewK8sPodList
 	viewK8sPodDetail
 	viewK8sPodLogs
+	viewProcessList
+	viewLogFileList
+	viewSSHStream
 	viewProbeList
 	viewProbeDetail
 	viewConfig
 )
 
-// resourceCount is the number of items in the resource picker (0-indexed).
-const resourceCount = 13
+// resourceCount removed — replaced by dynamic visibleResourceRows()
 
 // networkSubViewCount is the number of sub-views in the network picker.
 const networkSubViewCount = 4
@@ -323,6 +348,30 @@ type Model struct {
 	k8sLogDetailScroll    int  // scroll offset for log detail view
 	k8sLogDetailWasStreaming bool // resume streaming after closing detail
 	k8sPodLogFromDetail   bool // true when logs opened from pod detail (Esc returns to detail)
+
+	// supervisord processes
+	processes     []config.Process
+	processCursor int
+
+	// log files
+	logFileEntries  []config.LogEntry
+	logFileCursor   int
+	logFileStats    map[int]logFileStat // index → {size, modtime}
+	logFileStatDone bool
+
+	// generic SSH stream view (used by log tail, process actions, etc.)
+	streamLines       []string
+	streamCursor      int
+	streamCancel      context.CancelFunc
+	streamChan        chan string
+	streamStreaming    bool
+	streamTitle       string // display title in breadcrumb
+	streamSourceName  string // clean name for file save (no special chars)
+	streamReturnView  view
+	streamNewestFirst bool // true = newest on top (log tail), false = append (command output)
+	streamAutoDone    bool // true = show "Done" when command finishes
+	streamGeneration  int  // incremented on each start, used to discard stale messages
+	streamLastConfig  *SSHStreamConfig // saved for pause/resume
 
 	// probes fleet
 	probesManager     *probes.Manager
@@ -1072,6 +1121,91 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.probesStreaming = false
 		return m, nil
 
+	case fetchProcessesMsg:
+		dismissLoadingFor(&m, "processes")
+		if msg.err != nil {
+			mm, cmd, handled := m.handleSudoOrFlash(msg.err, m.fetchProcesses())
+			if handled {
+				return mm, cmd
+			}
+			m.flash = fmt.Sprintf("Failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.processes = msg.processes
+		return m, nil
+
+	case sshStreamBatchMsg:
+		if msg.generation != m.streamGeneration {
+			return m, nil // stale message from previous stream
+		}
+		if m.streamNewestFirst {
+			wasAtTop := m.streamCursor == 0
+			m.streamLines = append(msg.lines, m.streamLines...)
+			if len(m.streamLines) > 1000 {
+				m.streamLines = m.streamLines[:1000]
+			}
+			if wasAtTop {
+				m.streamCursor = 0
+			} else {
+				m.streamCursor += len(msg.lines)
+			}
+		} else {
+			m.streamLines = append(m.streamLines, msg.lines...)
+			if len(m.streamLines) > 1000 {
+				m.streamLines = m.streamLines[len(m.streamLines)-1000:]
+			}
+		}
+		if m.streamChan != nil {
+			return m, m.listenForStreamLines()
+		}
+		return m, nil
+
+	case sshStreamDoneMsg:
+		if msg.generation != m.streamGeneration {
+			return m, nil // stale done from previous stream
+		}
+		m.streamChan = nil
+		m.streamStreaming = false
+		if m.streamAutoDone {
+			m.streamLines = append(m.streamLines, "", ansiColor("✓ Done — press Esc to return", "32"))
+		}
+		return m, nil
+
+	case fetchLogFileStatMsg:
+		dismissLoadingFor(&m, "logfiles")
+		if msg.err != nil {
+			m.flash = fmt.Sprintf("Failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.logFileStats = msg.stats
+		m.logFileStatDone = true
+		return m, nil
+
+	case startProcessActionViewMsg:
+		// Validate action against allowlist
+		action := msg.action
+		switch action {
+		case "start", "stop", "restart":
+			// valid
+		default:
+			m.flash = fmt.Sprintf("Invalid action: %s", action)
+			m.flashError = true
+			return m, nil
+		}
+		cmd := fmt.Sprintf("sudo supervisorctl %s '%s'; echo ''; echo '--- Current Status ---'; sudo supervisorctl status",
+			action, shellQuote(msg.process))
+		return m, m.startSSHStream(SSHStreamConfig{
+			Command:     cmd,
+			Title:       "Processes › " + msg.action + " " + msg.process,
+			SourceName:  msg.action + "-" + msg.process,
+			ReturnView:  viewProcessList,
+			HostIdx:     m.selectedHost,
+			NewestFirst: false,
+			AutoDone:    true,
+		})
+
 	case fetchAzureAKSMsg:
 		dismissLoadingFor(&m, "aks")
 		if msg.err != nil {
@@ -1655,6 +1789,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(tea.EnterAltScreen, m.fetchAccounts())
 		case viewNetworkPicker:
 			return m, tea.Batch(tea.EnterAltScreen, m.fetchNetworkInfo())
+		case viewProcessList:
+			return m, tea.Batch(tea.EnterAltScreen, m.fetchProcesses())
+		case viewLogFileList:
+			return m, tea.Batch(tea.EnterAltScreen, m.fetchLogFileStats())
+		case viewSSHStream:
+			return m, tea.EnterAltScreen
 		}
 		return m, tea.EnterAltScreen
 
@@ -1772,6 +1912,12 @@ func (m Model) renderCurrentView() string {
 		return m.renderK8sPodDetail()
 	case viewK8sPodLogs:
 		return m.renderK8sPodLogs()
+	case viewProcessList:
+		return m.renderProcessList()
+	case viewLogFileList:
+		return m.renderLogFileList()
+	case viewSSHStream:
+		return m.renderSSHStream()
 	case viewProbeList:
 		return m.renderProbeList()
 	case viewProbeDetail:

--- a/internal/app/sshstream.go
+++ b/internal/app/sshstream.go
@@ -1,0 +1,244 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// SSHStreamConfig configures a generic SSH command stream rendered in-TUI.
+type SSHStreamConfig struct {
+	Command    string // shell command to run (sudo will be rewritten automatically)
+	Title      string // display title in breadcrumb
+	SourceName string // clean name for file save (no special chars)
+	ReturnView view   // view to return to on Esc
+	HostIdx    int    // host index for SSH connection
+	Sudo       bool   // whether to use sudo rewrite
+	NewestFirst bool  // true = prepend lines (log tail), false = append (command output)
+	AutoDone   bool   // true = show "Done" message when command finishes (for one-shot commands)
+}
+
+// sshStream holds the runtime state for a generic SSH stream view.
+// These fields live on Model — this struct documents the contract.
+// Model fields: streamLines, streamCursor, streamCancel, streamChan,
+//               streamStreaming, streamTitle, streamReturnView, streamNewestFirst, streamAutoDone
+
+type sshStreamBatchMsg struct {
+	lines      []string
+	generation int
+}
+
+type sshStreamDoneMsg struct {
+	generation int
+}
+
+// startSSHStream launches a generic SSH command stream.
+func (m *Model) startSSHStream(cfg SSHStreamConfig) tea.Cmd {
+	if m.streamStreaming {
+		m.stopSSHStream()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.streamCancel = cancel
+	m.streamStreaming = true
+	m.streamLines = nil
+	m.streamCursor = 0
+	m.streamTitle = cfg.Title
+	m.streamSourceName = cfg.SourceName
+	if m.streamSourceName == "" {
+		m.streamSourceName = cfg.Title // fallback
+	}
+	m.streamReturnView = cfg.ReturnView
+	m.streamNewestFirst = cfg.NewestFirst
+	m.streamAutoDone = cfg.AutoDone
+	m.streamGeneration++
+	m.streamLastConfig = &cfg
+	m.view = viewSSHStream
+
+	ch := make(chan string, 200)
+	m.streamChan = ch
+
+	sm := m.ssh
+	idx := cfg.HostIdx
+	cmd := cfg.Command
+	logger := m.logger
+
+	go func() {
+		defer close(ch)
+
+		client := sm.GetConnection(idx)
+		if client == nil {
+			ch <- "ERROR: no SSH connection to host"
+			return
+		}
+
+		session, err := client.NewSession()
+		if err != nil {
+			ch <- fmt.Sprintf("ERROR: SSH session: %v", err)
+			return
+		}
+		defer session.Close()
+
+		// Rewrite sudo if password is cached
+		finalCmd := sm.RewriteSudoInCmd(idx, cmd)
+		// Merge stderr so we see errors
+		finalCmd = finalCmd + " 2>&1"
+
+		logCmd := finalCmd
+		if strings.Contains(logCmd, "| sudo -S") {
+			logCmd = "[sudo-rewritten]"
+		}
+		logger.Debug("ssh stream start", "cmd_prefix", logCmd[:min(len(logCmd), 60)])
+
+		stdout, err := session.StdoutPipe()
+		if err != nil {
+			ch <- fmt.Sprintf("ERROR: pipe: %v", err)
+			return
+		}
+		if err := session.Start(finalCmd); err != nil {
+			ch <- fmt.Sprintf("ERROR: start: %v", err)
+			return
+		}
+
+		// Cancel watcher: close session when context is cancelled.
+		// This unblocks scanner.Scan() which is blocking I/O on the SSH pipe.
+		go func() {
+			<-ctx.Done()
+			session.Close()
+		}()
+
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			ch <- scanner.Text()
+		}
+		session.Wait()
+		logger.Debug("ssh stream complete")
+	}()
+
+	return m.listenForStreamLines()
+}
+
+// stopSSHStream cancels the active stream.
+func (m *Model) stopSSHStream() {
+	if m.streamCancel != nil {
+		m.streamCancel()
+		m.streamCancel = nil
+	}
+	m.streamChan = nil
+	m.streamStreaming = false
+}
+
+// listenForStreamLines blocks on the stream channel, returns sshStreamBatchMsg.
+func (m Model) listenForStreamLines() tea.Cmd {
+	ch := m.streamChan
+	if ch == nil {
+		return nil
+	}
+	gen := m.streamGeneration
+	return func() tea.Msg {
+		first, ok := <-ch
+		if !ok {
+			return sshStreamDoneMsg{generation: gen}
+		}
+		batch := []string{first}
+		for len(batch) < 50 {
+			select {
+			case line, ok := <-ch:
+				if !ok {
+					return sshStreamBatchMsg{lines: batch, generation: gen}
+				}
+				batch = append(batch, line)
+			default:
+				return sshStreamBatchMsg{lines: batch, generation: gen}
+			}
+		}
+		return sshStreamBatchMsg{lines: batch, generation: gen}
+	}
+}
+
+// renderSSHStream renders the generic SSH stream view.
+func (m Model) renderSSHStream() string {
+	h := m.hosts[m.selectedHost]
+	f := m.fleets[m.selectedFleet]
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	breadcrumb := f.Name + " › " + h.Entry.Name + " › " + m.streamTitle
+	s := m.renderHeader(breadcrumb, m.streamCursor+1, len(m.streamLines)) + "\n"
+
+	// Status bar
+	var statusParts []string
+	if m.streamStreaming {
+		statusParts = append(statusParts, ansiColor("● LIVE", "32"))
+	} else {
+		statusParts = append(statusParts, ansiColor("■ STOPPED", "33"))
+	}
+	if m.streamNewestFirst && m.streamCursor == 0 {
+		statusParts = append(statusParts, ansiColor("↑ AUTO-SCROLL", "36"))
+	}
+	statusLine := "  " + strings.Join(statusParts, "  ")
+	s += borderedRow(statusLine, iw+2, colHeaderStyle) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	if len(m.streamLines) == 0 {
+		s += borderedRow("  Waiting for output...", iw, normalRowStyle) + "\n"
+	} else {
+		maxVisible := m.height - 6
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+
+		var startIdx, endIdx int
+		if m.streamNewestFirst {
+			// Cursor 0 = newest at top, scroll down into history
+			startIdx = m.streamCursor
+			if startIdx >= len(m.streamLines) {
+				startIdx = len(m.streamLines) - 1
+			}
+			if startIdx < 0 {
+				startIdx = 0
+			}
+			endIdx = startIdx + maxVisible
+			if endIdx > len(m.streamLines) {
+				endIdx = len(m.streamLines)
+			}
+		} else {
+			// Newest at bottom (command output style)
+			endIdx = len(m.streamLines)
+			startIdx = endIdx - maxVisible
+			if startIdx < 0 {
+				startIdx = 0
+			}
+		}
+
+		for i := startIdx; i < endIdx; i++ {
+			line := m.streamLines[i]
+			if len(line) > iw-2 {
+				line = line[:iw-3] + "…"
+			}
+			s += borderedRow("  "+line, iw, normalRowStyle) + "\n"
+		}
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
+
+	hints := [][]string{{"Esc", "Back"}}
+	if m.streamNewestFirst {
+		hints = [][]string{
+			{"↑↓", "Scroll"},
+			{"Space", "Pause/Resume"},
+			{"G", "Latest"},
+			{"w", "Save"},
+			{"Esc", "Stop & Back"},
+		}
+	}
+	s += m.renderHintBar(hintWithHelp(hints))
+	return s
+}

--- a/internal/app/view_logfiles.go
+++ b/internal/app/view_logfiles.go
@@ -1,0 +1,171 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+func (m Model) renderLogFileList() string {
+	h := m.hosts[m.selectedHost]
+	f := m.fleets[m.selectedFleet]
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	filtered := m.filteredLogFiles()
+	filterInfo := ""
+	if m.filterText != "" {
+		filterInfo = fmt.Sprintf(" [filter: %s]", m.filterText)
+	}
+
+	breadcrumb := f.Name + " › " + h.Entry.Name + " › Logs"
+	cur := 0
+	if len(filtered) > 0 {
+		cur = m.logFileCursor + 1
+	}
+	s := m.renderHeader(breadcrumb+filterInfo, cur, len(filtered)) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	if len(filtered) == 0 {
+		msg := "  No log files configured"
+		if m.filterText != "" {
+			msg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+		}
+		s += borderedRow(msg, iw, normalRowStyle) + "\n"
+	} else {
+		nameCol := len("NAME")
+		pathCol := len("PATH")
+		sizeCol := len("SIZE")
+		// modCol not needed — last column is not fixed-width
+		for _, e := range filtered {
+			if len(e.entry.Name) > nameCol {
+				nameCol = len(e.entry.Name)
+			}
+			if len(e.entry.Path) > pathCol {
+				pathCol = len(e.entry.Path)
+			}
+		}
+		nameCol += 2
+		// Cap path column
+		maxPath := iw - nameCol - 40
+		if maxPath < 10 {
+			maxPath = 10
+		}
+		if pathCol > maxPath {
+			pathCol = maxPath
+		}
+		sizeCol = 8
+
+		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %s",
+			nameCol, "NAME"+m.sortIndicator(1),
+			pathCol, "PATH"+m.sortIndicator(2),
+			sizeCol, "SIZE"+m.sortIndicator(3),
+			"LAST MODIFIED"+m.sortIndicator(4),
+		)
+		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
+		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+
+		maxVisible := m.height - 8
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+		offset := 0
+		if m.logFileCursor >= offset+maxVisible {
+			offset = m.logFileCursor - maxVisible + 1
+		}
+		end := offset + maxVisible
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+
+		for i := offset; i < end; i++ {
+			item := filtered[i]
+			cursor := "   "
+			if i == m.logFileCursor {
+				cursor = " ▸ "
+			}
+
+			pathStr := item.entry.Path
+			if len(pathStr) > pathCol {
+				pathStr = pathStr[:pathCol-1] + "…"
+			}
+
+			sizeStr := "---"
+			modStr := "---"
+			if stat, ok := m.logFileStats[item.origIdx]; ok {
+				sizeStr = stat.Size
+				modStr = stat.ModTime
+			}
+
+			// Sudo indicator
+			sudoPrefix := " "
+			if item.entry.Sudo {
+				sudoPrefix = ansiColor("⚡", "33")
+			}
+
+			line := fmt.Sprintf("%s%s %-*s  %-*s  %-*s  %s",
+				cursor, sudoPrefix,
+				nameCol, item.entry.Name,
+				pathCol, pathStr,
+				sizeCol, sizeStr,
+				modStr,
+			)
+
+			var style lipgloss.Style
+			if i == m.logFileCursor {
+				style = selectedRowStyle
+			} else if i%2 == 0 {
+				style = altRowStyle
+			} else {
+				style = normalRowStyle
+			}
+			s += borderedRow(line, iw, style) + "\n"
+		}
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
+
+	if m.filterActive {
+		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
+	} else {
+		s += m.renderHintBar(hintWithHelp([][]string{
+			{"↑↓", "Navigate"},
+			{"Enter", "Tail"},
+			{"/", "Filter"},
+			{"r", "Refresh"},
+			{"Esc", "Back"},
+		}))
+	}
+	return s
+}
+
+type logFileItem struct {
+	entry   config.LogEntry
+	origIdx int // index into m.logFileEntries for stat lookup
+}
+
+func (m Model) filteredLogFiles() []logFileItem {
+	var items []logFileItem
+	for i, e := range m.logFileEntries {
+		items = append(items, logFileItem{entry: e, origIdx: i})
+	}
+	if m.filterText == "" {
+		return items
+	}
+	f := strings.ToLower(m.filterText)
+	var result []logFileItem
+	for _, item := range items {
+		if strings.Contains(strings.ToLower(item.entry.Name), f) ||
+			strings.Contains(strings.ToLower(item.entry.Path), f) {
+			result = append(result, item)
+		}
+	}
+	return result
+}

--- a/internal/app/view_processes.go
+++ b/internal/app/view_processes.go
@@ -1,0 +1,200 @@
+package app
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
+)
+
+func (m Model) renderProcessList() string {
+	h := m.hosts[m.selectedHost]
+	f := m.fleets[m.selectedFleet]
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	filtered := m.filteredProcesses()
+	filterInfo := ""
+	if m.filterText != "" {
+		filterInfo = fmt.Sprintf(" [filter: %s]", m.filterText)
+	}
+
+	breadcrumb := f.Name + " › " + h.Entry.Name + " › Processes"
+	cur := 0
+	if len(filtered) > 0 {
+		cur = m.processCursor + 1
+	}
+	s := m.renderHeader(breadcrumb+filterInfo, cur, len(filtered)) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	if len(filtered) == 0 {
+		msg := "  No processes"
+		if m.filterText != "" {
+			msg += " matching filter"
+		}
+		s += borderedRow(msg, iw, normalRowStyle) + "\n"
+	} else {
+		nameCol := len("PROCESS")
+		stateCol := len("STATE")
+		uptimeCol := len("UPTIME")
+		pidCol := len("PID")
+		for _, p := range filtered {
+			if len(p.Name) > nameCol {
+				nameCol = len(p.Name)
+			}
+			if len(p.State) > stateCol {
+				stateCol = len(p.State)
+			}
+		}
+		nameCol += 2
+		stateCol += 2
+		uptimeCol += 2
+		pidCol += 2
+
+		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %s",
+			nameCol, "PROCESS"+m.sortIndicator(1),
+			stateCol, "STATE"+m.sortIndicator(2),
+			uptimeCol, "UPTIME"+m.sortIndicator(3),
+			"PID"+m.sortIndicator(4),
+		)
+		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
+		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+
+		maxVisible := m.height - 8
+		if maxVisible < 1 {
+			maxVisible = 1
+		}
+		offset := 0
+		if m.processCursor >= offset+maxVisible {
+			offset = m.processCursor - maxVisible + 1
+		}
+		end := offset + maxVisible
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+
+		for i := offset; i < end; i++ {
+			p := filtered[i]
+			cursor := "   "
+			if i == m.processCursor {
+				cursor = " ▸ "
+			}
+
+			// State prefix for failures
+			nameDisplay := p.Name
+			if p.State == "FATAL" || p.State == "BACKOFF" {
+				nameDisplay = "✗ " + nameDisplay
+			}
+
+			// Color state
+			stateStr := processStateColor(p.State)
+
+			line := fmt.Sprintf("%s  %-*s  %s  %-*s  %-*s",
+				cursor,
+				nameCol, nameDisplay,
+				stateStr,
+				uptimeCol, p.Uptime,
+				pidCol, p.PID,
+			)
+
+			var style lipgloss.Style
+			if i == m.processCursor {
+				style = selectedRowStyle
+			} else if i%2 == 0 {
+				style = altRowStyle
+			} else {
+				style = normalRowStyle
+			}
+			s += borderedRow(line, iw, style) + "\n"
+		}
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
+
+	if m.filterActive {
+		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s█", m.filterText))
+	} else {
+		s += m.renderHintBar(hintWithHelp([][]string{
+			{"↑↓", "Navigate"},
+			{"s", "Start"},
+			{"o", "Stop"},
+			{"t", "Restart"},
+			{"l", "Logs"},
+			{"/", "Filter"},
+			{"1-4", "Sort"},
+			{"r", "Refresh"},
+			{"Esc", "Back"},
+		}))
+	}
+	return s
+}
+
+func processStateColor(state string) string {
+	// Pre-pad to fixed width for alignment (ANSI codes break %-Ns)
+	padded := fmt.Sprintf("%-10s", state)
+	switch state {
+	case "RUNNING":
+		return ansiColor(padded, "32") // green
+	case "FATAL", "BACKOFF":
+		return ansiColor(padded, "31") // red
+	case "STOPPED", "EXITED":
+		return ansiColor(padded, "33") // yellow
+	case "STARTING", "STOPPING":
+		return ansiColor(padded, "36") // cyan
+	default:
+		return ansiColor(padded, "90") // dim
+	}
+}
+
+func (m Model) filteredProcesses() []config.Process {
+	if m.filterText == "" {
+		return m.processes
+	}
+	f := strings.ToLower(m.filterText)
+	var result []config.Process
+	for _, p := range m.processes {
+		if strings.Contains(strings.ToLower(p.Name), f) ||
+			strings.Contains(strings.ToLower(p.State), f) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func (m *Model) sortProcesses() {
+	sort.Slice(m.processes, func(i, j int) bool {
+		if m.sortColumn == 0 {
+			oi := ssh.ProcessStateOrder(m.processes[i].State)
+			oj := ssh.ProcessStateOrder(m.processes[j].State)
+			if oi != oj {
+				return oi < oj
+			}
+			return m.processes[i].Name < m.processes[j].Name
+		}
+		var less bool
+		switch m.sortColumn {
+		case 1:
+			less = strings.ToLower(m.processes[i].Name) < strings.ToLower(m.processes[j].Name)
+		case 2:
+			less = ssh.ProcessStateOrder(m.processes[i].State) < ssh.ProcessStateOrder(m.processes[j].State)
+		case 3:
+			less = m.processes[i].Uptime < m.processes[j].Uptime
+		case 4:
+			less = m.processes[i].PID < m.processes[j].PID
+		default:
+			return false
+		}
+		if m.sortAsc {
+			return less
+		}
+		return !less
+	})
+}

--- a/internal/app/view_resource.go
+++ b/internal/app/view_resource.go
@@ -4,36 +4,24 @@ import (
 	"fmt"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
-func (m Model) renderResourcePicker() string {
+// pickerRow represents a single row in the dynamic resource picker.
+type pickerRow struct {
+	label   string
+	total   int
+	running int
+	failed  int
+	target  view
+}
+
+// visibleResourceRows builds the dynamic resource picker rows based on current host state.
+func (m Model) visibleResourceRows() []pickerRow {
 	h := m.hosts[m.selectedHost]
-	f := m.fleets[m.selectedFleet]
-	w := m.width
-	if w < 20 {
-		w = 80
-	}
-	iw := w - 2
 
-	breadcrumb := f.Name + " \u203a " + h.Entry.Name
-	s := m.renderHeader(breadcrumb, m.resourceCursor+1, resourceCount) + "\n"
-	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
-
-	nameCol := len("SELinux Denials") + 2
-
-	hdr := fmt.Sprintf("     %-*s  %7s  %7s  %7s", nameCol, "RESOURCE", "TOTAL", "RUNNING", "FAILED")
-	s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-	s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
-
-	type resRow struct {
-		name    string
-		total   int
-		running int
-		failed  int
-	}
-
-	// use fetched (filtered) data if available, otherwise probe counts
+	// Services + Containers counts
 	svcTotal, svcRunning, svcFailed := 0, 0, 0
 	if len(m.services) > 0 {
 		svcTotal = len(m.services)
@@ -57,7 +45,6 @@ func (m Model) renderResourcePicker() string {
 			}
 		}
 	}
-
 	updTotal, updFailed := 0, 0
 	if len(m.updates) > 0 {
 		for _, u := range m.updates {
@@ -69,24 +56,81 @@ func (m Model) renderResourcePicker() string {
 		}
 	}
 
-	rows := []resRow{
-		{"Services", svcTotal, svcRunning, svcFailed},
-		{"Containers", ctnTotal, ctnRunning, ctnFailed},
-		{"Cron Jobs", h.CronCount, 0, 0},
-		{"System Logs", h.ErrorCount, 0, 0},
-		{"Updates", updTotal, 0, updFailed},
-		{"Disk", h.DiskCount, 0, h.DiskHighCount},
-		{"Subscription", 0, 0, 0},
-		{"Accounts", h.UserCount, 0, 0},
-		{"Network", h.InterfacesTotal, h.InterfacesUp, 0},
+	// Process count
+	procTotal, procFailed := 0, 0
+	if len(m.processes) > 0 {
+		procTotal = len(m.processes)
+		for _, p := range m.processes {
+			if p.State == "FATAL" || p.State == "BACKOFF" {
+				procFailed++
+			}
+		}
 	}
+
+	rows := []pickerRow{
+		{"Services", svcTotal, svcRunning, svcFailed, viewServiceList},
+	}
+
+	// Processes — conditional on supervisord presence
+	if h.SupervisorctlPresent {
+		rows = append(rows, pickerRow{"Processes", procTotal, 0, procFailed, viewProcessList})
+	}
+
+	rows = append(rows,
+		pickerRow{"Containers", ctnTotal, ctnRunning, ctnFailed, viewContainerList},
+		pickerRow{"Cron Jobs", h.CronCount, 0, 0, viewCronList},
+		pickerRow{"System Logs", h.ErrorCount, 0, 0, viewLogLevelPicker},
+		pickerRow{"Updates", updTotal, 0, updFailed, viewUpdateList},
+		pickerRow{"Disk", h.DiskCount, 0, h.DiskHighCount, viewDiskList},
+		pickerRow{"Subscription", 0, 0, 0, viewSubscription},
+		pickerRow{"Accounts", h.UserCount, 0, 0, viewAccountList},
+		pickerRow{"Network", h.InterfacesTotal, h.InterfacesUp, 0, viewNetworkPicker},
+	)
+
+	// Security views
+	rows = append(rows,
+		pickerRow{"Failed Logins", 0, 0, 0, viewSecurityFailedLogins},
+		pickerRow{"Sudo Activity", 0, 0, 0, viewSecuritySudo},
+		pickerRow{"SELinux Denials", 0, 0, 0, viewSecuritySELinux},
+		pickerRow{"Audit Summary", 0, 0, 0, viewSecurityAudit},
+	)
+
+	// Logs — conditional on configured log paths
+	if len(h.Entry.Logs) > 0 {
+		rows = append(rows, pickerRow{"Logs", len(h.Entry.Logs), 0, 0, viewLogFileList})
+	}
+
+	return rows
+}
+
+func (m Model) renderResourcePicker() string {
+	h := m.hosts[m.selectedHost]
+	f := m.fleets[m.selectedFleet]
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	rows := m.visibleResourceRows()
+
+	breadcrumb := f.Name + " › " + h.Entry.Name
+	s := m.renderHeader(breadcrumb, m.resourceCursor+1, len(rows)) + "\n"
+	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
+
+	nameCol := len("SELinux Denials") + 2
+
+	hdr := fmt.Sprintf("     %-*s  %7s  %7s  %7s", nameCol, "RESOURCE", "TOTAL", "RUNNING", "FAILED")
+	s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
+	s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+
 	for i, r := range rows {
 		cur := "   "
 		if i == m.resourceCursor {
-			cur = " \u25b8 "
+			cur = " ▸ "
 		}
 		failedStr := fmt.Sprintf("%d", r.failed)
-		line := fmt.Sprintf("%s  %-*s  %7d  %7d  %7s", cur, nameCol, r.name, r.total, r.running, failedStr)
+		line := fmt.Sprintf("%s  %-*s  %7d  %7d  %7s", cur, nameCol, r.label, r.total, r.running, failedStr)
 
 		var style lipgloss.Style
 		if i == m.resourceCursor {
@@ -100,12 +144,55 @@ func (m Model) renderResourcePicker() string {
 	}
 
 	s = m.padToBottom(s, iw)
-	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
+	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"
 	s += m.renderHintBar(hintWithHelp([][]string{
-		{"\u2191\u2193", "Navigate"},
+		{"↑↓", "Navigate"},
 		{"Enter", "Select"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},
 	}))
 	return s
+}
+
+// resourcePickerEnter handles the Enter key in the resource picker.
+// Returns the target view and fetch command based on the current cursor row.
+func (m Model) resourcePickerEnter() (view, func() tea.Cmd, string) {
+	rows := m.visibleResourceRows()
+	if m.resourceCursor >= len(rows) {
+		return viewResourcePicker, nil, ""
+	}
+	row := rows[m.resourceCursor]
+	switch row.target {
+	case viewServiceList:
+		return viewServiceList, func() tea.Cmd { return m.fetchServices() }, "services"
+	case viewProcessList:
+		return viewProcessList, func() tea.Cmd { return m.fetchProcesses() }, "processes"
+	case viewContainerList:
+		return viewContainerList, func() tea.Cmd { return m.fetchContainers() }, "containers"
+	case viewCronList:
+		return viewCronList, func() tea.Cmd { return m.fetchCronJobs() }, "cron"
+	case viewLogLevelPicker:
+		return viewLogLevelPicker, func() tea.Cmd { return m.fetchLogLevels() }, "loglevels"
+	case viewUpdateList:
+		return viewUpdateList, func() tea.Cmd { return m.fetchUpdates() }, "updates"
+	case viewDiskList:
+		return viewDiskList, func() tea.Cmd { return m.fetchDisk() }, "disk"
+	case viewSubscription:
+		return viewSubscription, func() tea.Cmd { return m.fetchSubscription() }, "subscription"
+	case viewAccountList:
+		return viewAccountList, func() tea.Cmd { return m.fetchAccounts() }, "accounts"
+	case viewNetworkPicker:
+		return viewNetworkPicker, func() tea.Cmd { return m.fetchNetworkInfo() }, "network"
+	case viewSecurityFailedLogins:
+		return viewSecurityFailedLogins, func() tea.Cmd { return m.fetchFailedLogins() }, "failedlogins"
+	case viewSecuritySudo:
+		return viewSecuritySudo, func() tea.Cmd { return m.fetchSudoActivity() }, "sudo"
+	case viewSecuritySELinux:
+		return viewSecuritySELinux, func() tea.Cmd { return m.fetchSELinuxDenials() }, "selinux"
+	case viewSecurityAudit:
+		return viewSecurityAudit, func() tea.Cmd { return m.fetchAuditSummary() }, "audit"
+	case viewLogFileList:
+		return viewLogFileList, func() tea.Cmd { return m.fetchLogFileStats() }, "logfiles"
+	}
+	return viewResourcePicker, nil, ""
 }

--- a/internal/config/logs.go
+++ b/internal/config/logs.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// MergeLogEntries merges log entries from defaults, group, and host levels.
+// Dedupe by name: host overrides group, group overrides defaults.
+// New names from any level are added (additive catalog, not replace).
+func MergeLogEntries(defaults, group, host []LogEntry) []LogEntry {
+	seen := make(map[string]int) // name → index in result
+	var result []LogEntry
+
+	// Seed with defaults
+	for _, e := range defaults {
+		seen[e.Name] = len(result)
+		result = append(result, e)
+	}
+
+	// Overlay group: add new, override existing
+	for _, e := range group {
+		if idx, ok := seen[e.Name]; ok {
+			result[idx] = e
+		} else {
+			seen[e.Name] = len(result)
+			result = append(result, e)
+		}
+	}
+
+	// Overlay host: add new, override existing
+	for _, e := range host {
+		if idx, ok := seen[e.Name]; ok {
+			result[idx] = e
+		} else {
+			seen[e.Name] = len(result)
+			result = append(result, e)
+		}
+	}
+
+	return result
+}
+
+// shellMetachars is the set of characters not allowed in log paths.
+const shellMetachars = "$`;&|<>\n\r\\(){}[]'"
+
+// ValidateLogPath checks that a log path is absolute and contains no shell metacharacters.
+func ValidateLogPath(name, path string) error {
+	if path == "" {
+		return fmt.Errorf("log %q: path is empty", name)
+	}
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("log %q: path must be absolute, got %q", name, path)
+	}
+	if len(path) > 512 {
+		return fmt.Errorf("log %q: path too long (%d chars, max 512)", name, len(path))
+	}
+	for _, c := range shellMetachars {
+		if strings.ContainsRune(path, c) {
+			return fmt.Errorf("log %q: path contains illegal character %q", name, string(c))
+		}
+	}
+	if filepath.Clean(path) != path {
+		return fmt.Errorf("log %q: path must be canonical (no .. components), got %q", name, path)
+	}
+	return nil
+}

--- a/internal/config/logs_test.go
+++ b/internal/config/logs_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMergeLogEntries_DefaultsOnly(t *testing.T) {
+	defaults := []LogEntry{{Name: "syslog", Path: "/var/log/messages", Sudo: true}}
+	result := MergeLogEntries(defaults, nil, nil)
+	if len(result) != 1 || result[0].Name != "syslog" {
+		t.Errorf("got %v, want 1 entry named syslog", result)
+	}
+}
+
+func TestMergeLogEntries_GroupAdds(t *testing.T) {
+	defaults := []LogEntry{{Name: "syslog", Path: "/var/log/messages"}}
+	group := []LogEntry{{Name: "app", Path: "/var/log/app.log"}}
+	result := MergeLogEntries(defaults, group, nil)
+	if len(result) != 2 {
+		t.Fatalf("got %d entries, want 2", len(result))
+	}
+	if result[0].Name != "syslog" || result[1].Name != "app" {
+		t.Errorf("got names %q %q, want syslog app", result[0].Name, result[1].Name)
+	}
+}
+
+func TestMergeLogEntries_HostAdds(t *testing.T) {
+	defaults := []LogEntry{{Name: "syslog", Path: "/var/log/messages"}}
+	host := []LogEntry{{Name: "tower", Path: "/var/log/tower/tower.log", Sudo: true}}
+	result := MergeLogEntries(defaults, nil, host)
+	if len(result) != 2 {
+		t.Fatalf("got %d entries, want 2", len(result))
+	}
+	if result[1].Name != "tower" {
+		t.Errorf("got %q, want tower", result[1].Name)
+	}
+}
+
+func TestMergeLogEntries_HostOverridesSameName(t *testing.T) {
+	defaults := []LogEntry{{Name: "syslog", Path: "/var/log/messages", Sudo: false}}
+	host := []LogEntry{{Name: "syslog", Path: "/var/log/syslog", Sudo: true}}
+	result := MergeLogEntries(defaults, nil, host)
+	if len(result) != 1 {
+		t.Fatalf("got %d entries, want 1", len(result))
+	}
+	if result[0].Path != "/var/log/syslog" || !result[0].Sudo {
+		t.Errorf("host should override: got path=%q sudo=%v", result[0].Path, result[0].Sudo)
+	}
+}
+
+func TestMergeLogEntries_GroupOverridesDefaults(t *testing.T) {
+	defaults := []LogEntry{{Name: "syslog", Path: "/var/log/messages"}}
+	group := []LogEntry{{Name: "syslog", Path: "/var/log/syslog"}}
+	result := MergeLogEntries(defaults, group, nil)
+	if len(result) != 1 || result[0].Path != "/var/log/syslog" {
+		t.Errorf("group should override defaults: got %v", result)
+	}
+}
+
+func TestMergeLogEntries_AllThreeLevels(t *testing.T) {
+	defaults := []LogEntry{
+		{Name: "syslog", Path: "/var/log/messages"},
+		{Name: "secure", Path: "/var/log/secure"},
+	}
+	group := []LogEntry{
+		{Name: "app", Path: "/var/log/app.log"},
+	}
+	host := []LogEntry{
+		{Name: "tower", Path: "/var/log/tower/tower.log", Sudo: true},
+		{Name: "syslog", Path: "/var/log/syslog"}, // override defaults
+	}
+	result := MergeLogEntries(defaults, group, host)
+	if len(result) != 4 {
+		t.Fatalf("got %d entries, want 4", len(result))
+	}
+	// syslog should be overridden by host
+	if result[0].Path != "/var/log/syslog" {
+		t.Errorf("syslog should be overridden: got %q", result[0].Path)
+	}
+}
+
+func TestMergeLogEntries_Empty(t *testing.T) {
+	result := MergeLogEntries(nil, nil, nil)
+	if len(result) != 0 {
+		t.Errorf("got %d entries, want 0", len(result))
+	}
+}
+
+func TestValidateLogPath_Valid(t *testing.T) {
+	if err := ValidateLogPath("test", "/var/log/test.log"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateLogPath_ValidWithSpaces(t *testing.T) {
+	if err := ValidateLogPath("test", "/var/log/my app/test.log"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateLogPath_RelativePath(t *testing.T) {
+	err := ValidateLogPath("test", "var/log/test.log")
+	if err == nil {
+		t.Fatal("expected error for relative path")
+	}
+	if !strings.Contains(err.Error(), "absolute") {
+		t.Errorf("error = %q, want to mention absolute", err.Error())
+	}
+}
+
+func TestValidateLogPath_Empty(t *testing.T) {
+	err := ValidateLogPath("test", "")
+	if err == nil {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestValidateLogPath_ShellMetacharacters(t *testing.T) {
+	badPaths := []string{
+		"/var/log/$HOME/test.log",
+		"/var/log/test;rm -rf /",
+		"/var/log/test&bg",
+		"/var/log/test|pipe",
+		"/var/log/test>redirect",
+		"/var/log/test<input",
+		"/var/log/test`cmd`",
+		"/var/log/test\ninjection",
+		"/var/log/test\\escaped",
+		"/var/log/test'quote",
+	}
+	for _, p := range badPaths {
+		if err := ValidateLogPath("test", p); err == nil {
+			t.Errorf("expected error for path %q", p)
+		}
+	}
+}
+
+func TestValidateLogPath_TooLong(t *testing.T) {
+	long := "/" + strings.Repeat("a", 512)
+	err := ValidateLogPath("test", long)
+	if err == nil {
+		t.Fatal("expected error for long path")
+	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Errorf("error = %q, want to mention too long", err.Error())
+	}
+}

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -24,35 +24,44 @@ type fleetFile struct {
 }
 
 type defaultsFile struct {
-	User            string   `yaml:"user"`
-	Port            int      `yaml:"port"`
-	Timeout         string   `yaml:"timeout"`
-	SystemdMode     string   `yaml:"systemd_mode"`
-	ServiceFilter   []string `yaml:"service_filter"`
-	ErrorLogSince   string   `yaml:"error_log_since"`
-	RefreshInterval string   `yaml:"refresh_interval"`
-	RHOrgID         string   `yaml:"rh_org_id"`
-	RHActivationKey string   `yaml:"rh_activation_key"`
-	SatelliteURL    string   `yaml:"satellite_url"`
+	User            string         `yaml:"user"`
+	Port            int            `yaml:"port"`
+	Timeout         string         `yaml:"timeout"`
+	SystemdMode     string         `yaml:"systemd_mode"`
+	ServiceFilter   []string       `yaml:"service_filter"`
+	Logs            []logEntryFile `yaml:"logs"`
+	ErrorLogSince   string         `yaml:"error_log_since"`
+	RefreshInterval string         `yaml:"refresh_interval"`
+	RHOrgID         string         `yaml:"rh_org_id"`
+	RHActivationKey string         `yaml:"rh_activation_key"`
+	SatelliteURL    string         `yaml:"satellite_url"`
+}
+
+type logEntryFile struct {
+	Name string `yaml:"name"`
+	Path string `yaml:"path"`
+	Sudo bool   `yaml:"sudo"`
 }
 
 type groupFile struct {
 	Name          string          `yaml:"name"`
 	Hosts         []hostEntryFile `yaml:"hosts"`
 	ServiceFilter []string        `yaml:"service_filter"`
+	Logs          []logEntryFile  `yaml:"logs"`
 }
 
 type hostEntryFile struct {
-	Name            string   `yaml:"name"`
-	Hostname        string   `yaml:"hostname"`
-	User            string   `yaml:"user"`
-	Port            int      `yaml:"port"`
-	Timeout         string   `yaml:"timeout"`
-	SystemdMode     string   `yaml:"systemd_mode"`
-	ServiceFilter   []string `yaml:"service_filter"`
-	RHOrgID         string   `yaml:"rh_org_id"`
-	RHActivationKey string   `yaml:"rh_activation_key"`
-	SatelliteURL    string   `yaml:"satellite_url"`
+	Name            string         `yaml:"name"`
+	Hostname        string         `yaml:"hostname"`
+	User            string         `yaml:"user"`
+	Port            int            `yaml:"port"`
+	Timeout         string         `yaml:"timeout"`
+	SystemdMode     string         `yaml:"systemd_mode"`
+	ServiceFilter   []string       `yaml:"service_filter"`
+	Logs            []logEntryFile `yaml:"logs"`
+	RHOrgID         string         `yaml:"rh_org_id"`
+	RHActivationKey string         `yaml:"rh_activation_key"`
+	SatelliteURL    string         `yaml:"satellite_url"`
 }
 
 // probeFleetFile is the raw YAML structure for a probes fleet file.
@@ -150,10 +159,22 @@ func ParseFleetFile(path string) (Fleet, error) {
 		defaults.Timeout = 10 * time.Second
 	}
 
+	// parse default logs
+	for _, l := range raw.Defaults.Logs {
+		if l.Name == "" {
+			return Fleet{}, fmt.Errorf("log entry missing required field 'name'")
+		}
+		if err := ValidateLogPath(l.Name, l.Path); err != nil {
+			return Fleet{}, err
+		}
+		defaults.Logs = append(defaults.Logs, LogEntry{Name: l.Name, Path: l.Path, Sudo: l.Sudo})
+	}
+
 	// parse groups
 	var groups []HostGroup
 	for _, g := range raw.Groups {
-		hosts, err := parseHosts(g.Hosts, defaults, g.ServiceFilter)
+		groupLogs := convertLogEntries(g.Logs)
+		hosts, err := parseHosts(g.Hosts, defaults, g.ServiceFilter, groupLogs)
 		if err != nil {
 			return Fleet{}, fmt.Errorf("group %q: %w", g.Name, err)
 		}
@@ -164,7 +185,7 @@ func ParseFleetFile(path string) (Fleet, error) {
 	}
 
 	// parse ungrouped hosts
-	hosts, err := parseHosts(raw.Hosts, defaults, nil)
+	hosts, err := parseHosts(raw.Hosts, defaults, nil, nil)
 	if err != nil {
 		return Fleet{}, fmt.Errorf("hosts: %w", err)
 	}
@@ -189,7 +210,8 @@ func ParseFleetFile(path string) (Fleet, error) {
 
 // parseHosts converts raw host entries, applying defaults where needed.
 // groupFilter is the group-level service filter (can be nil).
-func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string) ([]HostEntry, error) {
+// groupLogs is the group-level log entries (can be nil).
+func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string, groupLogs []LogEntry) ([]HostEntry, error) {
 	var hosts []HostEntry
 	for _, r := range raw {
 		if r.Name == "" {
@@ -251,9 +273,28 @@ func parseHosts(raw []hostEntryFile, defaults HostDefaults, groupFilter []string
 			h.Timeout = defaults.Timeout
 		}
 
+		// logs: merge defaults + group + host (additive, dedupe by name)
+		hostLogs := convertLogEntries(r.Logs)
+		merged := MergeLogEntries(defaults.Logs, groupLogs, hostLogs)
+		for _, l := range merged {
+			if err := ValidateLogPath(l.Name, l.Path); err != nil {
+				return nil, fmt.Errorf("host %q: %w", r.Name, err)
+			}
+		}
+		h.Logs = merged
+
 		hosts = append(hosts, h)
 	}
 	return hosts, nil
+}
+
+// convertLogEntries converts raw YAML log entries to domain LogEntry.
+func convertLogEntries(raw []logEntryFile) []LogEntry {
+	var entries []LogEntry
+	for _, r := range raw {
+		entries = append(entries, LogEntry{Name: r.Name, Path: r.Path, Sudo: r.Sudo})
+	}
+	return entries
 }
 
 // parseProbeFleetFile parses a probes fleet YAML file into a Fleet with ProbeFleet set.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,6 +23,7 @@ type HostDefaults struct {
 	Timeout         time.Duration `yaml:"timeout"`
 	SystemdMode     string        `yaml:"systemd_mode"`
 	ServiceFilter   []string      `yaml:"service_filter"`
+	Logs            []LogEntry    `yaml:"-"` // populated by parser via merge cascade
 	ErrorLogSince   string
 	RefreshInterval string
 	RHOrgID         string `yaml:"rh_org_id"`
@@ -45,9 +46,10 @@ type HostEntry struct {
 	Timeout         time.Duration `yaml:"timeout"`
 	SystemdMode     string        `yaml:"systemd_mode"`
 	ServiceFilter   []string
-	RHOrgID         string `yaml:"rh_org_id"`
-	RHActivationKey string `yaml:"rh_activation_key"`
-	SatelliteURL    string `yaml:"satellite_url"`
+	Logs            []LogEntry // merged from defaults + group + host
+	RHOrgID         string     `yaml:"rh_org_id"`
+	RHActivationKey string     `yaml:"rh_activation_key"`
+	SatelliteURL    string     `yaml:"satellite_url"`
 }
 
 // Host is the runtime representation of a host with connection state.
@@ -71,8 +73,9 @@ type Host struct {
 	InterfacesTotal int
 	ListeningPorts  int
 	UpdateCount     int
-	SudoReady       bool
-	Error           string
+	SudoReady              bool
+	SupervisorctlPresent   bool
+	Error                  string
 }
 
 // HostStatus represents the connection state of a host.
@@ -245,6 +248,21 @@ type ContainerDetail struct {
 	Env     []string
 	Mounts  []string // "source:destination" format
 	Ports   []string // "hostPort:containerPort/proto" format
+}
+
+// LogEntry is a named log file path on a remote host.
+type LogEntry struct {
+	Name string
+	Path string
+	Sudo bool
+}
+
+// Process represents a supervisord-managed process.
+type Process struct {
+	Name   string // full group:process name
+	State  string // RUNNING, FATAL, STOPPED, BACKOFF, STARTING, EXITED
+	Uptime string
+	PID    string
 }
 
 // ProbeFleet holds the probes-fleet-specific config parsed from YAML.

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -283,6 +283,23 @@ func (sm *Manager) ConnectWithPassword(idx int, h config.Host, password string) 
 	return PasswordRetryResult{Index: idx, Info: info}
 }
 
+// RewriteSudoInCmd rewrites sudo commands with the cached password for the given host.
+// If no password is cached, returns the command unchanged.
+func (sm *Manager) RewriteSudoInCmd(idx int, cmd string) string {
+	pw := sm.GetSudoPassword(idx)
+	if pw == "" {
+		return cmd
+	}
+	return rewriteSudoCmd(cmd, pw)
+}
+
+// GetConnection returns the SSH client for the given host index, or nil if not connected.
+func (sm *Manager) GetConnection(idx int) *gossh.Client {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	return sm.conns[idx]
+}
+
 // HasConnection returns true if the manager has an active SSH client for the given host index.
 func (sm *Manager) HasConnection(idx int) bool {
 	sm.mu.Lock()
@@ -324,7 +341,8 @@ func Probe(client *gossh.Client, systemdMode string, errorLogSince string) (Prob
 		`(ip -br link | grep -c UP || echo 0) && ` +
 		`ip -br link | wc -l && ` +
 		`(ss -tlnp 2>/dev/null | tail -n +2 | wc -l || echo 0) && ` +
-		`(dnf check-update --quiet 2>/dev/null | grep -c '^\S' || echo 0)`
+		`(dnf check-update --quiet 2>/dev/null | grep -c '^\S' || echo 0) && ` +
+		`(command -v supervisorctl >/dev/null 2>&1 && echo 1 || echo 0)`
 
 	out, err := session.CombinedOutput(cmd)
 	if err != nil {

--- a/internal/ssh/probe.go
+++ b/internal/ssh/probe.go
@@ -20,8 +20,9 @@ type ProbeInfo struct {
 	InterfacesUp    int
 	InterfacesTotal int
 	ListeningPorts  int
-	UpdateCount     int
-	SystemdMode     string
+	UpdateCount          int
+	SupervisorctlPresent bool
+	SystemdMode          string
 }
 
 // FormatDateEU converts a date string to DD/MM/YYYY format.
@@ -57,6 +58,7 @@ func FormatDateEU(s string) string {
 //	9: interfaces total
 //	10: listening ports
 //	11: update count (dnf check-update)
+//	12: supervisorctl present (1 or 0)
 func ParseProbeOutput(output string, systemdMode string) (ProbeInfo, error) {
 	// Strip any shell warnings (e.g., "Could not chdir to home directory")
 	// that appear before the probe sentinel marker.
@@ -88,7 +90,8 @@ func ParseProbeOutput(output string, systemdMode string) (ProbeInfo, error) {
 		InterfacesUp:    getInt(8),
 		InterfacesTotal: getInt(9),
 		ListeningPorts:  getInt(10),
-		UpdateCount:     getInt(11),
-		SystemdMode:     systemdMode,
+		UpdateCount:          getInt(11),
+		SupervisorctlPresent: getInt(12) == 1,
+		SystemdMode:          systemdMode,
 	}, nil
 }

--- a/internal/ssh/supervisord.go
+++ b/internal/ssh/supervisord.go
@@ -1,0 +1,70 @@
+package ssh
+
+import (
+	"strings"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+// ParseSupervisordStatus parses the output of `supervisorctl status`.
+// Each line: "name   STATE   pid NNN, uptime H:MM:SS"
+// Or for FATAL/STOPPED: "name   STATE   description"
+func ParseSupervisordStatus(output string) []config.Process {
+	var processes []config.Process
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		p := config.Process{
+			Name:  fields[0],
+			State: strings.ToUpper(fields[1]),
+		}
+
+		// Parse PID and uptime from remaining fields
+		rest := strings.Join(fields[2:], " ")
+		if strings.HasPrefix(rest, "pid ") {
+			parts := strings.SplitN(rest, ",", 2)
+			pidStr := strings.TrimPrefix(parts[0], "pid ")
+			p.PID = strings.TrimSpace(pidStr)
+			if len(parts) > 1 {
+				uptime := strings.TrimSpace(parts[1])
+				uptime = strings.TrimPrefix(uptime, "uptime ")
+				p.Uptime = uptime
+			}
+		} else {
+			p.PID = "-"
+		}
+
+		processes = append(processes, p)
+	}
+	return processes
+}
+
+// ProcessStateOrder returns the sort priority for supervisord process states.
+// Lower = higher priority (shown first).
+func ProcessStateOrder(state string) int {
+	switch strings.ToUpper(state) {
+	case "FATAL":
+		return 0
+	case "BACKOFF":
+		return 1
+	case "STOPPED":
+		return 2
+	case "EXITED":
+		return 3
+	case "STARTING":
+		return 4
+	case "STOPPING":
+		return 5
+	case "RUNNING":
+		return 6
+	default:
+		return 7
+	}
+}

--- a/internal/ssh/supervisord_test.go
+++ b/internal/ssh/supervisord_test.go
@@ -1,0 +1,117 @@
+package ssh
+
+import (
+	"testing"
+)
+
+func TestParseSupervisordStatus_Running(t *testing.T) {
+	output := `tower-processes:awx-uwsgi                RUNNING   pid 1007, uptime 0:05:45`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 1 {
+		t.Fatalf("got %d procs, want 1", len(procs))
+	}
+	p := procs[0]
+	if p.Name != "tower-processes:awx-uwsgi" {
+		t.Errorf("Name = %q", p.Name)
+	}
+	if p.State != "RUNNING" {
+		t.Errorf("State = %q", p.State)
+	}
+	if p.PID != "1007" {
+		t.Errorf("PID = %q, want 1007", p.PID)
+	}
+	if p.Uptime != "0:05:45" {
+		t.Errorf("Uptime = %q, want 0:05:45", p.Uptime)
+	}
+}
+
+func TestParseSupervisordStatus_Fatal(t *testing.T) {
+	output := `tower-processes:awx-daphne               FATAL     Exited too quickly (process log may have details)`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 1 {
+		t.Fatalf("got %d procs, want 1", len(procs))
+	}
+	p := procs[0]
+	if p.State != "FATAL" {
+		t.Errorf("State = %q, want FATAL", p.State)
+	}
+	if p.PID != "-" {
+		t.Errorf("PID = %q, want -", p.PID)
+	}
+}
+
+func TestParseSupervisordStatus_Stopped(t *testing.T) {
+	output := `tower-processes:awx-dispatcher           STOPPED   Not started`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 1 {
+		t.Fatalf("got %d procs, want 1", len(procs))
+	}
+	if procs[0].State != "STOPPED" {
+		t.Errorf("State = %q, want STOPPED", procs[0].State)
+	}
+}
+
+func TestParseSupervisordStatus_Backoff(t *testing.T) {
+	output := `tower-processes:awx-rsyslogd             BACKOFF   Exited too quickly (process log may have details)`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 1 {
+		t.Fatalf("got %d procs, want 1", len(procs))
+	}
+	if procs[0].State != "BACKOFF" {
+		t.Errorf("State = %q, want BACKOFF", procs[0].State)
+	}
+}
+
+func TestParseSupervisordStatus_MultipleProcesses(t *testing.T) {
+	output := `master-event-listener                    FATAL     can't find command '/usr/bin/failure-event-handler'
+tower-processes:awx-callback-receiver    RUNNING   pid 10355, uptime 0:02:14
+tower-processes:awx-daphne               RUNNING   pid 11090, uptime 0:00:05
+tower-processes:awx-dispatcher           RUNNING   pid 10354, uptime 0:02:14
+tower-processes:awx-rsyslogd             BACKOFF   Exited too quickly (process log may have details)
+tower-processes:awx-uwsgi                RUNNING   pid 10356, uptime 0:02:14`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 6 {
+		t.Fatalf("got %d procs, want 6", len(procs))
+	}
+	// Check first is FATAL
+	if procs[0].State != "FATAL" {
+		t.Errorf("first proc State = %q, want FATAL", procs[0].State)
+	}
+	// Check a running proc has PID
+	if procs[1].PID != "10355" {
+		t.Errorf("callback-receiver PID = %q, want 10355", procs[1].PID)
+	}
+}
+
+func TestParseSupervisordStatus_Empty(t *testing.T) {
+	procs := ParseSupervisordStatus("")
+	if len(procs) != 0 {
+		t.Errorf("got %d procs, want 0", len(procs))
+	}
+}
+
+func TestParseSupervisordStatus_UngroupedName(t *testing.T) {
+	output := `myprocess                                RUNNING   pid 42, uptime 1:00:00`
+	procs := ParseSupervisordStatus(output)
+	if len(procs) != 1 {
+		t.Fatalf("got %d procs, want 1", len(procs))
+	}
+	if procs[0].Name != "myprocess" {
+		t.Errorf("Name = %q, want myprocess", procs[0].Name)
+	}
+}
+
+func TestProcessStateOrder(t *testing.T) {
+	if ProcessStateOrder("FATAL") >= ProcessStateOrder("BACKOFF") {
+		t.Error("FATAL should sort before BACKOFF")
+	}
+	if ProcessStateOrder("BACKOFF") >= ProcessStateOrder("STOPPED") {
+		t.Error("BACKOFF should sort before STOPPED")
+	}
+	if ProcessStateOrder("STOPPED") >= ProcessStateOrder("RUNNING") {
+		t.Error("STOPPED should sort before RUNNING")
+	}
+	if ProcessStateOrder("RUNNING") >= ProcessStateOrder("UNKNOWN_STATE") {
+		t.Error("RUNNING should sort before unknown")
+	}
+}


### PR DESCRIPTION
## Summary

- **Log Tail view**: YAML `logs:` field with merge+dedupe cascade (defaults → group → host), in-TUI streaming with pause/resume/save (`w`), newest-first, path validation
- **Processes view**: supervisord status with start/stop/restart actions streamed in-TUI, `l` key for process log tailing, failures-first sort
- **Generic SSH stream** (`sshstream.go`): reusable abstraction for any SSH command output — single view, single key handler, generation counter for stale messages
- **Dynamic Resource Picker**: conditional rows (Processes/Logs), removed hardcoded `resourceCount`
- **Probe extension**: supervisord binary detection via `command -v supervisorctl`
- 20+ unit tests covering parser, merge cascade, path validation, supervisord parser

## New files

- `internal/app/sshstream.go` — generic SSH stream abstraction
- `internal/app/logwriter.go` — on-demand log save utility
- `internal/app/view_processes.go` — supervisord process list
- `internal/app/view_logfiles.go` — log file list with stat metadata
- `internal/config/logs.go` — MergeLogEntries, ValidateLogPath
- `internal/ssh/supervisord.go` — ParseSupervisordStatus, ProcessStateOrder