### PR TITLE
chore: adopt teatest framework with baseline UI tests (FLE-80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,33 @@ make test     # run unit tests
 
 TDD: Opus (Step 2) designs *what to test* across all tiers. Sonnet (Step 3) translates unit + UI tests into Go test code. Integration tests go into the Test Plan/Run in Linear for Step 4.
 
+### UI test pattern (teatest)
+
+UI tests drive a real `tea.Program` via `github.com/charmbracelet/x/exp/teatest`. They verify rendered output and key-handler wiring end-to-end.
+
+Minimal shape:
+
+```go
+tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(100, 30))
+
+teatest.WaitFor(t, tm.Output(),
+    func(bts []byte) bool { return bytes.Contains(bts, []byte("expected text")) },
+    teatest.WithDuration(2*time.Second),
+)
+
+tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+```
+
+Guidelines:
+- Always set an initial term size — the Model's width/height guards fall back to 80×24 but explicit is clearer and avoids reflow surprises
+- Use `WaitFor` with a 2s duration for render assertions — teatest's 1s default is sometimes tight under CI load
+- Use `WaitFinished` with a 2s timeout after sending the quit key
+- Construct `Model` via a test helper that sets `AppConfig.FleetDir` to a placeholder (any non-empty string) — an empty FleetDir triggers the first-run wizard and makes the view state unpredictable
+- Use `bytes.Contains` on raw output rather than golden files for baseline tests — golden files make sense only once a view's rendering is stable
+
+See `internal/app/teatest_baseline_test.go` for the canonical example.
+
 ## Security
 
 - No hardcoded credentials, keys, or secrets — use environment variables

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913
 	github.com/kevinburke/ssh_config v1.6.0
 	github.com/mattn/go-runewidth v0.0.22
 	golang.org/x/crypto v0.49.0
@@ -13,9 +14,11 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -27,7 +30,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.3.2 h1:9J27WdztfJQVAQKX2WOlSSRB+5gaKqqITmrvb1uTIiI=
@@ -10,6 +12,10 @@ github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a h1:G99klV19u0QnhiizODirwVksQB91TJKV/UaTnACcG30=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913 h1:MvJqk9htSLLxNlNQRqfRMhObcytCT4+xfO4830kNlVs=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913/go.mod h1:aPVjFrBwbJgj5Qz1F0IXsnbcOVJcMKgu1ySUfTAxh7k=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/internal/app/teatest_baseline_test.go
+++ b/internal/app/teatest_baseline_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+// baselineModel builds a Model for teatest UI tests.
+// FleetDir is set to a placeholder so the first-run wizard does not fire.
+func baselineModel(fleets []config.Fleet) Model {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	appCfg := config.AppConfig{FleetDir: "/tmp/fleetdesk-teatest"}
+	return NewModel(fleets, appCfg, logger, "test", "none")
+}
+
+func TestTeatestBaseline_FleetPickerEmptyState(t *testing.T) {
+	tm := teatest.NewTestModel(t, baselineModel(nil),
+		teatest.WithInitialTermSize(100, 30),
+	)
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("No fleet files found"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestTeatestBaseline_FleetPickerRendersFleets(t *testing.T) {
+	fleets := []config.Fleet{
+		{Name: "test-vm", Type: "vm", Path: "/tmp/test-vm.yaml"},
+		{Name: "test-azure", Type: "azure", Path: "/tmp/test-azure.yaml"},
+	}
+	tm := teatest.NewTestModel(t, baselineModel(fleets),
+		teatest.WithInitialTermSize(100, 30),
+	)
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("test-vm")) &&
+				bytes.Contains(bts, []byte("test-azure"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}


### PR DESCRIPTION
## Summary

Adds the `teatest` test framework and two baseline UI tests. Prerequisite for FLE-81 (shared list renderer) and v0.15.0 Team Notes (FLE-77/78/79), whose acceptance criteria require teatest-backed UI tests.

## Changes

- `go.mod` / `go.sum` — add `github.com/charmbracelet/x/exp/teatest`
- `internal/app/teatest_baseline_test.go` — two baseline tests driving a real `tea.Program`:
  - `TestTeatestBaseline_FleetPickerEmptyState` — no fleets → renders "No fleet files found", `q` quits
  - `TestTeatestBaseline_FleetPickerRendersFleets` — two fleets → both names render, `q` quits
- `CLAUDE.md` — new "UI test pattern (teatest)" section under Testing tiers, with example snippet and guidelines

## Out of scope

- Migrating existing tests to teatest
- UI test suites for current views (per-feature work)

## Test results

```
go test ./internal/app/ -run TestTeatestBaseline -race -v
--- PASS: TestTeatestBaseline_FleetPickerEmptyState (0.06s)
--- PASS: TestTeatestBaseline_FleetPickerRendersFleets (0.06s)
```

`go test ./...` passes.

Lint fails with a pre-existing Go-toolchain mismatch (`golangci-lint` built against go1.24, repo targets go1.25.7) — unrelated to this change.

Closes FLE-80.