### PR TITLE
feat: v0.15.0 Team Notes + prerequisites (FLE-77/78/79/80/81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,33 @@ make test     # run unit tests
 
 TDD: Opus (Step 2) designs *what to test* across all tiers. Sonnet (Step 3) translates unit + UI tests into Go test code. Integration tests go into the Test Plan/Run in Linear for Step 4.
 
+### UI test pattern (teatest)
+
+UI tests drive a real `tea.Program` via `github.com/charmbracelet/x/exp/teatest`. They verify rendered output and key-handler wiring end-to-end.
+
+Minimal shape:
+
+```go
+tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(100, 30))
+
+teatest.WaitFor(t, tm.Output(),
+    func(bts []byte) bool { return bytes.Contains(bts, []byte("expected text")) },
+    teatest.WithDuration(2*time.Second),
+)
+
+tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+```
+
+Guidelines:
+- Always set an initial term size — the Model's width/height guards fall back to 80×24 but explicit is clearer and avoids reflow surprises
+- Use `WaitFor` with a 2s duration for render assertions — teatest's 1s default is sometimes tight under CI load
+- Use `WaitFinished` with a 2s timeout after sending the quit key
+- Construct `Model` via a test helper that sets `AppConfig.FleetDir` to a placeholder (any non-empty string) — an empty FleetDir triggers the first-run wizard and makes the view state unpredictable
+- Use `bytes.Contains` on raw output rather than golden files for baseline tests — golden files make sense only once a view's rendering is stable
+
+See `internal/app/teatest_baseline_test.go` for the canonical example.
+
 ## Security
 
 - No hardcoded credentials, keys, or secrets — use environment variables

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913
 	github.com/kevinburke/ssh_config v1.6.0
 	github.com/mattn/go-runewidth v0.0.22
 	golang.org/x/crypto v0.49.0
@@ -13,9 +14,11 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
 	github.com/charmbracelet/colorprofile v0.3.2 // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -27,7 +30,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.3.2 h1:9J27WdztfJQVAQKX2WOlSSRB+5gaKqqITmrvb1uTIiI=
@@ -10,6 +12,10 @@ github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a h1:G99klV19u0QnhiizODirwVksQB91TJKV/UaTnACcG30=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913 h1:MvJqk9htSLLxNlNQRqfRMhObcytCT4+xfO4830kNlVs=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260413165052-6921c759c913/go.mod h1:aPVjFrBwbJgj5Qz1F0IXsnbcOVJcMKgu1ySUfTAxh7k=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/internal/app/commands_notes.go
+++ b/internal/app/commands_notes.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"os"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
+)
+
+// --- Messages for the notes feature ---
+
+// noteListLoadedMsg is sent after the note list for the current ref is loaded.
+type noteListLoadedMsg struct {
+	ref   notes.ResourceRef
+	notes []notes.Note
+	err   error
+}
+
+// noteReadLoadedMsg is sent after a note file's contents have been read.
+type noteReadLoadedMsg struct {
+	path    string
+	content string
+	err     error
+}
+
+// noteCreatedMsg is sent after a new (empty) note file has been created on disk.
+// Triggers an editor handover; on editor exit, we reload the list and drop
+// empty files.
+type noteCreatedMsg struct {
+	ref  notes.ResourceRef
+	path string
+	err  error
+}
+
+// noteEditFinishedMsg is sent when the editor returns after a note create/edit.
+type noteEditFinishedMsg struct {
+	path      string // path of the note being edited (may be the just-created empty file)
+	createdAt bool   // true if this was the post-create flow (delete if still empty)
+}
+
+// noteDeletedMsg is sent after Engine.Delete completes.
+type noteDeletedMsg struct {
+	path string
+	err  error
+}
+
+// noteCountsLoadedMsg is sent after a batch stat of note counts for refs in
+// the current view (FLE-79).
+type noteCountsLoadedMsg struct {
+	counts map[string]int
+}
+
+// --- Commands ---
+
+// loadNoteListCmd reads notes for ref and emits noteListLoadedMsg.
+func (m Model) loadNoteListCmd(ref notes.ResourceRef) tea.Cmd {
+	engine := m.noteEngine
+	return func() tea.Msg {
+		items, err := engine.List(ref)
+		return noteListLoadedMsg{ref: ref, notes: items, err: err}
+	}
+}
+
+// loadNoteReadCmd reads a single note file and emits noteReadLoadedMsg.
+func (m Model) loadNoteReadCmd(path string) tea.Cmd {
+	return func() tea.Msg {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return noteReadLoadedMsg{path: path, err: err}
+		}
+		return noteReadLoadedMsg{path: path, content: string(data)}
+	}
+}
+
+// createNoteCmd creates an empty note file for ref and emits noteCreatedMsg.
+func (m Model) createNoteCmd(ref notes.ResourceRef) tea.Cmd {
+	engine := m.noteEngine
+	return func() tea.Msg {
+		path, err := engine.Create(ref)
+		return noteCreatedMsg{ref: ref, path: path, err: err}
+	}
+}
+
+// editNoteCmd opens the given note path in the user's editor. On exit, a
+// noteEditFinishedMsg fires. `afterCreate` distinguishes the post-create
+// flow (where we drop the file if still empty) from a normal edit.
+func (m Model) editNoteCmd(path string, afterCreate bool) tea.Cmd {
+	e := &editorExec{path: path, editor: m.appCfg.Editor()}
+	return tea.Exec(e, func(err error) tea.Msg {
+		return noteEditFinishedMsg{path: path, createdAt: afterCreate}
+	})
+}
+
+// deleteNoteCmd removes a note file and emits noteDeletedMsg.
+func (m Model) deleteNoteCmd(path string) tea.Cmd {
+	engine := m.noteEngine
+	return func() tea.Msg {
+		err := engine.Delete(path)
+		return noteDeletedMsg{path: path, err: err}
+	}
+}
+
+// loadNoteCountsCmd stats each ref's note directory and emits
+// noteCountsLoadedMsg with a map keyed by ref.Key().
+func (m Model) loadNoteCountsCmd(refs []notes.ResourceRef) tea.Cmd {
+	engine := m.noteEngine
+	if engine == nil || len(refs) == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		counts := make(map[string]int, len(refs))
+		for _, r := range refs {
+			counts[r.Key()] = engine.Count(r)
+		}
+		return noteCountsLoadedMsg{counts: counts}
+	}
+}
+
+// fileIsEmpty reports whether the file at path has zero bytes of
+// non-whitespace content. Used to clean up abandoned create flows.
+func fileIsEmpty(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == ""
+}

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -113,6 +113,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.k8sWorkloadCursor = 0
 				m.k8sPodCursor = 0
 				m.k8sPodContainerCursor = 0
+				m.noteCursor = 0
 			}
 		default:
 			if msg.Type == tea.KeyRunes {
@@ -142,6 +143,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.k8sWorkloadCursor = 0
 				m.k8sPodCursor = 0
 				m.k8sPodContainerCursor = 0
+				m.noteCursor = 0
 			}
 		}
 		return m, nil
@@ -149,6 +151,22 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	m.flash = ""
 	m.flashError = false
+
+	// Global `n` key intercept (FLE-78): open Note List for the currently
+	// selected resource. Only fires on noteable list views; individual view
+	// handlers never see the `n` key when their view is noteable.
+	if msg.String() == "n" && isNoteableView(m.view) && m.noteEngine != nil {
+		ref, ok := m.currentNoteRef()
+		if !ok {
+			return m, nil
+		}
+		m.noteRef = ref
+		m.previousView = m.view
+		m.noteCursor = 0
+		m.filterText = ""
+		m.filterActive = false
+		return m, m.loadNoteListCmd(ref)
+	}
 
 	switch msg.String() {
 	case "q", "ctrl+c":
@@ -256,6 +274,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleProbeDetailKeys(msg)
 	case viewConfig:
 		return m.handleConfigKeys(msg)
+	case viewNoteList:
+		return m.handleNoteListKeys(msg)
+	case viewNoteRead:
+		return m.handleNoteReadKeys(msg)
 	}
 	return m, nil
 }

--- a/internal/app/logwriter.go
+++ b/internal/app/logwriter.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/fspath"
 )
 
 // logWriter manages saving streamed log output to a file.
@@ -20,10 +21,10 @@ type logWriter struct {
 //
 // Returns nil (no error) if the file cannot be created — log saving is best-effort.
 func newLogWriter(fleetDir, fleetName, hostName, sourceName string) *logWriter {
-	dir := filepath.Join(fleetDir, "logs", sanitizePathComponent(fleetName), sanitizePathComponent(hostName))
+	dir := filepath.Join(fleetDir, "logs", fspath.Sanitize(fleetName), fspath.Sanitize(hostName))
 	os.MkdirAll(dir, 0755)
 
-	fileName := fmt.Sprintf("%s-%s.log", sanitizePathComponent(sourceName), time.Now().Format("2006-01-02_150405"))
+	fileName := fmt.Sprintf("%s-%s.log", fspath.Sanitize(sourceName), time.Now().Format("2006-01-02_150405"))
 	f, err := os.Create(filepath.Join(dir, fileName))
 	if err != nil {
 		return nil
@@ -64,10 +65,4 @@ func (lw *logWriter) Path() string {
 		return ""
 	}
 	return lw.file.Name()
-}
-
-// sanitizePathComponent replaces characters unsafe for directory/file names.
-func sanitizePathComponent(s string) string {
-	r := strings.NewReplacer("/", "_", "\\", "_", " ", "-", ":", "_")
-	return r.Replace(s)
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/probes"
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/ssh"
 )
@@ -263,6 +264,8 @@ const (
 	viewProbeList
 	viewProbeDetail
 	viewConfig
+	viewNoteList
+	viewNoteRead
 )
 
 // resourceCount removed — replaced by dynamic visibleResourceRows()
@@ -515,6 +518,17 @@ type Model struct {
 	modal           *ModalOverlay
 	wizardCancelled bool
 	wizardExitError error
+
+	// notes (FLE-77/78/79)
+	noteEngine      *notes.Engine
+	noteRef         notes.ResourceRef // resource whose notes are being viewed
+	noteList        []notes.Note      // loaded notes, newest first
+	noteCursor      int
+	noteReadLines   []string // split contents for scrollable reader
+	noteReadOffset  int
+	noteCounts      map[string]int // ref.Key() → count, for FLE-79 indicators
+	previousView    view           // for Esc-back from Note List to the originating view
+	noteLastCreated string         // path of just-created note; delete on exit if still empty
 }
 
 func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logger, version, commit string) Model {
@@ -529,6 +543,10 @@ func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logge
 		logger:        logger,
 		version: version,
 		commit:  commit,
+		noteCounts: make(map[string]int),
+	}
+	if appCfg.FleetDir != "" {
+		m.noteEngine = notes.New(appCfg.FleetDir)
 	}
 	if appCfg.FleetDir == "" {
 		m.modal = NewFirstRunWizard()
@@ -1794,6 +1812,72 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.EnterAltScreen
 
+	case noteListLoadedMsg:
+		if msg.err != nil {
+			m.flash = fmt.Sprintf("Notes load failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.noteList = msg.notes
+		if m.noteCursor >= len(m.noteList) {
+			m.noteCursor = max(0, len(m.noteList)-1)
+		}
+		m.view = viewNoteList
+		return m, nil
+
+	case noteReadLoadedMsg:
+		if msg.err != nil {
+			m.flash = fmt.Sprintf("Read failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.noteReadLines = strings.Split(msg.content, "\n")
+		m.noteReadOffset = 0
+		m.view = viewNoteRead
+		return m, nil
+
+	case noteCreatedMsg:
+		if msg.err != nil {
+			m.flash = fmt.Sprintf("Create failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.noteLastCreated = msg.path
+		return m, m.editNoteCmd(msg.path, true)
+
+	case noteEditFinishedMsg:
+		// If this was a post-create flow and the file is still empty, delete it.
+		if msg.createdAt && fileIsEmpty(msg.path) {
+			_ = m.noteEngine.Delete(msg.path)
+		}
+		m.noteLastCreated = ""
+		// Invalidate count cache for this ref so indicators refresh on re-entry.
+		delete(m.noteCounts, m.noteRef.Key())
+		return m, tea.Batch(
+			tea.EnterAltScreen,
+			m.loadNoteListCmd(m.noteRef),
+		)
+
+	case noteDeleteConfirmedMsg:
+		m.modal = nil
+		return m, m.deleteNoteCmd(msg.path)
+
+	case noteDeletedMsg:
+		if msg.err != nil {
+			m.flash = fmt.Sprintf("Delete failed: %v", msg.err)
+			m.flashError = true
+			return m, nil
+		}
+		m.flash = "Note deleted"
+		delete(m.noteCounts, m.noteRef.Key())
+		return m, m.loadNoteListCmd(m.noteRef)
+
+	case noteCountsLoadedMsg:
+		for k, v := range msg.counts {
+			m.noteCounts[k] = v
+		}
+		return m, nil
+
 	case sshHandoverFinishedMsg:
 		m.modal = nil
 		// refresh list after terminal handover returns
@@ -1951,6 +2035,10 @@ func (m Model) renderCurrentView() string {
 		return m.renderProbeList()
 	case viewProbeDetail:
 		return m.renderProbeDetail()
+	case viewNoteList:
+		return m.renderNoteList()
+	case viewNoteRead:
+		return m.renderNoteRead()
 	}
 	return ""
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -555,7 +555,10 @@ func NewModel(fleets []config.Fleet, appCfg config.AppConfig, logger *slog.Logge
 }
 
 func (m Model) Init() tea.Cmd {
-	return nil
+	// On startup, the initial view is Fleet Picker (or first-run wizard). If
+	// it's noteable, fire an initial note-count load so indicators appear
+	// without waiting for the first tick.
+	return m.refreshNoteCountsCmd()
 }
 
 // WizardCancelled returns true if the first-run wizard was cancelled.
@@ -1912,21 +1915,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.EnterAltScreen
 
 	case tickMsg:
+		countsCmd := m.refreshNoteCountsCmd()
 		if m.view == viewHostList {
-			return m, tea.Batch(m.startProbe(), m.tickCmd())
+			return m, tea.Batch(m.startProbe(), m.tickCmd(), countsCmd)
 		}
 		if m.view == viewAzureSubList {
-			return m, tea.Batch(m.startAzureProbe(), m.tickCmd())
+			return m, tea.Batch(m.startAzureProbe(), m.tickCmd(), countsCmd)
 		}
 		if m.view == viewAzureAKSList {
-			return m, tea.Batch(m.fetchAzureAKSClusters(), m.tickCmd())
+			return m, tea.Batch(m.fetchAzureAKSClusters(), m.tickCmd(), countsCmd)
 		}
 		if m.view == viewK8sPodList {
 			ns := m.k8sNamespaces[m.selectedK8sNamespace].Name
 			w := m.k8sWorkloads[m.selectedK8sWorkload]
-			return m, tea.Batch(m.fetchK8sPods(ns, w.Name), m.tickCmd())
+			return m, tea.Batch(m.fetchK8sPods(ns, w.Name), m.tickCmd(), countsCmd)
 		}
-		return m, nil
+		return m, countsCmd
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)

--- a/internal/app/note_indicator.go
+++ b/internal/app/note_indicator.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
+)
+
+const noteIcon = "\U0001f4dd " // 📝 + space
+
+// notePrefix returns the note indicator for ref based on the cached count,
+// or an empty string when no notes are recorded. The count cache is
+// populated asynchronously — until loaded, the view renders without
+// indicators (no flicker on first render).
+func (m Model) notePrefix(ref notes.ResourceRef) string {
+	if m.noteCounts[ref.Key()] > 0 {
+		return noteIcon
+	}
+	return ""
+}
+
+// refreshNoteCountsCmd returns a Cmd that batch-loads note counts for the
+// currently visible refs in the current view. Returns nil if the engine
+// is not initialized or the view is not noteable.
+func (m Model) refreshNoteCountsCmd() tea.Cmd {
+	if m.noteEngine == nil {
+		return nil
+	}
+	refs := m.refsInView()
+	if len(refs) == 0 {
+		return nil
+	}
+	return m.loadNoteCountsCmd(refs)
+}

--- a/internal/app/noteref.go
+++ b/internal/app/noteref.go
@@ -1,0 +1,303 @@
+package app
+
+import (
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
+)
+
+// isNoteableView reports whether the `n` key should open the Note List for
+// the currently displayed view. Only resource list views that carry a
+// well-defined selected resource are noteable.
+func isNoteableView(v view) bool {
+	switch v {
+	case viewFleetPicker,
+		viewHostList,
+		viewServiceList,
+		viewContainerList,
+		viewAzureSubList,
+		viewAzureVMList,
+		viewAzureAKSList,
+		viewK8sClusterList,
+		viewK8sNamespaceList,
+		viewK8sWorkloadList,
+		viewK8sPodList:
+		return true
+	}
+	return false
+}
+
+// currentNoteRef returns the ResourceRef for the currently selected item in
+// the current view. Returns (_, false) when no ref can be produced (e.g.
+// view has no items, or cursor is out of range).
+func (m Model) currentNoteRef() (notes.ResourceRef, bool) {
+	switch m.view {
+	case viewFleetPicker:
+		if m.fleetCursor >= len(m.fleets) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{Fleet: m.fleets[m.fleetCursor].Name}, true
+
+	case viewHostList:
+		if m.hostCursor >= len(m.hosts) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet:    m.fleets[m.selectedFleet].Name,
+			Segments: []string{"hosts", m.hosts[m.hostCursor].Entry.Name},
+		}, true
+
+	case viewServiceList:
+		svcs := m.filteredServices()
+		if m.serviceCursor >= len(svcs) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"hosts", m.hosts[m.selectedHost].Entry.Name,
+				"services", svcs[m.serviceCursor].Name,
+			},
+		}, true
+
+	case viewContainerList:
+		cts := m.filteredContainers()
+		if m.containerCursor >= len(cts) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"hosts", m.hosts[m.selectedHost].Entry.Name,
+				"containers", cts[m.containerCursor].Name,
+			},
+		}, true
+
+	case viewAzureSubList:
+		if m.azureSubCursor >= len(m.azureSubs) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet:    m.fleets[m.selectedFleet].Name,
+			Segments: []string{"azure", m.azureSubs[m.azureSubCursor].Name},
+		}, true
+
+	case viewAzureVMList:
+		vms := m.filteredAzureVMs()
+		if m.azureVMCursor >= len(vms) {
+			return notes.ResourceRef{}, false
+		}
+		vm := vms[m.azureVMCursor]
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"azure", m.azureSubs[m.selectedAzureSub].Name,
+				vm.ResourceGroup, "vm", vm.Name,
+			},
+		}, true
+
+	case viewAzureAKSList:
+		if m.azureAKSCursor >= len(m.azureAKSClusters) {
+			return notes.ResourceRef{}, false
+		}
+		aks := m.azureAKSClusters[m.azureAKSCursor]
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"azure", m.azureSubs[m.selectedAzureSub].Name,
+				aks.ResourceGroup, "aks", aks.Name,
+			},
+		}, true
+
+	case viewK8sClusterList:
+		if m.k8sClusterCursor >= len(m.k8sClusters) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet:    m.fleets[m.selectedFleet].Name,
+			Segments: []string{"k8s", m.k8sClusters[m.k8sClusterCursor].Name},
+		}, true
+
+	case viewK8sNamespaceList:
+		nss := m.filteredK8sNamespaces()
+		if m.k8sNamespaceCursor >= len(nss) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"k8s", m.k8sClusters[m.selectedK8sCluster].Name,
+				m.selectedK8sContext, nss[m.k8sNamespaceCursor].Name,
+			},
+		}, true
+
+	case viewK8sWorkloadList:
+		wls := m.filteredK8sWorkloads()
+		if m.k8sWorkloadCursor >= len(wls) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"k8s", m.k8sClusters[m.selectedK8sCluster].Name,
+				m.selectedK8sContext,
+				m.k8sNamespaces[m.selectedK8sNamespace].Name,
+				wls[m.k8sWorkloadCursor].Name,
+			},
+		}, true
+
+	case viewK8sPodList:
+		pods := m.filteredK8sPodList()
+		if m.k8sPodCursor >= len(pods) {
+			return notes.ResourceRef{}, false
+		}
+		return notes.ResourceRef{
+			Fleet: m.fleets[m.selectedFleet].Name,
+			Segments: []string{
+				"k8s", m.k8sClusters[m.selectedK8sCluster].Name,
+				m.selectedK8sContext,
+				m.k8sNamespaces[m.selectedK8sNamespace].Name,
+				"pods", pods[m.k8sPodCursor].Name,
+			},
+		}, true
+	}
+	return notes.ResourceRef{}, false
+}
+
+// refsInView returns one ResourceRef per visible item in the current view.
+// Used by FLE-79 to batch-load note counts on view entry. Returns nil if the
+// view is not noteable.
+func (m Model) refsInView() []notes.ResourceRef {
+	if !isNoteableView(m.view) {
+		return nil
+	}
+	fleet := func() string {
+		if m.selectedFleet < len(m.fleets) {
+			return m.fleets[m.selectedFleet].Name
+		}
+		return ""
+	}
+
+	switch m.view {
+	case viewFleetPicker:
+		refs := make([]notes.ResourceRef, 0, len(m.fleets))
+		for _, f := range m.fleets {
+			refs = append(refs, notes.ResourceRef{Fleet: f.Name})
+		}
+		return refs
+
+	case viewHostList:
+		refs := make([]notes.ResourceRef, 0, len(m.hosts))
+		for _, h := range m.hosts {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"hosts", h.Entry.Name},
+			})
+		}
+		return refs
+
+	case viewServiceList:
+		svcs := m.filteredServices()
+		refs := make([]notes.ResourceRef, 0, len(svcs))
+		hostName := m.hosts[m.selectedHost].Entry.Name
+		for _, svc := range svcs {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"hosts", hostName, "services", svc.Name},
+			})
+		}
+		return refs
+
+	case viewContainerList:
+		cts := m.filteredContainers()
+		refs := make([]notes.ResourceRef, 0, len(cts))
+		hostName := m.hosts[m.selectedHost].Entry.Name
+		for _, c := range cts {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"hosts", hostName, "containers", c.Name},
+			})
+		}
+		return refs
+
+	case viewAzureSubList:
+		refs := make([]notes.ResourceRef, 0, len(m.azureSubs))
+		for _, sub := range m.azureSubs {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"azure", sub.Name},
+			})
+		}
+		return refs
+
+	case viewAzureVMList:
+		vms := m.filteredAzureVMs()
+		refs := make([]notes.ResourceRef, 0, len(vms))
+		subName := m.azureSubs[m.selectedAzureSub].Name
+		for _, vm := range vms {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"azure", subName, vm.ResourceGroup, "vm", vm.Name},
+			})
+		}
+		return refs
+
+	case viewAzureAKSList:
+		refs := make([]notes.ResourceRef, 0, len(m.azureAKSClusters))
+		subName := m.azureSubs[m.selectedAzureSub].Name
+		for _, aks := range m.azureAKSClusters {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"azure", subName, aks.ResourceGroup, "aks", aks.Name},
+			})
+		}
+		return refs
+
+	case viewK8sClusterList:
+		refs := make([]notes.ResourceRef, 0, len(m.k8sClusters))
+		for _, c := range m.k8sClusters {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"k8s", c.Name},
+			})
+		}
+		return refs
+
+	case viewK8sNamespaceList:
+		nss := m.filteredK8sNamespaces()
+		refs := make([]notes.ResourceRef, 0, len(nss))
+		clusterName := m.k8sClusters[m.selectedK8sCluster].Name
+		for _, ns := range nss {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, ns.Name},
+			})
+		}
+		return refs
+
+	case viewK8sWorkloadList:
+		wls := m.filteredK8sWorkloads()
+		refs := make([]notes.ResourceRef, 0, len(wls))
+		clusterName := m.k8sClusters[m.selectedK8sCluster].Name
+		nsName := m.k8sNamespaces[m.selectedK8sNamespace].Name
+		for _, wl := range wls {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, nsName, wl.Name},
+			})
+		}
+		return refs
+
+	case viewK8sPodList:
+		pods := m.filteredK8sPodList()
+		refs := make([]notes.ResourceRef, 0, len(pods))
+		clusterName := m.k8sClusters[m.selectedK8sCluster].Name
+		nsName := m.k8sNamespaces[m.selectedK8sNamespace].Name
+		for _, p := range pods {
+			refs = append(refs, notes.ResourceRef{
+				Fleet:    fleet(),
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, nsName, "pods", p.Name},
+			})
+		}
+		return refs
+	}
+	return nil
+}

--- a/internal/app/notes_teatest_test.go
+++ b/internal/app/notes_teatest_test.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
+)
+
+// newNotesTestModel builds a Model with a real notes engine rooted at fleetDir.
+// Used by FLE-78 UI tests that need to seed note files on disk.
+func newNotesTestModel(t *testing.T, fleetDir string, fleets []config.Fleet) Model {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	appCfg := config.AppConfig{FleetDir: fleetDir}
+	return NewModel(fleets, appCfg, logger, "test", "none")
+}
+
+// seedNote writes a note file directly on disk to simulate a pre-existing note.
+func seedNote(t *testing.T, fleetDir string, ref notes.ResourceRef, content string) {
+	t.Helper()
+	dir := ref.Dir(filepath.Join(fleetDir, "notes"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := time.Now().UTC().Format("2006-01-02T15-04-05.000") + "_note.txt"
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Sleep 1ms to avoid filename collision on rapid seeds within the same test.
+	time.Sleep(time.Millisecond)
+}
+
+func TestNotes_N_OnHostList_OpensEmptyNoteList(t *testing.T) {
+	fleetDir := t.TempDir()
+	m := newNotesTestModel(t, fleetDir, []config.Fleet{{Name: "test", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host-a"}, Status: config.HostOnline}}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			// Note List breadcrumb includes the fleet + resource path
+			return bytes.Contains(bts, []byte("Notes")) &&
+				bytes.Contains(bts, []byte("host-a")) &&
+				bytes.Contains(bts, []byte("No notes for this resource"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestNotes_N_OnHostList_ShowsExistingNotes(t *testing.T) {
+	fleetDir := t.TempDir()
+	ref := notes.ResourceRef{Fleet: "test", Segments: []string{"hosts", "host-a"}}
+	seedNote(t, fleetDir, ref, "first note about host-a")
+	seedNote(t, fleetDir, ref, "second note later")
+
+	m := newNotesTestModel(t, fleetDir, []config.Fleet{{Name: "test", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host-a"}, Status: config.HostOnline}}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("DATE")) &&
+				bytes.Contains(bts, []byte("PREVIEW")) &&
+				bytes.Contains(bts, []byte("first note about host-a")) &&
+				bytes.Contains(bts, []byte("second note later"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestNotes_NoteList_Esc_ReturnsToHostList(t *testing.T) {
+	fleetDir := t.TempDir()
+	m := newNotesTestModel(t, fleetDir, []config.Fleet{{Name: "test", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host-a"}, Status: config.HostOnline}}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool { return bytes.Contains(bts, []byte("No notes for this resource")) },
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			// Back on Host List: "HOST" header + host-a visible, no "No notes" message
+			return bytes.Contains(bts, []byte("HOST")) &&
+				bytes.Contains(bts, []byte("host-a")) &&
+				!bytes.Contains(bts, []byte("No notes for this resource"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestNotes_NoteList_DeleteShowsConfirmModal(t *testing.T) {
+	fleetDir := t.TempDir()
+	ref := notes.ResourceRef{Fleet: "test", Segments: []string{"hosts", "host-a"}}
+	seedNote(t, fleetDir, ref, "important context from the incident")
+
+	m := newNotesTestModel(t, fleetDir, []config.Fleet{{Name: "test", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host-a"}, Status: config.HostOnline}}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool { return bytes.Contains(bts, []byte("important context from the incident")) },
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("Delete note")) &&
+				bytes.Contains(bts, []byte("important context from the incident"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	// Cancel the modal — ensures we don't actually delete during test.
+	tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+

--- a/internal/app/notes_teatest_test.go
+++ b/internal/app/notes_teatest_test.go
@@ -125,6 +125,50 @@ func TestNotes_NoteList_Esc_ReturnsToHostList(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
 }
 
+func TestNotes_Indicator_AppearsOnHostWithNotes(t *testing.T) {
+	fleetDir := t.TempDir()
+	// Seed a note on host-b only.
+	seedNote(t, fleetDir, notes.ResourceRef{Fleet: "test", Segments: []string{"hosts", "host-b"}}, "operational note")
+
+	m := newNotesTestModel(t, fleetDir, []config.Fleet{{Name: "test", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{
+		{Entry: config.HostEntry{Name: "host-a"}, Status: config.HostOnline, OS: "RHEL 9"},
+		{Entry: config.HostEntry{Name: "host-b"}, Status: config.HostOnline, OS: "RHEL 9"},
+	}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	// The count load fires via Init(). WaitFor the indicator to appear on host-b.
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			// The note icon 📝 should appear before host-b but not host-a.
+			lines := bytes.Split(bts, []byte("\n"))
+			hostARow := findLineContaining(lines, []byte("host-a"))
+			hostBRow := findLineContaining(lines, []byte("host-b"))
+			if hostARow == nil || hostBRow == nil {
+				return false
+			}
+			return bytes.Contains(hostBRow, []byte("\U0001f4dd")) &&
+				!bytes.Contains(hostARow, []byte("\U0001f4dd"))
+		},
+		teatest.WithDuration(3*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func findLineContaining(lines [][]byte, needle []byte) []byte {
+	for _, line := range lines {
+		if bytes.Contains(line, needle) {
+			return line
+		}
+	}
+	return nil
+}
+
 func TestNotes_NoteList_DeleteShowsConfirmModal(t *testing.T) {
 	fleetDir := t.TempDir()
 	ref := notes.ResourceRef{Fleet: "test", Segments: []string{"hosts", "host-a"}}

--- a/internal/app/teatest_baseline_test.go
+++ b/internal/app/teatest_baseline_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+)
+
+// baselineModel builds a Model for teatest UI tests.
+// FleetDir is set to a placeholder so the first-run wizard does not fire.
+func baselineModel(fleets []config.Fleet) Model {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	appCfg := config.AppConfig{FleetDir: "/tmp/fleetdesk-teatest"}
+	return NewModel(fleets, appCfg, logger, "test", "none")
+}
+
+func TestTeatestBaseline_FleetPickerEmptyState(t *testing.T) {
+	tm := teatest.NewTestModel(t, baselineModel(nil),
+		teatest.WithInitialTermSize(100, 30),
+	)
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("No fleet files found"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestTeatestBaseline_FleetPickerRendersFleets(t *testing.T) {
+	fleets := []config.Fleet{
+		{Name: "test-vm", Type: "vm", Path: "/tmp/test-vm.yaml"},
+		{Name: "test-azure", Type: "azure", Path: "/tmp/test-azure.yaml"},
+	}
+	tm := teatest.NewTestModel(t, baselineModel(fleets),
+		teatest.WithInitialTermSize(100, 30),
+	)
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("test-vm")) &&
+				bytes.Contains(bts, []byte("test-azure"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}

--- a/internal/app/view_azure_aks.go
+++ b/internal/app/view_azure_aks.go
@@ -229,6 +229,7 @@ func (m Model) renderAzureAKSList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
+			{"n", "Notes"},
 			{"s", "Start"},
 			{"o", "Stop"},
 			{"d", "Delete"},

--- a/internal/app/view_azure_sublist.go
+++ b/internal/app/view_azure_sublist.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
 )
 
@@ -24,81 +22,50 @@ func (m Model) renderAzureSubList() string {
 	s := m.renderHeader(breadcrumb, m.azureSubCursor+1, len(m.azureSubs)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if len(m.azureSubs) == 0 {
-		s += borderedRow("  No subscriptions in fleet.", iw, normalRowStyle) + "\n"
-	} else {
-		nameCol := len("SUBSCRIPTION")
-		tenantCol := len("TENANT")
-		userCol := len("USER")
-		for _, sub := range m.azureSubs {
-			if len(sub.Name) > nameCol {
-				nameCol = len(sub.Name)
-			}
-			if len(sub.Tenant) > tenantCol {
-				tenantCol = len(sub.Tenant)
-			}
-			if len(sub.User) > userCol {
-				userCol = len(sub.User)
-			}
-		}
-		nameCol += 2
-		tenantCol += 2
-		userCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s",
-			nameCol, "SUBSCRIPTION"+m.sortIndicator(1),
-			tenantCol, "TENANT"+m.sortIndicator(2),
-			userCol, "USER"+m.sortIndicator(3),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+	nameCol := len("SUBSCRIPTION")
+	for _, sub := range m.azureSubs {
+		if len(sub.Name) > nameCol {
+			nameCol = len(sub.Name)
+		}
+	}
+	nameCol += 2
 
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.azureSubCursor >= offset+maxVisible {
-			offset = m.azureSubCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(m.azureSubs) {
-			end = len(m.azureSubs)
-		}
-
-		for i := offset; i < end; i++ {
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "SUBSCRIPTION", Width: nameCol, SortIndex: 1},
+			{Label: "TENANT", SortIndex: 2},
+			{Label: "USER", SortIndex: 3},
+		},
+		RowCount: len(m.azureSubs),
+		RowBuilder: func(i int) []string {
 			sub := m.azureSubs[i]
-			cur := "   "
-			if i == m.azureSubCursor {
-				cur = " ▸ "
-			}
-
-			var line string
+			return []string{sub.Name, sub.Tenant, sub.User}
+		},
+		RowOverride: func(i int) string {
+			sub := m.azureSubs[i]
 			switch sub.Status {
 			case azure.SubConnecting:
-				line = fmt.Sprintf("%s  %-*s  checking...", cur, nameCol, sub.Name)
+				return fmt.Sprintf("%-*s  checking...", nameCol, sub.Name)
 			case azure.SubError:
 				reason := sub.Error
 				if reason == "" {
 					reason = "unknown"
 				}
-				line = fmt.Sprintf("%s  %-*s  error (%s)", cur, nameCol, sub.Name, reason)
-			case azure.SubOnline:
-				line = fmt.Sprintf("%s  %-*s  %-*s  %-*s",
-					cur, nameCol, sub.Name, tenantCol, sub.Tenant, userCol, sub.User)
+				return fmt.Sprintf("%-*s  error (%s)", nameCol, sub.Name, reason)
 			}
-
-			var style lipgloss.Style
-			if i == m.azureSubCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+			return ""
+		},
+		Cursor:        m.azureSubCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  "  No subscriptions in fleet.",
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"

--- a/internal/app/view_azure_sublist.go
+++ b/internal/app/view_azure_sublist.go
@@ -84,6 +84,7 @@ func (m Model) renderAzureSubList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Drill In"},
+			{"n", "Notes"},
 			{"r", "Refresh"},
 			{"/", "Filter"},
 			{"1-3", "Sort"},

--- a/internal/app/view_azure_sublist.go
+++ b/internal/app/view_azure_sublist.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/azure"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderAzureSubList() string {
@@ -35,6 +36,7 @@ func (m Model) renderAzureSubList() string {
 	}
 	nameCol += 2
 
+	fleetName := m.fleets[m.selectedFleet].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "SUBSCRIPTION", Width: nameCol, SortIndex: 1},
@@ -45,6 +47,12 @@ func (m Model) renderAzureSubList() string {
 		RowBuilder: func(i int) []string {
 			sub := m.azureSubs[i]
 			return []string{sub.Name, sub.Tenant, sub.User}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"azure", m.azureSubs[i].Name},
+			})
 		},
 		RowOverride: func(i int) string {
 			sub := m.azureSubs[i]

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -37,111 +37,41 @@ func (m Model) renderAzureVMList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.azureVMCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if len(filtered) == 0 {
-		if m.filterText != "" {
-			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
-		} else {
-			s += borderedRow("  No VMs in subscription.", iw, normalRowStyle) + "\n"
-		}
-	} else {
-		nameCol := len("NAME")
-		rgCol := len("RESOURCE GROUP")
-		statusCol := len("STATUS")
-		sizeCol := len("SIZE")
-		osCol := len("OS")
-		ipCol := len("PRIVATE IP")
-		hostCol := len("HOSTNAME")
-		for _, vm := range filtered {
-			if len(vm.Name) > nameCol {
-				nameCol = len(vm.Name)
-			}
-			if len(vm.ResourceGroup) > rgCol {
-				rgCol = len(vm.ResourceGroup)
-			}
-			if len(vm.PowerState) > statusCol {
-				statusCol = len(vm.PowerState)
-			}
-			if len(vm.VMSize) > sizeCol {
-				sizeCol = len(vm.VMSize)
-			}
-			if len(vm.OSType) > osCol {
-				osCol = len(vm.OSType)
-			}
-			if len(vm.PrivateIP) > ipCol {
-				ipCol = len(vm.PrivateIP)
-			}
-			if len(vm.Hostname) > hostCol {
-				hostCol = len(vm.Hostname)
-			}
-		}
-		// Account for transition overlay display strings
-		for k, t := range m.transitions {
-			if strings.HasPrefix(k, "vm/") && len(t.Display) > statusCol {
-				statusCol = len(t.Display)
-			}
-		}
-		nameCol += 2
-		rgCol += 2
-		statusCol += 2
-		sizeCol += 2
-		osCol += 2
-		ipCol += 2
-		hostCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
-			nameCol, "NAME"+m.sortIndicator(1),
-			rgCol, "RESOURCE GROUP"+m.sortIndicator(2),
-			statusCol, "STATUS"+m.sortIndicator(3),
-			sizeCol, "SIZE"+m.sortIndicator(4),
-			osCol, "OS"+m.sortIndicator(5),
-			ipCol, "PRIVATE IP"+m.sortIndicator(6),
-			"HOSTNAME"+m.sortIndicator(7),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
+	emptyMsg := "  No VMs in subscription."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+	}
 
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.azureVMCursor >= offset+maxVisible {
-			offset = m.azureVMCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
-
-		for i := offset; i < end; i++ {
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME", SortIndex: 1},
+			{Label: "RESOURCE GROUP", SortIndex: 2},
+			{Label: "STATUS", SortIndex: 3},
+			{Label: "SIZE", SortIndex: 4},
+			{Label: "OS", SortIndex: 5},
+			{Label: "PRIVATE IP", SortIndex: 6},
+			{Label: "HOSTNAME", SortIndex: 7},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
 			vm := filtered[i]
-			cur := "   "
-			if i == m.azureVMCursor {
-				cur = " ▸ "
-			}
-
-			// Overlay: check if VM has an in-flight transition
 			status := vm.PowerState
 			if t, ok := m.transitions["vm/"+vm.Name]; ok {
 				status = t.Display
 			}
-
-			line := fmt.Sprintf("%s  %-*s  %-*s  %-*s  %-*s  %-*s  %-*s  %s",
-				cur, nameCol, vm.Name, rgCol, vm.ResourceGroup,
-				statusCol, status, sizeCol, vm.VMSize, osCol, vm.OSType,
-				ipCol, vm.PrivateIP, vm.Hostname)
-
-			var style lipgloss.Style
-			if i == m.azureVMCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+			return []string{vm.Name, vm.ResourceGroup, status, vm.VMSize, vm.OSType, vm.PrivateIP, vm.Hostname}
+		},
+		Cursor:        m.azureVMCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -93,6 +93,7 @@ func (m Model) renderAzureVMList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Detail"},
+			{"n", "Notes"},
 			{"s", "Start"},
 			{"o", "Stop"},
 			{"t", "Restart"},

--- a/internal/app/view_azure_vms.go
+++ b/internal/app/view_azure_vms.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func azureVMStatusStyle(state string) lipgloss.Style {
@@ -47,6 +49,8 @@ func (m Model) renderAzureVMList() string {
 		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	subName := m.azureSubs[m.selectedAzureSub].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "NAME", SortIndex: 1},
@@ -65,6 +69,13 @@ func (m Model) renderAzureVMList() string {
 				status = t.Display
 			}
 			return []string{vm.Name, vm.ResourceGroup, status, vm.VMSize, vm.OSType, vm.PrivateIP, vm.Hostname}
+		},
+		RowPrefix: func(i int) string {
+			vm := filtered[i]
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"azure", subName, vm.ResourceGroup, "vm", vm.Name},
+			})
 		},
 		Cursor:        m.azureVMCursor,
 		MaxVisible:    maxVisible,

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -129,6 +129,7 @@ func (m Model) renderContainerList() string {
 	s += m.renderHintBar(hintWithHelp([][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Detail"},
+		{"n", "Notes"},
 		{"1-3", "Sort"},
 		{"/", "Search"},
 		{"l", "Logs"},

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderContainerList() string {
@@ -91,6 +93,8 @@ func (m Model) renderContainerList() string {
 		maxVisible = 1
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	hostName := m.hosts[m.selectedHost].Entry.Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "CONTAINER", SortIndex: 1},
@@ -104,10 +108,14 @@ func (m Model) renderContainerList() string {
 		},
 		RowPrefix: func(i int) string {
 			c := filtered[i]
+			note := m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"hosts", hostName, "containers", c.Name},
+			})
 			if !strings.HasPrefix(c.Status, "Up") && !strings.HasPrefix(c.Status, "Exited (0)") && c.Status != "Created" {
-				return "\u2717 "
+				return note + "\u2717 "
 			}
-			return ""
+			return note
 		},
 		Cursor:        m.containerCursor,
 		MaxVisible:    maxVisible,

--- a/internal/app/view_containers.go
+++ b/internal/app/view_containers.go
@@ -83,65 +83,38 @@ func (m Model) renderContainerList() string {
 		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
 	}
 
-	if len(filtered) == 0 {
-		s += borderedRow("  No containers found.", iw, normalRowStyle) + "\n"
-	} else {
-		nameCol := len("CONTAINER")
-		imgCol := len("IMAGE")
-		for _, c := range filtered {
-			if len(c.Name) > nameCol {
-				nameCol = len(c.Name)
-			}
-			if len(c.Image) > imgCol {
-				imgCol = len(c.Image)
-			}
-		}
-		nameCol += 2
-		imgCol += 2
-
-		hdr := fmt.Sprintf("     %-*s  %-*s  %s", nameCol, "CONTAINER"+m.sortIndicator(1), imgCol, "IMAGE"+m.sortIndicator(2), "STATUS"+m.sortIndicator(3))
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
-
-		maxVisible := m.height - 8
-		if m.filterText != "" {
-			maxVisible -= 2
-		}
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.containerCursor >= offset+maxVisible {
-			offset = m.containerCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
-
-		for i := offset; i < end; i++ {
-			c := filtered[i]
-			cur := "   "
-			if i == m.containerCursor {
-				cur = " \u25b8 "
-			}
-			prefix := ""
-			if !strings.HasPrefix(c.Status, "Up") && !strings.HasPrefix(c.Status, "Exited (0)") && c.Status != "Created" {
-				prefix = "\u2717 "
-			}
-			line := fmt.Sprintf("%s  %s%-*s  %-*s  %s", cur, prefix, nameCol, c.Name, imgCol, c.Image, c.Status)
-
-			var style lipgloss.Style
-			if i == m.containerCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
+	maxVisible := m.height - 8
+	if m.filterText != "" {
+		maxVisible -= 2
 	}
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "CONTAINER", SortIndex: 1},
+			{Label: "IMAGE", SortIndex: 2},
+			{Label: "STATUS", SortIndex: 3},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
+			c := filtered[i]
+			return []string{c.Name, c.Image, c.Status}
+		},
+		RowPrefix: func(i int) string {
+			c := filtered[i]
+			if !strings.HasPrefix(c.Status, "Up") && !strings.HasPrefix(c.Status, "Exited (0)") && c.Status != "Created" {
+				return "\u2717 "
+			}
+			return ""
+		},
+		Cursor:        m.containerCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  "  No containers found.",
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -3,8 +3,6 @@ package app
 import (
 	"fmt"
 	"strings"
-
-	"github.com/charmbracelet/lipgloss"
 )
 
 func (m Model) renderFleetPicker() string {
@@ -17,71 +15,38 @@ func (m Model) renderFleetPicker() string {
 	s := m.renderHeader("", m.fleetCursor+1, len(m.fleets)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(m.fleets) == 0 {
-		noFleetMsg := "  No fleet files found"
-		if m.appCfg.FleetDir != "" {
-			noFleetMsg += " in " + m.appCfg.FleetDir
-		}
-		s += borderedRow(noFleetMsg, iw, normalRowStyle) + "\n"
-	} else {
-		nameCol := len("FLEET")
-		for _, f := range m.fleets {
-			if len(f.Name) > nameCol {
-				nameCol = len(f.Name)
-			}
-		}
-		nameCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-6s  %s", nameCol, "FLEET", "TYPE", "TARGETS")
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
+	emptyMsg := "  No fleet files found"
+	if m.appCfg.FleetDir != "" {
+		emptyMsg += " in " + m.appCfg.FleetDir
+	}
 
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
+	typeLabel := func(t string) string {
+		switch t {
+		case "kubernetes":
+			return "Kubernetes"
+		case "azure":
+			return "Azure"
+		case "probes":
+			return "Probes"
+		default:
+			return "VM"
 		}
-		offset := 0
-		if m.fleetCursor >= offset+maxVisible {
-			offset = m.fleetCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(m.fleets) {
-			end = len(m.fleets)
-		}
+	}
 
-		// build type group start map
-		typeStarts := make(map[int]string)
-		lastType := ""
-		for i, f := range m.fleets {
-			if f.Type != lastType {
-				label := f.Type
-				if label == "kubernetes" {
-					label = "Kubernetes"
-				} else if label == "azure" {
-					label = "Azure"
-				} else if label == "probes" {
-					label = "Probes"
-				} else {
-					label = "VM"
-				}
-				typeStarts[i] = label
-				lastType = f.Type
-			}
-		}
-
-		for i := offset; i < end; i++ {
-			// type group header
-			if typeName, ok := typeStarts[i]; ok {
-				groupLine := fmt.Sprintf("  \u2500\u2500 %s \u2500\u2500", typeName)
-				s += borderedRow(groupLine, iw, groupHeaderStyle) + "\n"
-			}
-
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "FLEET"},
+			{Label: "TYPE", Width: 6},
+			{Label: "TARGETS"},
+		},
+		RowCount: len(m.fleets),
+		RowBuilder: func(i int) []string {
 			f := m.fleets[i]
-			cur := "   "
-			if i == m.fleetCursor {
-				cur = " \u25b8 "
-			}
-
 			ftype := f.Type
 			if ftype == "kubernetes" {
 				ftype = "k8s"
@@ -95,19 +60,19 @@ func (m Model) renderFleetPicker() string {
 			default:
 				targetCount = len(f.Groups)
 			}
-			line := fmt.Sprintf("%s  %-*s  %-6s  %d", cur, nameCol, f.Name, ftype, targetCount)
-
-			var style lipgloss.Style
-			if i == m.fleetCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
+			return []string{f.Name, ftype, fmt.Sprintf("%d", targetCount)}
+		},
+		GroupHeader: func(i int) (string, bool) {
+			if i > 0 && m.fleets[i-1].Type == m.fleets[i].Type {
+				return "", false
 			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+			return typeLabel(m.fleets[i].Type), true
+		},
+		Cursor:       m.fleetCursor,
+		MaxVisible:   maxVisible,
+		InnerWidth:   iw,
+		EmptyMessage: emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderFleetPicker() string {
@@ -61,6 +63,9 @@ func (m Model) renderFleetPicker() string {
 				targetCount = len(f.Groups)
 			}
 			return []string{f.Name, ftype, fmt.Sprintf("%d", targetCount)}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{Fleet: m.fleets[i].Name})
 		},
 		GroupHeader: func(i int) (string, bool) {
 			if i > 0 && m.fleets[i-1].Type == m.fleets[i].Type {

--- a/internal/app/view_fleet.go
+++ b/internal/app/view_fleet.go
@@ -83,6 +83,7 @@ func (m Model) renderFleetPicker() string {
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
 	s += m.renderHintBar(hintWithHelp([][]string{
 		{"Enter", "Select"},
+		{"n", "Notes"},
 		{"a", "About"},
 		{"e", "Edit"},
 		{"c", "Config"},

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderHostList() string {
@@ -41,6 +42,7 @@ func (m Model) renderHostList() string {
 		}
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "HOST", Width: nameCol},
@@ -56,6 +58,12 @@ func (m Model) renderHostList() string {
 				updStr = "\u2014"
 			}
 			return []string{h.Entry.Name, h.OS, h.UpSince, updStr}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"hosts", m.hosts[i].Entry.Name},
+			})
 		},
 		RowOverride: func(i int) string {
 			h := m.hosts[i]

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -95,6 +95,7 @@ func (m Model) renderHostList() string {
 	hints := [][]string{
 		{"↑↓", "Navigate"},
 		{"Enter", "Drill In"},
+		{"n", "Notes"},
 		{"x", "Shell"},
 		{"c", "Commands"},
 		{"K", "Deploy Key"},

--- a/internal/app/view_hostlist.go
+++ b/internal/app/view_hostlist.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
 )
 
@@ -20,100 +18,68 @@ func (m Model) renderHostList() string {
 	s := m.renderHeader(f.Name, m.hostCursor+1, len(m.hosts)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(m.hosts) == 0 {
-		s += borderedRow("  No hosts in fleet.", iw, normalRowStyle) + "\n"
-	} else {
-		nameCol := len("HOST")
-		osCol := len("OS")
-		for _, h := range m.hosts {
-			if len(h.Entry.Name) > nameCol {
-				nameCol = len(h.Entry.Name)
-			}
-			if len(h.OS) > osCol {
-				osCol = len(h.OS)
-			}
-		}
-		nameCol += 2
-		osCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		// compute dynamic column widths from actual data
-		upCol := len("UP SINCE")
-		for _, h := range m.hosts {
-			if len(h.UpSince) > upCol {
-				upCol = len(h.UpSince)
+	nameCol := len("HOST")
+	for _, h := range m.hosts {
+		if len(h.Entry.Name) > nameCol {
+			nameCol = len(h.Entry.Name)
+		}
+	}
+	nameCol += 2
+
+	// Group starts keyed by host index (only when group label differs from previous).
+	groupStarts := make(map[int]string)
+	for i, h := range m.hosts {
+		if h.Group != "" {
+			if i == 0 || m.hosts[i-1].Group != h.Group {
+				groupStarts[i] = h.Group
 			}
 		}
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %s", nameCol, "HOST", osCol, "OS", upCol, "UP SINCE", "UPD")
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
-
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.hostCursor >= offset+maxVisible {
-			offset = m.hostCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(m.hosts) {
-			end = len(m.hosts)
-		}
-
-		// build group start index map
-		groupStarts := make(map[int]string)
-		for i, h := range m.hosts {
-			if h.Group != "" {
-				if i == 0 || m.hosts[i-1].Group != h.Group {
-					groupStarts[i] = h.Group
-				}
-			}
-		}
-
-		for i := offset; i < end; i++ {
-			// render group header if this host starts a new group
-			if groupName, ok := groupStarts[i]; ok {
-				groupLine := fmt.Sprintf("  \u2500\u2500 %s \u2500\u2500", groupName)
-				s += borderedRow(groupLine, iw, groupHeaderStyle) + "\n"
-			}
-
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "HOST", Width: nameCol},
+			{Label: "OS"},
+			{Label: "UP SINCE"},
+			{Label: "UPD"},
+		},
+		RowCount: len(m.hosts),
+		RowBuilder: func(i int) []string {
 			h := m.hosts[i]
-			cur := "   "
-			if i == m.hostCursor {
-				cur = " \u25b8 "
+			updStr := fmt.Sprintf("%d", h.UpdateCount)
+			if h.UpdateCount == 0 {
+				updStr = "\u2014"
 			}
-
-			var line string
+			return []string{h.Entry.Name, h.OS, h.UpSince, updStr}
+		},
+		RowOverride: func(i int) string {
+			h := m.hosts[i]
 			switch h.Status {
 			case config.HostConnecting:
-				line = fmt.Sprintf("%s  %-*s  connecting...", cur, nameCol, h.Entry.Name)
+				return fmt.Sprintf("%-*s  connecting...", nameCol, h.Entry.Name)
 			case config.HostUnreachable:
 				reason := h.Error
 				if reason == "" {
 					reason = "unknown"
 				}
-				line = fmt.Sprintf("%s  %-*s  unreachable (%s)", cur, nameCol, h.Entry.Name, reason)
-			default:
-				updStr := fmt.Sprintf("%d", h.UpdateCount)
-				if h.UpdateCount == 0 {
-					updStr = "—"
-				}
-				line = fmt.Sprintf("%s  %-*s  %-*s  %-*s  %s",
-					cur, nameCol, h.Entry.Name, osCol, h.OS, upCol, h.UpSince, updStr)
+				return fmt.Sprintf("%-*s  unreachable (%s)", nameCol, h.Entry.Name, reason)
 			}
-
-			var style lipgloss.Style
-			if i == m.hostCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+			return ""
+		},
+		GroupHeader: func(i int) (string, bool) {
+			label, ok := groupStarts[i]
+			return label, ok
+		},
+		Cursor:       m.hostCursor,
+		MaxVisible:   maxVisible,
+		InnerWidth:   iw,
+		EmptyMessage: "  No hosts in fleet.",
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_k8s_clusters.go
+++ b/internal/app/view_k8s_clusters.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/lipgloss"
-
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
 )
 
@@ -20,67 +18,45 @@ func (m Model) renderK8sClusterList() string {
 	s := m.renderHeader(f.Name, m.k8sClusterCursor+1, len(m.k8sClusters)) + "\n"
 	s += borderStyle.Render("┌"+strings.Repeat("─", iw)+"┐") + "\n"
 
-	if len(m.k8sClusters) == 0 {
-		s += borderedRow("  No clusters in fleet.", iw, normalRowStyle) + "\n"
-	} else {
-		nameCol := len("CLUSTER")
-		verCol := len("K8S VERSION")
-		for _, c := range m.k8sClusters {
-			if len(c.Name) > nameCol {
-				nameCol = len(c.Name)
-			}
-		}
-		nameCol += 2
-		verCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %s",
-			nameCol, "CLUSTER"+m.sortIndicator(1),
-			"K8S VERSION"+m.sortIndicator(2),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("├"+strings.Repeat("─", iw)+"┤") + "\n"
-
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.k8sClusterCursor >= offset+maxVisible {
-			offset = m.k8sClusterCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(m.k8sClusters) {
-			end = len(m.k8sClusters)
-		}
-
-		for i := offset; i < end; i++ {
-			c := m.k8sClusters[i]
-			cur := "   "
-			if i == m.k8sClusterCursor {
-				cur = " ▸ "
-			}
-
-			var line string
-			switch c.Status {
-			case k8s.ClusterChecking:
-				line = fmt.Sprintf("%s  %-*s  checking...", cur, nameCol, c.Name)
-			case k8s.ClusterError:
-				line = fmt.Sprintf("%s  %-*s  unavailable", cur, nameCol, c.Name)
-			case k8s.ClusterOnline:
-				line = fmt.Sprintf("%s  %-*s  %s", cur, nameCol, c.Name, c.K8sVersion)
-			}
-
-			var style lipgloss.Style
-			if i == m.k8sClusterCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
+	nameCol := len("CLUSTER")
+	for _, c := range m.k8sClusters {
+		if len(c.Name) > nameCol {
+			nameCol = len(c.Name)
 		}
 	}
+	nameCol += 2
+
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "CLUSTER", Width: nameCol, SortIndex: 1},
+			{Label: "K8S VERSION", SortIndex: 2},
+		},
+		RowCount: len(m.k8sClusters),
+		RowBuilder: func(i int) []string {
+			c := m.k8sClusters[i]
+			return []string{c.Name, c.K8sVersion}
+		},
+		RowOverride: func(i int) string {
+			c := m.k8sClusters[i]
+			switch c.Status {
+			case k8s.ClusterChecking:
+				return fmt.Sprintf("%-*s  checking...", nameCol, c.Name)
+			case k8s.ClusterError:
+				return fmt.Sprintf("%-*s  unavailable", nameCol, c.Name)
+			}
+			return ""
+		},
+		Cursor:        m.k8sClusterCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  "  No clusters in fleet.",
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("└"+strings.Repeat("─", iw)+"┘") + "\n"

--- a/internal/app/view_k8s_clusters.go
+++ b/internal/app/view_k8s_clusters.go
@@ -75,6 +75,7 @@ func (m Model) renderK8sClusterList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"↑↓", "Navigate"},
 			{"Enter", "Contexts"},
+			{"n", "Notes"},
 			{"r", "Refresh"},
 			{"/", "Filter"},
 			{"1-2", "Sort"},

--- a/internal/app/view_k8s_clusters.go
+++ b/internal/app/view_k8s_clusters.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderK8sClusterList() string {
@@ -31,6 +32,7 @@ func (m Model) renderK8sClusterList() string {
 	}
 	nameCol += 2
 
+	fleetName := m.fleets[m.selectedFleet].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "CLUSTER", Width: nameCol, SortIndex: 1},
@@ -40,6 +42,12 @@ func (m Model) renderK8sClusterList() string {
 		RowBuilder: func(i int) []string {
 			c := m.k8sClusters[i]
 			return []string{c.Name, c.K8sVersion}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"k8s", m.k8sClusters[i].Name},
+			})
 		},
 		RowOverride: func(i int) string {
 			c := m.k8sClusters[i]

--- a/internal/app/view_k8s_namespaces.go
+++ b/internal/app/view_k8s_namespaces.go
@@ -82,6 +82,7 @@ func (m Model) renderK8sNamespaceList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Workloads"},
+			{"n", "Notes"},
 			{"/", "Filter"},
 			{"1-7", "Sort"},
 			{"r", "Refresh"},

--- a/internal/app/view_k8s_namespaces.go
+++ b/internal/app/view_k8s_namespaces.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderK8sNamespaceList() string {
@@ -33,6 +35,8 @@ func (m Model) renderK8sNamespaceList() string {
 		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	clusterName := m.k8sClusters[m.selectedK8sCluster].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "NAMESPACE", SortIndex: 1},
@@ -55,6 +59,12 @@ func (m Model) renderK8sNamespaceList() string {
 				fmt.Sprintf("%d", ns.DSCount),
 				ns.Age,
 			}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, filtered[i].Name},
+			})
 		},
 		Cursor:        m.k8sNamespaceCursor,
 		MaxVisible:    maxVisible,

--- a/internal/app/view_k8s_namespaces.go
+++ b/internal/app/view_k8s_namespaces.go
@@ -3,8 +3,6 @@ package app
 import (
 	"fmt"
 	"strings"
-
-	"github.com/charmbracelet/lipgloss"
 )
 
 func (m Model) renderK8sNamespaceList() string {
@@ -25,83 +23,45 @@ func (m Model) renderK8sNamespaceList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sNamespaceCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(filtered) == 0 {
-		if m.filterText != "" {
-			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
-		} else {
-			s += borderedRow("  No namespaces.", iw, normalRowStyle) + "\n"
-		}
-	} else {
-		nameCol := len("NAMESPACE")
-		statusCol := len("STATUS")
-		podsCol := 5
-		deployCol := 6
-		stsCol := 4
-		dsCol := 3
-		for _, ns := range filtered {
-			if len(ns.Name) > nameCol {
-				nameCol = len(ns.Name)
-			}
-			if len(ns.Status) > statusCol {
-				statusCol = len(ns.Status)
-			}
-		}
-		nameCol += 2
-		statusCol += 2
-
-		hdr := fmt.Sprintf("     %-*s  %-*s  %*s  %*s  %*s  %*s  %s",
-			nameCol, "NAMESPACE"+m.sortIndicator(1),
-			statusCol, "STATUS"+m.sortIndicator(2),
-			podsCol, "PODS"+m.sortIndicator(3),
-			deployCol, "DEPLOY"+m.sortIndicator(4),
-			stsCol, "STS"+m.sortIndicator(5),
-			dsCol, "DS"+m.sortIndicator(6),
-			"AGE"+m.sortIndicator(7),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
-
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.k8sNamespaceCursor >= offset+maxVisible {
-			offset = m.k8sNamespaceCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
-
-		for i := offset; i < end; i++ {
-			ns := filtered[i]
-			cur := "   "
-			if i == m.k8sNamespaceCursor {
-				cur = " \u25b8 "
-			}
-
-			line := fmt.Sprintf("%s  %-*s  %-*s  %*d  %*d  %*d  %*d  %s",
-				cur, nameCol, ns.Name,
-				statusCol, ns.Status,
-				podsCol, ns.PodCount,
-				deployCol, ns.DeployCount,
-				stsCol, ns.STSCount,
-				dsCol, ns.DSCount,
-				ns.Age,
-			)
-
-			var style lipgloss.Style
-			if i == m.k8sNamespaceCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
 	}
+
+	emptyMsg := "  No namespaces."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+	}
+
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAMESPACE", SortIndex: 1},
+			{Label: "STATUS", SortIndex: 2},
+			{Label: "PODS", Width: 5, SortIndex: 3, RightAlign: true},
+			{Label: "DEPLOY", Width: 6, SortIndex: 4, RightAlign: true},
+			{Label: "STS", Width: 4, SortIndex: 5, RightAlign: true},
+			{Label: "DS", Width: 3, SortIndex: 6, RightAlign: true},
+			{Label: "AGE", SortIndex: 7},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
+			ns := filtered[i]
+			return []string{
+				ns.Name,
+				ns.Status,
+				fmt.Sprintf("%d", ns.PodCount),
+				fmt.Sprintf("%d", ns.DeployCount),
+				fmt.Sprintf("%d", ns.STSCount),
+				fmt.Sprintf("%d", ns.DSCount),
+				ns.Age,
+			}
+		},
+		Cursor:        m.k8sNamespaceCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -107,6 +107,7 @@ func (m Model) renderK8sPodList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Detail"},
+			{"n", "Notes"},
 			{"l", "Logs"},
 			{"d", "Delete"},
 			{"/", "Filter"},

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -43,94 +43,49 @@ func (m Model) renderK8sPodList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sPodCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(filtered) == 0 {
-		if m.filterText != "" {
-			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
-		} else {
-			s += borderedRow("  No pods.", iw, normalRowStyle) + "\n"
-		}
-	} else {
-		nameCol := len("NAME")
-		statusCol := len("STATUS")
-		readyCol := len("READY")
-		restartsCol := len("RESTARTS")
-		nodeCol := len("NODE")
-		for _, p := range filtered {
-			if len(p.Name) > nameCol {
-				nameCol = len(p.Name)
-			}
-			if len(p.Status) > statusCol {
-				statusCol = len(p.Status)
-			}
-			if len(p.Ready) > readyCol {
-				readyCol = len(p.Ready)
-			}
-			if len(p.Node) > nodeCol {
-				nodeCol = len(p.Node)
-			}
-		}
-		nameCol += 2
-		statusCol += 2
-		readyCol += 2
-		restartsCol += 2
-		nodeCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-*s  %-*s  %*s  %-*s  %s",
-			nameCol, "NAME"+m.sortIndicator(1),
-			statusCol, "STATUS"+m.sortIndicator(2),
-			readyCol, "READY"+m.sortIndicator(3),
-			restartsCol, "RESTARTS"+m.sortIndicator(4),
-			nodeCol, "NODE"+m.sortIndicator(5),
-			"AGE"+m.sortIndicator(6),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
+	emptyMsg := "  No pods."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+	}
 
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.k8sPodCursor >= offset+maxVisible {
-			offset = m.k8sPodCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
+	restartsCol := len("RESTARTS") + 2
 
-		for i := offset; i < end; i++ {
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME", SortIndex: 1},
+			{Label: "STATUS", SortIndex: 2},
+			{Label: "READY", SortIndex: 3},
+			{Label: "RESTARTS", Width: restartsCol, SortIndex: 4, RightAlign: true},
+			{Label: "NODE", SortIndex: 5},
+			{Label: "AGE", SortIndex: 6},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
 			p := filtered[i]
-			cur := "   "
-			if i == m.k8sPodCursor {
-				cur = " \u25b8 "
-			}
-
 			status := p.Status
 			if t, ok := m.transitions["k8s-pod/"+p.Name]; ok {
 				status = t.Display
 			}
-
-			line := fmt.Sprintf("%s  %-*s  %-*s  %-*s  %*d  %-*s  %s",
-				cur, nameCol, p.Name,
-				statusCol, status,
-				readyCol, p.Ready,
-				restartsCol, p.Restarts,
-				nodeCol, p.Node,
+			return []string{
+				p.Name,
+				status,
+				p.Ready,
+				fmt.Sprintf("%d", p.Restarts),
+				p.Node,
 				p.Age,
-			)
-
-			var style lipgloss.Style
-			if i == m.k8sPodCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
 			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+		},
+		Cursor:        m.k8sPodCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_k8s_pods.go
+++ b/internal/app/view_k8s_pods.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func k8sPodStatusStyle(status string) lipgloss.Style {
@@ -55,6 +57,9 @@ func (m Model) renderK8sPodList() string {
 
 	restartsCol := len("RESTARTS") + 2
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	clusterName := m.k8sClusters[m.selectedK8sCluster].Name
+	nsName := m.k8sNamespaces[m.selectedK8sNamespace].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "NAME", SortIndex: 1},
@@ -79,6 +84,12 @@ func (m Model) renderK8sPodList() string {
 				p.Node,
 				p.Age,
 			}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, nsName, "pods", filtered[i].Name},
+			})
 		},
 		Cursor:        m.k8sPodCursor,
 		MaxVisible:    maxVisible,

--- a/internal/app/view_k8s_workloads.go
+++ b/internal/app/view_k8s_workloads.go
@@ -3,8 +3,6 @@ package app
 import (
 	"fmt"
 	"strings"
-
-	"github.com/charmbracelet/lipgloss"
 )
 
 func (m Model) renderK8sWorkloadList() string {
@@ -26,94 +24,49 @@ func (m Model) renderK8sWorkloadList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.k8sWorkloadCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(filtered) == 0 {
-		if m.filterText != "" {
-			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
-		} else {
-			s += borderedRow("  No workloads.", iw, normalRowStyle) + "\n"
-		}
-	} else {
-		nameCol := len("NAME")
-		readyCol := 7
-		for _, wl := range filtered {
-			if len(wl.Name) > nameCol {
-				nameCol = len(wl.Name)
-			}
-			if len(wl.Ready) > readyCol {
-				readyCol = len(wl.Ready)
-			}
-		}
-		nameCol += 2
-		readyCol += 2
-
-		hdr := fmt.Sprintf("     %-*s  %-*s  %s",
-			nameCol, "NAME"+m.sortIndicator(1),
-			readyCol, "READY"+m.sortIndicator(2),
-			"AGE"+m.sortIndicator(3),
-		)
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
-
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.k8sWorkloadCursor >= offset+maxVisible {
-			offset = m.k8sWorkloadCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
-
-		// build group start index map by kind
-		groupStarts := make(map[int]string)
-		kindLabels := map[string]string{
-			"Deployment":  "Deployments",
-			"StatefulSet": "StatefulSets",
-			"DaemonSet":   "DaemonSets",
-		}
-		for i, wl := range filtered {
-			if i == 0 || filtered[i-1].Kind != wl.Kind {
-				label := kindLabels[wl.Kind]
-				if label == "" {
-					label = wl.Kind
-				}
-				groupStarts[i] = label
-			}
-		}
-
-		for i := offset; i < end; i++ {
-			// render group header if this workload starts a new kind
-			if groupLabel, ok := groupStarts[i]; ok {
-				groupLine := fmt.Sprintf("  \u2500\u2500 %s \u2500\u2500", groupLabel)
-				s += borderedRow(groupLine, iw, groupHeaderStyle) + "\n"
-			}
-
-			wl := filtered[i]
-			cur := "   "
-			if i == m.k8sWorkloadCursor {
-				cur = " \u25b8 "
-			}
-
-			line := fmt.Sprintf("%s  %-*s  %-*s  %s",
-				cur, nameCol, wl.Name,
-				readyCol, wl.Ready,
-				wl.Age,
-			)
-
-			var style lipgloss.Style
-			if i == m.k8sWorkloadCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
-			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
 	}
+
+	emptyMsg := "  No workloads."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+	}
+
+	kindLabels := map[string]string{
+		"Deployment":  "Deployments",
+		"StatefulSet": "StatefulSets",
+		"DaemonSet":   "DaemonSets",
+	}
+
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME", SortIndex: 1},
+			{Label: "READY", SortIndex: 2},
+			{Label: "AGE", SortIndex: 3},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
+			wl := filtered[i]
+			return []string{wl.Name, wl.Ready, wl.Age}
+		},
+		GroupHeader: func(i int) (string, bool) {
+			if i > 0 && filtered[i-1].Kind == filtered[i].Kind {
+				return "", false
+			}
+			label := kindLabels[filtered[i].Kind]
+			if label == "" {
+				label = filtered[i].Kind
+			}
+			return label, true
+		},
+		Cursor:        m.k8sWorkloadCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_k8s_workloads.go
+++ b/internal/app/view_k8s_workloads.go
@@ -88,6 +88,7 @@ func (m Model) renderK8sWorkloadList() string {
 		s += m.renderHintBar(hintWithHelp([][]string{
 			{"\u2191\u2193", "Navigate"},
 			{"Enter", "Pods"},
+			{"n", "Notes"},
 			{"/", "Filter"},
 			{"1-3", "Sort"},
 			{"r", "Refresh"},

--- a/internal/app/view_k8s_workloads.go
+++ b/internal/app/view_k8s_workloads.go
@@ -3,6 +3,8 @@ package app
 import (
 	"fmt"
 	"strings"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderK8sWorkloadList() string {
@@ -40,6 +42,9 @@ func (m Model) renderK8sWorkloadList() string {
 		"DaemonSet":   "DaemonSets",
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	clusterName := m.k8sClusters[m.selectedK8sCluster].Name
+	nsName := m.k8sNamespaces[m.selectedK8sNamespace].Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "NAME", SortIndex: 1},
@@ -50,6 +55,12 @@ func (m Model) renderK8sWorkloadList() string {
 		RowBuilder: func(i int) []string {
 			wl := filtered[i]
 			return []string{wl.Name, wl.Ready, wl.Age}
+		},
+		RowPrefix: func(i int) string {
+			return m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"k8s", clusterName, m.selectedK8sContext, nsName, filtered[i].Name},
+			})
 		},
 		GroupHeader: func(i int) (string, bool) {
 			if i > 0 && filtered[i-1].Kind == filtered[i].Kind {

--- a/internal/app/view_list.go
+++ b/internal/app/view_list.go
@@ -1,0 +1,194 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ListColumn describes one column in a resource list view.
+type ListColumn struct {
+	Label      string // header label, e.g. "SERVICE"
+	Width      int    // fixed width in chars; 0 = computed from max(label, data) + 2
+	SortIndex  int    // 0 = not sortable; positive = sort key number (matches ListConfig.SortIndicator argument)
+	RightAlign bool   // right-align cell content (for numeric columns)
+}
+
+// ListConfig is the input to renderList.
+type ListConfig struct {
+	Columns []ListColumn
+
+	RowCount   int
+	RowBuilder func(i int) []string // returns cell strings for row i, same order as Columns
+
+	// RowPrefix, if set, returns a short marker inserted between the cursor slot and
+	// the first cell for row i — e.g. "✗ " for failed, "📝 " for notes. Empty = no prefix.
+	RowPrefix func(i int) string
+
+	// RowOverride, if set and returns non-empty for row i, replaces the column-based
+	// cell layout with the provided string. Cursor marker and RowPrefix are still
+	// applied before the override. Use for status-dependent rows that don't fit the
+	// normal column structure (e.g. "connecting..." or "unreachable (reason)").
+	RowOverride func(i int) string
+
+	// GroupHeader, if set, returns (label, true) to inject a group-header line
+	// before row i. Called once per row in the viewport.
+	GroupHeader func(i int) (string, bool)
+
+	Cursor     int
+	MaxVisible int // viewport height in rows (excluding column header and separator)
+
+	// SortIndicator returns the ▲/▼/"" indicator for the given sort key. Only
+	// called for columns where ListColumn.SortIndex > 0.
+	SortIndicator func(key int) string
+
+	InnerWidth int // content width of the surrounding box (box width minus both borders)
+
+	// EmptyMessage is shown when RowCount == 0. If empty, a sensible default is used.
+	EmptyMessage string
+}
+
+// renderList renders the body of a resource list view: column header, separator,
+// and the visible rows (with optional group headers and per-row prefixes).
+//
+// The caller owns the surrounding frame — breadcrumb header, top and bottom borders,
+// filter bar, padToBottom, and hint bar.
+//
+// Returns a multi-line string ending with a trailing newline.
+func renderList(cfg ListConfig) string {
+	iw := cfg.InnerWidth
+
+	if cfg.RowCount == 0 {
+		msg := cfg.EmptyMessage
+		if msg == "" {
+			msg = "  No items found."
+		}
+		return borderedRow(msg, iw, normalRowStyle) + "\n"
+	}
+
+	widths := computeListWidths(cfg)
+
+	var s strings.Builder
+	s.WriteString(borderedRow(listHeaderLine(cfg, widths), iw, colHeaderStyle) + "\n")
+	s.WriteString(borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n")
+
+	offset := 0
+	if cfg.MaxVisible > 0 && cfg.Cursor >= cfg.MaxVisible {
+		offset = cfg.Cursor - cfg.MaxVisible + 1
+	}
+	end := min(offset+cfg.MaxVisible, cfg.RowCount)
+
+	for r := offset; r < end; r++ {
+		if cfg.GroupHeader != nil {
+			if label, ok := cfg.GroupHeader(r); ok {
+				groupLine := fmt.Sprintf("  \u2500\u2500 %s \u2500\u2500", label)
+				s.WriteString(borderedRow(groupLine, iw, groupHeaderStyle) + "\n")
+			}
+		}
+
+		s.WriteString(borderedRow(listRowLine(cfg, widths, r), iw, rowStyle(r, cfg.Cursor)) + "\n")
+	}
+
+	return s.String()
+}
+
+// computeListWidths returns the effective width for each column. Fixed widths
+// (ListColumn.Width > 0) are used as-is. Computed widths are max(label, data) + 2.
+func computeListWidths(cfg ListConfig) []int {
+	widths := make([]int, len(cfg.Columns))
+	for i, c := range cfg.Columns {
+		if c.Width > 0 {
+			widths[i] = c.Width
+			continue
+		}
+		w := len(c.Label)
+		for r := 0; r < cfg.RowCount; r++ {
+			cells := cfg.RowBuilder(r)
+			if i < len(cells) && lipgloss.Width(cells[i]) > w {
+				w = lipgloss.Width(cells[i])
+			}
+		}
+		widths[i] = w + 2
+	}
+	return widths
+}
+
+// listHeaderLine builds the column header line including sort indicators.
+// Leading "     " = 3-char cursor slot + 2-char gap, matching row layout.
+func listHeaderLine(cfg ListConfig, widths []int) string {
+	var b strings.Builder
+	b.WriteString("     ")
+	for i, c := range cfg.Columns {
+		label := c.Label
+		if c.SortIndex > 0 && cfg.SortIndicator != nil {
+			label += cfg.SortIndicator(c.SortIndex)
+		}
+		if i == len(cfg.Columns)-1 {
+			b.WriteString(label)
+			continue
+		}
+		if c.RightAlign {
+			b.WriteString(fmt.Sprintf("%*s", widths[i], label))
+		} else {
+			b.WriteString(fmt.Sprintf("%-*s", widths[i], label))
+		}
+		b.WriteString("  ")
+	}
+	return b.String()
+}
+
+// listRowLine builds a single data row: cursor marker, prefix, and either the
+// column-based cells from RowBuilder or the override string from RowOverride.
+func listRowLine(cfg ListConfig, widths []int, r int) string {
+	cur := "   "
+	if r == cfg.Cursor {
+		cur = " \u25b8 "
+	}
+	prefix := ""
+	if cfg.RowPrefix != nil {
+		prefix = cfg.RowPrefix(r)
+	}
+
+	var b strings.Builder
+	b.WriteString(cur)
+	b.WriteString("  ")
+	b.WriteString(prefix)
+
+	if cfg.RowOverride != nil {
+		if override := cfg.RowOverride(r); override != "" {
+			b.WriteString(override)
+			return b.String()
+		}
+	}
+
+	cells := cfg.RowBuilder(r)
+	for i, c := range cfg.Columns {
+		val := ""
+		if i < len(cells) {
+			val = cells[i]
+		}
+		if i == len(cfg.Columns)-1 {
+			b.WriteString(val)
+			continue
+		}
+		if c.RightAlign {
+			b.WriteString(fmt.Sprintf("%*s", widths[i], val))
+		} else {
+			b.WriteString(fmt.Sprintf("%-*s", widths[i], val))
+		}
+		b.WriteString("  ")
+	}
+	return b.String()
+}
+
+// rowStyle picks the lipgloss style based on cursor position and row index parity.
+func rowStyle(r, cursor int) lipgloss.Style {
+	if r == cursor {
+		return selectedRowStyle
+	}
+	if r%2 == 0 {
+		return altRowStyle
+	}
+	return normalRowStyle
+}

--- a/internal/app/view_list_teatest_test.go
+++ b/internal/app/view_list_teatest_test.go
@@ -1,0 +1,122 @@
+package app
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/config"
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/k8s"
+)
+
+// Parity tests for views migrated to the shared renderer in FLE-81.
+// Each test drives a real tea.Program and verifies the migrated view renders
+// expected columns and data without regressions.
+
+func TestRenderList_Parity_HostList(t *testing.T) {
+	m := baselineModel([]config.Fleet{{Name: "test-fleet", Type: "vm"}})
+	m.view = viewHostList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{
+		{
+			Entry:       config.HostEntry{Name: "host-a"},
+			OS:          "RHEL 9.5",
+			UpSince:     "5 days",
+			UpdateCount: 3,
+			Status:      config.HostOnline,
+		},
+		{
+			Entry:       config.HostEntry{Name: "host-b"},
+			OS:          "Ubuntu 22.04",
+			UpSince:     "2 hours",
+			UpdateCount: 0,
+			Status:      config.HostOnline,
+		},
+	}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(120, 30))
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("HOST")) &&
+				bytes.Contains(bts, []byte("OS")) &&
+				bytes.Contains(bts, []byte("UP SINCE")) &&
+				bytes.Contains(bts, []byte("host-a")) &&
+				bytes.Contains(bts, []byte("host-b")) &&
+				bytes.Contains(bts, []byte("RHEL 9.5")) &&
+				bytes.Contains(bts, []byte("Ubuntu 22.04"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestRenderList_Parity_ServiceList_WithFailedPrefix(t *testing.T) {
+	m := baselineModel([]config.Fleet{{Name: "test-fleet", Type: "vm"}})
+	m.view = viewServiceList
+	m.selectedFleet = 0
+	m.hosts = []config.Host{{Entry: config.HostEntry{Name: "host-a"}}}
+	m.selectedHost = 0
+	m.services = []config.Service{
+		{Name: "ok-svc", State: "active", Enabled: "enabled", Description: "healthy service"},
+		{Name: "bad-svc", State: "failed", Enabled: "enabled", Description: "broken service"},
+	}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(140, 30))
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("SERVICE")) &&
+				bytes.Contains(bts, []byte("STATE")) &&
+				bytes.Contains(bts, []byte("ok-svc")) &&
+				bytes.Contains(bts, []byte("bad-svc")) &&
+				// The ✗ prefix should appear on the failed service row
+				bytes.Contains(bts, []byte("\u2717 bad-svc"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}
+
+func TestRenderList_Parity_K8sPodList(t *testing.T) {
+	m := baselineModel([]config.Fleet{{Name: "test-fleet", Type: "kubernetes"}})
+	m.view = viewK8sPodList
+	m.selectedFleet = 0
+	m.k8sClusters = []k8s.K8sClusterItem{{Name: "test-cluster"}}
+	m.selectedK8sCluster = 0
+	m.selectedK8sContext = "test-ctx"
+	m.k8sNamespaces = []k8s.K8sNamespace{{Name: "default"}}
+	m.selectedK8sNamespace = 0
+	m.k8sWorkloads = []k8s.K8sWorkload{{Name: "nginx", Kind: "Deployment"}}
+	m.selectedK8sWorkload = 0
+	m.k8sPodList = []k8s.K8sPod{
+		{Name: "nginx-abc", Status: "Running", Ready: "1/1", Restarts: 0, Node: "node-1", Age: "2d"},
+		{Name: "nginx-xyz", Status: "Pending", Ready: "0/1", Restarts: 2, Node: "node-2", Age: "5m"},
+	}
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(140, 30))
+
+	teatest.WaitFor(t, tm.Output(),
+		func(bts []byte) bool {
+			return bytes.Contains(bts, []byte("NAME")) &&
+				bytes.Contains(bts, []byte("STATUS")) &&
+				bytes.Contains(bts, []byte("READY")) &&
+				bytes.Contains(bts, []byte("RESTARTS")) &&
+				bytes.Contains(bts, []byte("nginx-abc")) &&
+				bytes.Contains(bts, []byte("nginx-xyz")) &&
+				bytes.Contains(bts, []byte("Running")) &&
+				bytes.Contains(bts, []byte("Pending"))
+		},
+		teatest.WithDuration(2*time.Second),
+	)
+
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(2*time.Second))
+}

--- a/internal/app/view_list_test.go
+++ b/internal/app/view_list_test.go
@@ -1,0 +1,262 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderList_EmptyRows_DefaultMessage(t *testing.T) {
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "NAME"}},
+		RowCount:   0,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "No items found") {
+		t.Errorf("expected default empty message, got:\n%s", out)
+	}
+}
+
+func TestRenderList_EmptyRows_CustomMessage(t *testing.T) {
+	cfg := ListConfig{
+		Columns:      []ListColumn{{Label: "NAME"}},
+		RowCount:     0,
+		EmptyMessage: "  No services found.",
+		InnerWidth:   40,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "No services found") {
+		t.Errorf("expected custom empty message, got:\n%s", out)
+	}
+	if strings.Contains(out, "No items found") {
+		t.Errorf("expected custom message to override default, got:\n%s", out)
+	}
+}
+
+func TestRenderList_SingleRow(t *testing.T) {
+	rows := [][]string{{"foo", "running"}}
+	cfg := ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME"},
+			{Label: "STATE"},
+		},
+		RowCount:   1,
+		RowBuilder: func(i int) []string { return rows[i] },
+		Cursor:     0,
+		MaxVisible: 10,
+		InnerWidth: 60,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "STATE") {
+		t.Errorf("expected header labels in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "foo") || !strings.Contains(out, "running") {
+		t.Errorf("expected row values in output, got:\n%s", out)
+	}
+}
+
+func TestRenderList_CursorMarker(t *testing.T) {
+	rows := [][]string{{"a"}, {"b"}, {"c"}}
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "X"}},
+		RowCount:   3,
+		RowBuilder: func(i int) []string { return rows[i] },
+		Cursor:     1,
+		MaxVisible: 10,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	// ▸ marker should be on the cursor row only
+	cursorCount := strings.Count(out, "\u25b8")
+	if cursorCount != 1 {
+		t.Errorf("expected exactly 1 cursor marker, got %d in:\n%s", cursorCount, out)
+	}
+}
+
+func TestRenderList_RowPrefix(t *testing.T) {
+	rows := [][]string{{"ok-row"}, {"failed-row"}}
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "NAME"}},
+		RowCount:   2,
+		RowBuilder: func(i int) []string { return rows[i] },
+		RowPrefix: func(i int) string {
+			if i == 1 {
+				return "\u2717 "
+			}
+			return ""
+		},
+		MaxVisible: 10,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "\u2717 failed-row") {
+		t.Errorf("expected prefix on failed-row, got:\n%s", out)
+	}
+	// ok-row should not have the prefix
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "ok-row") && strings.Contains(line, "\u2717") {
+			t.Errorf("ok-row should not have ✗ prefix, got line: %s", line)
+		}
+	}
+}
+
+func TestRenderList_GroupHeader(t *testing.T) {
+	rows := [][]string{{"pod-a"}, {"pod-b"}, {"deploy-x"}}
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "NAME"}},
+		RowCount:   3,
+		RowBuilder: func(i int) []string { return rows[i] },
+		GroupHeader: func(i int) (string, bool) {
+			if i == 0 {
+				return "Pods", true
+			}
+			if i == 2 {
+				return "Deployments", true
+			}
+			return "", false
+		},
+		MaxVisible: 10,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "── Pods ──") {
+		t.Errorf("expected Pods group header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "── Deployments ──") {
+		t.Errorf("expected Deployments group header, got:\n%s", out)
+	}
+}
+
+func TestRenderList_SortIndicator(t *testing.T) {
+	rows := [][]string{{"foo"}}
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "NAME", SortIndex: 1}},
+		RowCount:   1,
+		RowBuilder: func(i int) []string { return rows[i] },
+		SortIndicator: func(key int) string {
+			if key == 1 {
+				return "\u25b2"
+			}
+			return ""
+		},
+		MaxVisible: 10,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "NAME\u25b2") {
+		t.Errorf("expected NAME▲ in header, got:\n%s", out)
+	}
+}
+
+func TestRenderList_RightAlign(t *testing.T) {
+	rows := [][]string{{"foo", "5"}, {"barbaz", "100"}}
+	cfg := ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME"},
+			{Label: "COUNT", Width: 8, RightAlign: true},
+		},
+		RowCount:   2,
+		RowBuilder: func(i int) []string { return rows[i] },
+		MaxVisible: 10,
+		InnerWidth: 60,
+	}
+	out := renderList(cfg)
+	// right-aligned "5" in a width-8 column should have leading spaces before it
+	if !strings.Contains(out, "       5") {
+		t.Errorf("expected right-aligned 5 with leading spaces, got:\n%s", out)
+	}
+}
+
+func TestRenderList_Viewport_ScrollsWithCursor(t *testing.T) {
+	rows := make([][]string, 20)
+	for i := range rows {
+		rows[i] = []string{"item-" + string(rune('a'+i))}
+	}
+	cfg := ListConfig{
+		Columns:    []ListColumn{{Label: "NAME"}},
+		RowCount:   20,
+		RowBuilder: func(i int) []string { return rows[i] },
+		Cursor:     15,
+		MaxVisible: 5,
+		InnerWidth: 40,
+	}
+	out := renderList(cfg)
+	// With cursor=15 and MaxVisible=5, offset = 15 - 5 + 1 = 11, rendered rows 11..15
+	if strings.Contains(out, "item-a") {
+		t.Errorf("rows before offset should not be rendered, got:\n%s", out)
+	}
+	if !strings.Contains(out, "item-p") { // index 15 = 'p'
+		t.Errorf("cursor row (item-p) should be rendered, got:\n%s", out)
+	}
+	if strings.Contains(out, "item-q") { // index 16 - out of viewport
+		t.Errorf("rows after viewport should not be rendered, got:\n%s", out)
+	}
+}
+
+func TestRenderList_ComputedWidth_IncludesTrailingPadding(t *testing.T) {
+	rows := [][]string{{"foo", "bar"}}
+	cfg := ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME"},
+			{Label: "VALUE"},
+		},
+		RowCount:   1,
+		RowBuilder: func(i int) []string { return rows[i] },
+		MaxVisible: 10,
+		InnerWidth: 80,
+	}
+	out := renderList(cfg)
+	// Computed width = max(label, data) + 2. For NAME col: max(4, 3) + 2 = 6.
+	// So "NAME  " (4 chars + 2 padding) followed by 2-space gap = "NAME    " before "VALUE"
+	if !strings.Contains(out, "NAME    VALUE") {
+		t.Errorf("expected NAME padded to width 6 then 2-space gap before VALUE, got:\n%s", out)
+	}
+}
+
+func TestRenderList_RowOverride_ReplacesCells(t *testing.T) {
+	cfg := ListConfig{
+		Columns: []ListColumn{
+			{Label: "HOST"},
+			{Label: "OS"},
+			{Label: "UPTIME"},
+		},
+		RowCount: 2,
+		RowBuilder: func(i int) []string {
+			return []string{"host" + string(rune('0'+i)), "RHEL 9", "5d"}
+		},
+		RowOverride: func(i int) string {
+			if i == 1 {
+				return "host1  connecting..."
+			}
+			return ""
+		},
+		MaxVisible: 10,
+		InnerWidth: 80,
+	}
+	out := renderList(cfg)
+	if !strings.Contains(out, "host1  connecting...") {
+		t.Errorf("expected override line for row 1, got:\n%s", out)
+	}
+	if !strings.Contains(out, "RHEL 9") {
+		t.Errorf("expected normal row for row 0 (RHEL 9), got:\n%s", out)
+	}
+}
+
+func TestRenderList_FixedWidth_UsedDirectly(t *testing.T) {
+	rows := [][]string{{"x", "ready"}}
+	cfg := ListConfig{
+		Columns: []ListColumn{
+			{Label: "NAME", Width: 10},
+			{Label: "STATE"},
+		},
+		RowCount:   1,
+		RowBuilder: func(i int) []string { return rows[i] },
+		MaxVisible: 10,
+		InnerWidth: 60,
+	}
+	out := renderList(cfg)
+	// Fixed width 10: "NAME      " (NAME + 6 pad) then 2-space gap then "STATE"
+	if !strings.Contains(out, "NAME        STATE") {
+		t.Errorf("expected NAME padded to fixed width 10 then gap, got:\n%s", out)
+	}
+}

--- a/internal/app/view_notelist.go
+++ b/internal/app/view_notelist.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// filteredNoteList returns indices into m.noteList matching m.filterText
+// (case-insensitive substring on the preview). When no filter is active
+// all indices are returned in order.
+func (m Model) filteredNoteList() []int {
+	if m.filterText == "" {
+		out := make([]int, len(m.noteList))
+		for i := range m.noteList {
+			out[i] = i
+		}
+		return out
+	}
+	filter := strings.ToLower(m.filterText)
+	out := []int{}
+	for i, n := range m.noteList {
+		if strings.Contains(strings.ToLower(n.Preview), filter) {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func (m Model) renderNoteList() string {
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	breadcrumb := "Notes \u203a " + m.noteRef.Key()
+	filtered := m.filteredNoteList()
+
+	s := m.renderHeader(breadcrumb, m.noteCursor+1, len(filtered)) + "\n"
+	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
+
+	if m.filterText != "" {
+		filterLine := fmt.Sprintf("  Filter: %s", m.filterText)
+		s += borderedRow(filterLine, iw, lipgloss.NewStyle().Foreground(colorCyan)) + "\n"
+		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
+	}
+
+	maxVisible := m.height - 8
+	if m.filterText != "" {
+		maxVisible -= 2
+	}
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+
+	emptyMsg := "  No notes for this resource. Press n to create one."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No notes match '%s'", m.filterText)
+	}
+
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "DATE"},
+			{Label: "PREVIEW"},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
+			n := m.noteList[filtered[i]]
+			date := n.CreatedAt.Local().Format("02/01/2006 15:04")
+			preview := n.Preview
+			if preview == "" {
+				preview = "(empty)"
+			}
+			return []string{date, preview}
+		},
+		Cursor:       m.noteCursor,
+		MaxVisible:   maxVisible,
+		InnerWidth:   iw,
+		EmptyMessage: emptyMsg,
+	})
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
+
+	if m.filterActive {
+		s += hintBarStyle.Width(m.width).Render(fmt.Sprintf("  /%s\u2588", m.filterText))
+	} else {
+		s += m.renderHintBar(hintWithHelp([][]string{
+			{"\u2191\u2193", "Navigate"},
+			{"Enter", "Read"},
+			{"n", "New"},
+			{"e", "Edit"},
+			{"d", "Delete"},
+			{"/", "Filter"},
+			{"Esc", "Back"},
+		}))
+	}
+	return s
+}
+
+func (m Model) handleNoteListKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	filtered := m.filteredNoteList()
+
+	switch msg.String() {
+	case "up", "k":
+		if m.noteCursor > 0 {
+			m.noteCursor--
+		}
+	case "down", "j":
+		if m.noteCursor < len(filtered)-1 {
+			m.noteCursor++
+		}
+	case "/":
+		m.filterActive = true
+		m.noteCursor = 0
+	case "esc":
+		m.view = m.previousView
+		m.filterText = ""
+	case "n":
+		// Create a new note for the current resource.
+		return m, m.createNoteCmd(m.noteRef)
+	case "enter":
+		if m.noteCursor < len(filtered) {
+			path := m.noteList[filtered[m.noteCursor]].Path
+			return m, m.loadNoteReadCmd(path)
+		}
+	case "e":
+		if m.noteCursor < len(filtered) {
+			path := m.noteList[filtered[m.noteCursor]].Path
+			return m, m.editNoteCmd(path, false)
+		}
+	case "d":
+		if m.noteCursor >= len(filtered) {
+			return m, nil
+		}
+		note := m.noteList[filtered[m.noteCursor]]
+		preview := note.Preview
+		if preview == "" {
+			preview = "(empty)"
+		}
+		date := note.CreatedAt.Local().Format("02/01/2006 15:04")
+		path := note.Path
+		m.modal = NewConfirmModal(
+			"Delete note",
+			fmt.Sprintf("Delete note from %s?\n\n  %s", date, preview),
+			func() tea.Msg {
+				return noteDeleteConfirmedMsg{path: path}
+			},
+		)
+	}
+	return m, nil
+}
+
+// noteDeleteConfirmedMsg is sent from the delete confirm modal.
+type noteDeleteConfirmedMsg struct {
+	path string
+}

--- a/internal/app/view_noteread.go
+++ b/internal/app/view_noteread.go
@@ -1,0 +1,67 @@
+package app
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func (m Model) renderNoteRead() string {
+	w := m.width
+	if w < 20 {
+		w = 80
+	}
+	iw := w - 2
+
+	breadcrumb := "Notes \u203a " + m.noteRef.Key() + " \u203a Read"
+	s := m.renderHeader(breadcrumb, m.noteReadOffset+1, len(m.noteReadLines)) + "\n"
+	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
+
+	maxVisible := m.height - 6
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+
+	if len(m.noteReadLines) == 0 {
+		s += borderedRow("  (empty note)", iw, normalRowStyle) + "\n"
+	} else {
+		end := m.noteReadOffset + maxVisible
+		if end > len(m.noteReadLines) {
+			end = len(m.noteReadLines)
+		}
+		for i := m.noteReadOffset; i < end; i++ {
+			s += borderedRow("  "+m.noteReadLines[i], iw, normalRowStyle) + "\n"
+		}
+	}
+
+	s = m.padToBottom(s, iw)
+	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"
+	s += m.renderHintBar(hintWithHelp([][]string{
+		{"\u2191\u2193", "Scroll"},
+		{"Esc", "Back"},
+	}))
+	return s
+}
+
+func (m Model) handleNoteReadKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	maxVisible := m.height - 6
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
+
+	switch msg.String() {
+	case "up", "k":
+		if m.noteReadOffset > 0 {
+			m.noteReadOffset--
+		}
+	case "down", "j":
+		if m.noteReadOffset < len(m.noteReadLines)-maxVisible {
+			m.noteReadOffset++
+		}
+	case "esc":
+		m.view = viewNoteList
+		m.noteReadLines = nil
+		m.noteReadOffset = 0
+	}
+	return m, nil
+}

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/notes"
 )
 
 func (m Model) renderServiceList() string {
@@ -169,6 +171,8 @@ func (m Model) renderServiceList() string {
 		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
 	}
 
+	fleetName := m.fleets[m.selectedFleet].Name
+	hostName := m.hosts[m.selectedHost].Entry.Name
 	s += renderList(ListConfig{
 		Columns: []ListColumn{
 			{Label: "SERVICE", SortIndex: 1},
@@ -186,10 +190,14 @@ func (m Model) renderServiceList() string {
 			return []string{svc.Name, svc.State, svc.Enabled, desc}
 		},
 		RowPrefix: func(i int) string {
+			note := m.notePrefix(notes.ResourceRef{
+				Fleet:    fleetName,
+				Segments: []string{"hosts", hostName, "services", filtered[i].Name},
+			})
 			if filtered[i].State == "failed" {
-				return "\u2717 "
+				return note + "\u2717 "
 			}
-			return ""
+			return note
 		},
 		Cursor:        m.serviceCursor,
 		MaxVisible:    maxVisible,

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -159,70 +159,44 @@ func (m Model) renderServiceList() string {
 	s := m.renderHeader(breadcrumb+filterInfo, m.serviceCursor+1, len(filtered)) + "\n"
 	s += borderStyle.Render("\u250c"+strings.Repeat("\u2500", iw)+"\u2510") + "\n"
 
-	if len(filtered) == 0 {
-		if m.filterText != "" {
-			s += borderedRow(fmt.Sprintf("  No matches for '%s'", m.filterText), iw, normalRowStyle) + "\n"
-		} else {
-			s += borderedRow("  No services found.", iw, normalRowStyle) + "\n"
-		}
-	} else {
-		nameCol := len("SERVICE")
-		enabledCol := len("ENABLED")
-		for _, svc := range filtered {
-			if len(svc.Name) > nameCol {
-				nameCol = len(svc.Name)
-			}
-			if len(svc.Enabled) > enabledCol {
-				enabledCol = len(svc.Enabled)
-			}
-		}
-		nameCol += 2
-		enabledCol += 2
+	maxVisible := m.height - 8
+	if maxVisible < 1 {
+		maxVisible = 1
+	}
 
-		hdr := fmt.Sprintf("     %-*s  %-10s  %-*s  %s", nameCol, "SERVICE"+m.sortIndicator(1), "STATE"+m.sortIndicator(2), enabledCol, "ENABLED"+m.sortIndicator(3), "DESCRIPTION"+m.sortIndicator(4))
-		s += borderedRow(hdr, iw, colHeaderStyle) + "\n"
-		s += borderStyle.Render("\u251c"+strings.Repeat("\u2500", iw)+"\u2524") + "\n"
+	emptyMsg := "  No services found."
+	if m.filterText != "" {
+		emptyMsg = fmt.Sprintf("  No matches for '%s'", m.filterText)
+	}
 
-		maxVisible := m.height - 8
-		if maxVisible < 1 {
-			maxVisible = 1
-		}
-		offset := 0
-		if m.serviceCursor >= offset+maxVisible {
-			offset = m.serviceCursor - maxVisible + 1
-		}
-		end := offset + maxVisible
-		if end > len(filtered) {
-			end = len(filtered)
-		}
-
-		for i := offset; i < end; i++ {
+	s += renderList(ListConfig{
+		Columns: []ListColumn{
+			{Label: "SERVICE", SortIndex: 1},
+			{Label: "STATE", Width: 10, SortIndex: 2},
+			{Label: "ENABLED", SortIndex: 3},
+			{Label: "DESCRIPTION", SortIndex: 4},
+		},
+		RowCount: len(filtered),
+		RowBuilder: func(i int) []string {
 			svc := filtered[i]
-			cur := "   "
-			if i == m.serviceCursor {
-				cur = " \u25b8 "
-			}
-			prefix := ""
-			if svc.State == "failed" {
-				prefix = "\u2717 "
-			}
 			desc := svc.Description
 			if desc == "" {
 				desc = "\u2014"
 			}
-			line := fmt.Sprintf("%s  %s%-*s  %-10s  %-*s  %s", cur, prefix, nameCol, svc.Name, svc.State, enabledCol, svc.Enabled, desc)
-
-			var style lipgloss.Style
-			if i == m.serviceCursor {
-				style = selectedRowStyle
-			} else if i%2 == 0 {
-				style = altRowStyle
-			} else {
-				style = normalRowStyle
+			return []string{svc.Name, svc.State, svc.Enabled, desc}
+		},
+		RowPrefix: func(i int) string {
+			if filtered[i].State == "failed" {
+				return "\u2717 "
 			}
-			s += borderedRow(line, iw, style) + "\n"
-		}
-	}
+			return ""
+		},
+		Cursor:        m.serviceCursor,
+		MaxVisible:    maxVisible,
+		InnerWidth:    iw,
+		SortIndicator: m.sortIndicator,
+		EmptyMessage:  emptyMsg,
+	})
 
 	s = m.padToBottom(s, iw)
 	s += borderStyle.Render("\u2514"+strings.Repeat("\u2500", iw)+"\u2518") + "\n"

--- a/internal/app/view_services.go
+++ b/internal/app/view_services.go
@@ -216,6 +216,7 @@ func (m Model) renderServiceList() string {
 			{"\u2191\u2193", "Navigate"},
 			{"1-4", "Sort"},
 			{"Enter", "Detail"},
+			{"n", "Notes"},
 			{"/", "Search"},
 			{"r", "Refresh"},
 			{"Esc", "Back"},

--- a/internal/fspath/sanitize.go
+++ b/internal/fspath/sanitize.go
@@ -1,0 +1,15 @@
+// Package fspath provides helpers for building safe filesystem paths from
+// user- or config-provided strings such as fleet names, hostnames, and
+// resource identifiers.
+package fspath
+
+import "strings"
+
+// Sanitize replaces characters unsafe for directory or file names:
+// forward/backward slashes, spaces, and colons are mapped to safe
+// alternatives. Intended for individual path components — callers join
+// sanitized components with filepath.Join.
+func Sanitize(s string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", " ", "-", ":", "_")
+	return r.Replace(s)
+}

--- a/internal/fspath/sanitize_test.go
+++ b/internal/fspath/sanitize_test.go
@@ -1,0 +1,28 @@
+package fspath
+
+import "testing"
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "fleet-a", "fleet-a"},
+		{"slash", "a/b", "a_b"},
+		{"backslash", `a\b`, "a_b"},
+		{"space", "Azure DEV", "Azure-DEV"},
+		{"colon", "host:22", "host_22"},
+		{"multiple", "a/b c:d", "a_b-c_d"},
+		{"empty", "", ""},
+		{"no-op ascii", "alphaNumeric_123.txt", "alphaNumeric_123.txt"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sanitize(tc.in)
+			if got != tc.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/notes/engine.go
+++ b/internal/notes/engine.go
@@ -1,0 +1,173 @@
+package notes
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// filenameLayout is the timestamp layout used for note filenames. It
+	// uses "-" in place of ":" so the name is filesystem-safe on all
+	// platforms, plus ".%03d" milliseconds to avoid collisions within the
+	// same second.
+	filenameLayout = "2006-01-02T15-04-05"
+	noteSuffix     = "_note.txt"
+	previewMaxLen  = 80
+)
+
+// Engine provides CRUD operations over notes stored under a base directory.
+// Typical usage: notes.New(appCfg.FleetDir).
+type Engine struct {
+	base string // {fleet_dir}/notes
+}
+
+// New returns an Engine rooted under fleetDir/notes. It does not create the
+// directory — directories are created on demand by Create.
+func New(fleetDir string) *Engine {
+	return &Engine{base: filepath.Join(fleetDir, "notes")}
+}
+
+// Count returns the number of notes stored for the given resource. Returns
+// 0 for non-existent directories.
+func (e *Engine) Count(ref ResourceRef) int {
+	entries, err := os.ReadDir(ref.Dir(e.base))
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(entry.Name(), noteSuffix) {
+			n++
+		}
+	}
+	return n
+}
+
+// List returns all notes for the given resource, sorted newest-first by
+// filename (the filename includes the creation timestamp). A non-existent
+// directory returns (nil, nil) — this is not an error condition.
+func (e *Engine) List(ref ResourceRef) ([]Note, error) {
+	dir := ref.Dir(e.base)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading notes dir: %w", err)
+	}
+
+	notes := make([]Note, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, noteSuffix) {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		created, ok := parseTimestamp(name)
+		if !ok {
+			continue
+		}
+		preview, _ := readPreview(path)
+		notes = append(notes, Note{
+			Path:      path,
+			CreatedAt: created,
+			Preview:   preview,
+		})
+	}
+
+	sort.Slice(notes, func(i, j int) bool {
+		return notes[i].CreatedAt.After(notes[j].CreatedAt)
+	})
+	return notes, nil
+}
+
+// Create creates a new empty note file at the resource's directory and
+// returns its absolute path. The filename is a UTC timestamp with
+// millisecond precision; parent directories are created as needed.
+//
+// The returned path is intended to be opened in the user's editor via the
+// usual terminal-handover flow.
+func (e *Engine) Create(ref ResourceRef) (string, error) {
+	dir := ref.Dir(e.base)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("creating notes dir: %w", err)
+	}
+	name := filename(time.Now().UTC())
+	path := filepath.Join(dir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("creating note file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("closing note file: %w", err)
+	}
+	return path, nil
+}
+
+// Delete removes the given note file. Non-existent files are not an error.
+func (e *Engine) Delete(notePath string) error {
+	if err := os.Remove(notePath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("deleting note: %w", err)
+	}
+	return nil
+}
+
+// filename builds a note filename for the given timestamp.
+// Format: 2006-01-02T15-04-05.123_note.txt
+func filename(t time.Time) string {
+	return fmt.Sprintf("%s.%03d%s", t.Format(filenameLayout), t.Nanosecond()/int(time.Millisecond), noteSuffix)
+}
+
+// parseTimestamp extracts the creation time from a note filename. Returns
+// (_, false) when the filename does not match the expected layout.
+func parseTimestamp(name string) (time.Time, bool) {
+	if !strings.HasSuffix(name, noteSuffix) {
+		return time.Time{}, false
+	}
+	stem := strings.TrimSuffix(name, noteSuffix)
+	// stem = "2006-01-02T15-04-05.123"
+	dot := strings.LastIndex(stem, ".")
+	if dot < 0 {
+		return time.Time{}, false
+	}
+	datePart := stem[:dot]
+	msPart := stem[dot+1:]
+	t, err := time.Parse(filenameLayout, datePart)
+	if err != nil {
+		return time.Time{}, false
+	}
+	var ms int
+	if _, err := fmt.Sscanf(msPart, "%d", &ms); err != nil {
+		return time.Time{}, false
+	}
+	return t.Add(time.Duration(ms) * time.Millisecond), true
+}
+
+// readPreview returns the first non-empty line of the note, truncated.
+func readPreview(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > previewMaxLen {
+			return line[:previewMaxLen] + "\u2026", nil
+		}
+		return line, nil
+	}
+	return "", nil
+}

--- a/internal/notes/engine_test.go
+++ b/internal/notes/engine_test.go
@@ -1,0 +1,342 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestResourceRef_Dir_AllFleetTypes(t *testing.T) {
+	base := "/tmp/fleetdesk/notes"
+	tests := []struct {
+		name string
+		ref  ResourceRef
+		want string
+	}{
+		{
+			"fleet-level",
+			ResourceRef{Fleet: "aap-prod"},
+			"/tmp/fleetdesk/notes/aap-prod",
+		},
+		{
+			"vm-host",
+			ResourceRef{Fleet: "aap-prod", Segments: []string{"hosts", "aap-ctrl-01"}},
+			"/tmp/fleetdesk/notes/aap-prod/hosts/aap-ctrl-01",
+		},
+		{
+			"vm-service",
+			ResourceRef{Fleet: "aap-prod", Segments: []string{"hosts", "aap-ctrl-01", "services", "automation-controller-web"}},
+			"/tmp/fleetdesk/notes/aap-prod/hosts/aap-ctrl-01/services/automation-controller-web",
+		},
+		{
+			"azure-sub",
+			ResourceRef{Fleet: "azure-dev", Segments: []string{"azure", "APP-DEV"}},
+			"/tmp/fleetdesk/notes/azure-dev/azure/APP-DEV",
+		},
+		{
+			"azure-vm",
+			ResourceRef{Fleet: "azure-dev", Segments: []string{"azure", "APP-DEV", "rg-app", "vm", "vm-ctrl-01"}},
+			"/tmp/fleetdesk/notes/azure-dev/azure/APP-DEV/rg-app/vm/vm-ctrl-01",
+		},
+		{
+			"k8s-namespace",
+			ResourceRef{Fleet: "aks-dev", Segments: []string{"k8s", "AKS-APP-DEV-BLUE", "ctx", "default"}},
+			"/tmp/fleetdesk/notes/aks-dev/k8s/AKS-APP-DEV-BLUE/ctx/default",
+		},
+		{
+			"sanitizes-unsafe-chars",
+			ResourceRef{Fleet: "dev / fleet", Segments: []string{"foo:bar", "a b"}},
+			"/tmp/fleetdesk/notes/dev-_-fleet/foo_bar/a-b",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.ref.Dir(base)
+			if got != tc.want {
+				t.Errorf("Dir = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResourceRef_Key_StableAcrossEqualRefs(t *testing.T) {
+	a := ResourceRef{Fleet: "f", Segments: []string{"hosts", "h1"}}
+	b := ResourceRef{Fleet: "f", Segments: []string{"hosts", "h1"}}
+	if a.Key() != b.Key() {
+		t.Errorf("equal refs should have equal keys: %q vs %q", a.Key(), b.Key())
+	}
+
+	c := ResourceRef{Fleet: "f", Segments: []string{"hosts", "h2"}}
+	if a.Key() == c.Key() {
+		t.Errorf("different refs should have different keys: %q == %q", a.Key(), c.Key())
+	}
+}
+
+func TestEngine_Create_WritesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"hosts", "h1"}}
+
+	path, err := e.Create(ref)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("note file should exist: %v", err)
+	}
+	if info.Size() != 0 {
+		t.Errorf("note file should be empty, got %d bytes", info.Size())
+	}
+
+	// Parent dir must be created under <base>/notes/f/hosts/h1
+	expectedDir := filepath.Join(dir, "notes", "f", "hosts", "h1")
+	if filepath.Dir(path) != expectedDir {
+		t.Errorf("note path parent = %q, want %q", filepath.Dir(path), expectedDir)
+	}
+}
+
+func TestEngine_Create_FilenameFormat(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	path, err := e.Create(ref)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	name := filepath.Base(path)
+	if !strings.HasSuffix(name, "_note.txt") {
+		t.Errorf("filename must end with _note.txt, got %q", name)
+	}
+	// Format: 2006-01-02T15-04-05.NNN_note.txt
+	stem := strings.TrimSuffix(name, "_note.txt")
+	if len(stem) != len("2006-01-02T15-04-05.000") {
+		t.Errorf("filename stem length = %d, want %d, stem=%q", len(stem), len("2006-01-02T15-04-05.000"), stem)
+	}
+	if _, ok := parseTimestamp(name); !ok {
+		t.Errorf("parseTimestamp could not re-parse filename %q", name)
+	}
+}
+
+func TestEngine_Create_MillisecondResolution_NoCollision(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	// Create 20 notes as fast as possible; expect unique filenames at ms
+	// resolution. On any reasonable machine, two consecutive os.Create
+	// calls will differ by well under 1ms — if they collide, we get
+	// "file exists" behavior (os.Create truncates). So instead: parse
+	// the timestamps and ensure uniqueness.
+	paths := make(map[string]bool)
+	for range 20 {
+		path, err := e.Create(ref)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if paths[path] {
+			t.Errorf("duplicate path generated: %s", path)
+		}
+		paths[path] = true
+		// Tiny sleep to guarantee ms tick between iterations.
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func TestEngine_List_SortedNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	p1, _ := e.Create(ref)
+	time.Sleep(5 * time.Millisecond)
+	p2, _ := e.Create(ref)
+	time.Sleep(5 * time.Millisecond)
+	p3, _ := e.Create(ref)
+
+	notes, err := e.List(ref)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(notes) != 3 {
+		t.Fatalf("expected 3 notes, got %d", len(notes))
+	}
+	if notes[0].Path != p3 || notes[1].Path != p2 || notes[2].Path != p1 {
+		t.Errorf("notes not sorted newest-first: got %v %v %v (want %v %v %v)",
+			notes[0].Path, notes[1].Path, notes[2].Path, p3, p2, p1)
+	}
+}
+
+func TestEngine_List_MissingDir_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "nonexistent", Segments: []string{"also", "missing"}}
+
+	notes, err := e.List(ref)
+	if err != nil {
+		t.Errorf("List on missing dir should not error, got %v", err)
+	}
+	if len(notes) != 0 {
+		t.Errorf("List on missing dir should return empty, got %d notes", len(notes))
+	}
+}
+
+func TestEngine_Count_MissingDir_ReturnsZero(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "nope"}
+	if n := e.Count(ref); n != 0 {
+		t.Errorf("Count on missing dir = %d, want 0", n)
+	}
+}
+
+func TestEngine_Count_MatchesListLength(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	for range 4 {
+		if _, err := e.Create(ref); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if n := e.Count(ref); n != 4 {
+		t.Errorf("Count = %d, want 4", n)
+	}
+}
+
+func TestEngine_Delete_RemovesFile(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	path, _ := e.Create(ref)
+
+	if err := e.Delete(path); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be gone, stat err = %v", err)
+	}
+}
+
+func TestEngine_Delete_MissingFile_IsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	if err := e.Delete(filepath.Join(dir, "does-not-exist.txt")); err != nil {
+		t.Errorf("Delete on missing file should not error, got %v", err)
+	}
+}
+
+func TestEngine_List_ReadsPreview(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	path, _ := e.Create(ref)
+	if err := os.WriteFile(path, []byte("\n\n  First real line of content  \n\nsecond line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	notes, err := e.List(ref)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(notes))
+	}
+	if notes[0].Preview != "First real line of content" {
+		t.Errorf("preview = %q, want 'First real line of content'", notes[0].Preview)
+	}
+}
+
+func TestEngine_List_PreviewTruncates(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	path, _ := e.Create(ref)
+	longLine := strings.Repeat("x", previewMaxLen+20)
+	if err := os.WriteFile(path, []byte(longLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	notes, _ := e.List(ref)
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(notes))
+	}
+	if !strings.HasSuffix(notes[0].Preview, "\u2026") {
+		t.Errorf("preview should end with ellipsis for long lines, got %q", notes[0].Preview)
+	}
+	if len(notes[0].Preview) > previewMaxLen+5 {
+		t.Errorf("preview should be truncated to ~%d chars, got %d", previewMaxLen, len(notes[0].Preview))
+	}
+}
+
+func TestEngine_List_EmptyFile_EmptyPreview(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	_, _ = e.Create(ref)
+
+	notes, _ := e.List(ref)
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d", len(notes))
+	}
+	if notes[0].Preview != "" {
+		t.Errorf("empty file should have empty preview, got %q", notes[0].Preview)
+	}
+}
+
+func TestEngine_List_IgnoresNonNoteFiles(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	ref := ResourceRef{Fleet: "f", Segments: []string{"h"}}
+
+	_, _ = e.Create(ref)
+
+	// Drop a stray file in the same directory.
+	noteDir := ref.Dir(e.base)
+	if err := os.WriteFile(filepath.Join(noteDir, "something.txt"), []byte("not a note"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	notes, _ := e.List(ref)
+	if len(notes) != 1 {
+		t.Errorf("expected 1 note (the stray file should be ignored), got %d", len(notes))
+	}
+}
+
+func TestParseTimestamp_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 4, 18, 9, 15, 30, 123_000_000, time.UTC)
+	name := filename(now)
+	parsed, ok := parseTimestamp(name)
+	if !ok {
+		t.Fatalf("parseTimestamp(%q) = false", name)
+	}
+	if !parsed.Equal(now) {
+		t.Errorf("round-trip mismatch: got %v, want %v", parsed, now)
+	}
+}
+
+func TestParseTimestamp_InvalidInputs(t *testing.T) {
+	cases := []string{
+		"not-a-note.log",
+		"garbage_note.txt",
+		"abc.123_note.txt",
+		"2026-04-18T09-15-00_note.txt", // missing milliseconds
+	}
+	for _, c := range cases {
+		if _, ok := parseTimestamp(c); ok {
+			t.Errorf("parseTimestamp(%q) should be false", c)
+		}
+	}
+}

--- a/internal/notes/types.go
+++ b/internal/notes/types.go
@@ -1,0 +1,65 @@
+// Package notes provides a file-based note storage engine.
+// Notes are plain text files stored at
+// {fleet_dir}/notes/{fleet}/{segments...}/{timestamp}_note.txt
+// and associated with resources (hosts, services, containers, VMs,
+// AKS clusters, K8s namespaces/workloads/pods, fleets themselves).
+package notes
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Gaetan-Jaminon/fleetdesk/internal/fspath"
+)
+
+// ResourceRef identifies a resource within a fleet by stable name-based path.
+// Segments are joined under the fleet name to form a directory, with each
+// component sanitized for filesystem safety.
+//
+// Examples:
+//
+//	{Fleet: "aap-prod", Segments: ["hosts", "aap-ctrl-01", "services", "automation-controller-web"]}
+//	{Fleet: "azure-dev", Segments: ["azure", "APP-DEV", "rg-app", "vm", "vm-ctrl-01"]}
+//	{Fleet: "aks-dev", Segments: ["k8s", "AKS-APP-DEV-BLUE", "ctx-aks-dev-blue", "default", "nginx"]}
+//	{Fleet: "aap-prod", Segments: nil} // fleet-level notes
+type ResourceRef struct {
+	Fleet    string
+	Segments []string
+}
+
+// Dir returns the absolute directory path for this resource's notes, rooted
+// under the provided base (typically fleet_dir/notes). Each segment is
+// sanitized via fspath.Sanitize.
+func (r ResourceRef) Dir(base string) string {
+	parts := make([]string, 0, len(r.Segments)+2)
+	parts = append(parts, base, fspath.Sanitize(r.Fleet))
+	for _, seg := range r.Segments {
+		parts = append(parts, fspath.Sanitize(seg))
+	}
+	return filepath.Join(parts...)
+}
+
+// Key returns a stable, compact string suitable for use as a map key (e.g.
+// for caching note counts in the UI). Two refs with equal Fleet and equal
+// Segments produce the same Key.
+func (r ResourceRef) Key() string {
+	var b strings.Builder
+	b.WriteString(r.Fleet)
+	for _, seg := range r.Segments {
+		b.WriteString("/")
+		b.WriteString(seg)
+	}
+	return b.String()
+}
+
+// Note represents a single persisted note.
+type Note struct {
+	// Path is the absolute path to the note file.
+	Path string
+	// CreatedAt is parsed from the timestamped filename (UTC).
+	CreatedAt time.Time
+	// Preview is the first non-empty line of the note, truncated to a
+	// reasonable length for display in list views.
+	Preview string
+}


### PR DESCRIPTION
## Summary

Bundled PR delivering v0.15.0 Team Notes — persistent plain-text notes attached to any resource across VM, Azure, and Kubernetes fleets — plus the two prerequisites it depends on.

**Supersedes #102** (orphaned by branch rename).

## Commits

| Commit | FLE | Scope |
|--------|-----|-------|
| `ca2f8ac` | FLE-80 | Adopt `teatest` + baseline UI tests |
| `4255f16` | FLE-81 | Shared list renderer, 10 views migrated |
| `a4976c8` | FLE-77 | `internal/fspath/` + `internal/notes/` packages + CRUD |
| `9b234ac` | FLE-78 | `n` key, Note List + Note Read views, editor/delete flows |
| `0507194` | FLE-79 | 📝 indicators on resource list views via `RowPrefix` |

## Feature walkthrough

- Press `n` on any resource list (host, service, container, Azure sub / VM / AKS, K8s cluster / namespace / workload / pod, or the fleet picker) → scoped Note List opens.
- `n` inside Note List → editor handover opens an empty timestamped file. On exit, empty files are cleaned up.
- `Enter` → full-screen scrollable read view.
- `e` → edit in editor.
- `d` → confirm modal, then delete.
- `/` → filter notes by preview.
- `Esc` → back to the originating list.
- Resources with notes show a 📝 prefix in the list, kept fresh on startup, on every tick, and after any CRUD within the session.

## Storage

Notes live at `{fleet_dir}/notes/{fleet}/{resource-segments...}/2026-04-18T09-15-00.123_note.txt` — UTC timestamp with ms resolution to avoid collisions. Resource paths mirror navigation: `hosts/<h>/services/<s>`, `azure/<sub>/<rg>/vm/<n>`, `k8s/<cluster>/<ctx>/<ns>/pods/<p>`, etc.

## Architecture notes

- One-time exception to the one-PR-per-FLE rule — the five issues form a single cohesive feature slice with no independent user value.
- `internal/fspath/` and `internal/notes/` are pure logic (no Bubble Tea), matching the `internal/ssh`, `internal/azure`, `internal/k8s` discipline.
- FLE-81's shared renderer is the integration point for FLE-79's indicators — adding 📝 support was one line per view, not a rewrite.
- `view_azure_aks.go` intentionally stays on its bespoke renderer (dynamic tag columns + raw ANSI coloring). No note indicator on AKS list in v0.15.0 — deferred if demand shows up.

## Tests

49 new tests across:
- Unit: 8 `fspath` + 19 `notes` engine + 12 `renderList` = 39
- UI (teatest): 2 baseline + 3 renderer parity + 4 note flow + 1 indicator = 10

`go test ./... -race` passes. `go build` passes.
Lint fails with a pre-existing Go toolchain mismatch (golangci-lint built against go1.24, repo targets go1.25.7) — unrelated to this change.

Closes FLE-77, FLE-78, FLE-79, FLE-80, FLE-81.