### PR TITLE
fix(subscription): per-repo dnf makecache + Check Repo action (FLE-82)

### DIFF
--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -595,7 +595,24 @@ func (m Model) fetchSubscription() func() tea.Msg {
 	return func() tea.Msg {
 		start := time.Now()
 		logger.Debug("fetch start", "view", "subscription", "host_idx", idx)
-		cmd := `echo '===IDENTITY===' && sudo subscription-manager identity 2>&1 && echo '===STATUS===' && sudo subscription-manager status 2>&1 && echo '===SERVER===' && sudo subscription-manager config --list 2>&1 | grep 'hostname' | head -1 && echo '===REPOS===' && dnf repolist --enabled 2>&1 && echo '===REPOCHECK===' && for repo in $(dnf repolist --enabled -q 2>/dev/null | tail -n+2 | awk '{print $1}'); do (echo "REPO:$repo:$(dnf repoinfo --disablerepo='*' --enablerepo=$repo 2>&1 | grep -c 'Error:')") & done; wait`
+		// Repo health check: per-repo `dnf makecache --refresh --repo=<id>` with
+		// bounded parallelism (4 concurrent). Each repo's status is dnf's exit
+		// code — same source of truth used by the per-repo "Check Repo" UI action,
+		// so the list and the inspector cannot disagree.
+		//
+		// We can't use a single all-repos `dnf makecache --refresh` because dnf
+		// stops emitting per-repo error blocks after the first failure (only the
+		// first failing repo is reported, the rest go silent — even if they also
+		// fail). That under-counts failures.
+		cmd := `echo '===IDENTITY===' && sudo subscription-manager identity 2>&1 && ` +
+			`echo '===STATUS===' && sudo subscription-manager status 2>&1 && ` +
+			`echo '===SERVER===' && sudo subscription-manager config --list 2>&1 | grep 'hostname' | head -1 && ` +
+			`echo '===REPOS===' && dnf repolist --enabled 2>&1 && ` +
+			`echo '===REPOCHECK===' && ` +
+			`i=0; for repo in $(dnf repolist --enabled -q 2>/dev/null | tail -n+2 | awk '{print $1}'); do ` +
+			`( sudo dnf makecache --refresh --repo="$repo" >/dev/null 2>&1; echo "REPO:$repo:$?" ) & ` +
+			`i=$((i+1)); [ $((i % 4)) -eq 0 ] && wait; ` +
+			`done; wait`
 		out, err := sm.RunSudoCommand(idx, cmd)
 		// Check for sudo password prompt only when no sudo password is cached.
 		// When cached, the rewritten command's "echo pw | sudo -S" still outputs

--- a/internal/app/help.go
+++ b/internal/app/help.go
@@ -246,6 +246,7 @@ func helpSubscription() string {
 	}) + "\n" + helpSection("Actions", [][]string{
 		{"u", "Unregister"},
 		{"g", "Register"},
+		{"c", "Check repo (run dnf makecache --refresh on selected repo)"},
 		{"d", "Disable repo"},
 		{"r", "Refresh"},
 	}) + "\n" + globalHelp(false)

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -1113,6 +1113,28 @@ func (m Model) handleSubscriptionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					sshHandover(h, []string{cmd}, banner))
 			}
 		}
+	case "c":
+		if len(m.subscriptions) > 0 {
+			sub := m.subscriptions[m.subscriptionCursor]
+			if strings.HasPrefix(sub.Field, "Repo: ") {
+				repoID := strings.TrimPrefix(sub.Field, "Repo: ")
+				// Redirect dnf's stderr to stdout *inline*. The sudo rewrite adds
+				// `sudo -S 2>/dev/null` to suppress the password prompt, and dnf
+				// inherits that /dev/null on fd 2 — so without our own `2>&1` after
+				// the dnf args, all error lines vanish. Capture dnf's exit into $rc
+				// before any subsequent command can stomp on $?.
+				cmd := fmt.Sprintf("sudo dnf makecache --refresh --repo='%s' 2>&1; rc=$?; echo; echo \"--- exit: $rc\"", shellQuote(repoID))
+				return m, m.startSSHStream(SSHStreamConfig{
+					Command:    cmd,
+					Title:      "Check repo " + repoID,
+					SourceName: "check-" + repoID,
+					ReturnView: viewSubscription,
+					HostIdx:    m.selectedHost,
+					Sudo:       true,
+					AutoDone:   true,
+				})
+			}
+		}
 	case "r":
 		m.subscriptions = nil
 		showLoading(&m, "subscription", "Loading subscription...")

--- a/internal/app/subscription_actions_test.go
+++ b/internal/app/subscription_actions_test.go
@@ -243,4 +243,55 @@ func TestSubscriptionHintBar(t *testing.T) {
 			t.Error("hint bar missing Register Satellite")
 		}
 	})
+
+	t.Run("hint bar advertises Check Repo", func(t *testing.T) {
+		m := subscriptionModel("Satellite")
+		rendered := m.renderSubscription()
+		if !strings.Contains(rendered, "Check Repo") {
+			t.Error("hint bar missing Check Repo")
+		}
+	})
+}
+
+// --- Check Repo (c key) ---
+
+func TestCheckRepoAction(t *testing.T) {
+	t.Run("c on a Repo entry switches to ssh stream view", func(t *testing.T) {
+		m := subscriptionModel("Satellite",
+			config.Subscription{Field: "Repo: rhel-9-for-x86_64-baseos-rpms", Value: "ERROR"},
+		)
+		// cursor on the Repo entry (Registration is index 0, Repo is index 1)
+		m.subscriptionCursor = 1
+
+		result, cmd := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+		m2 := result.(Model)
+
+		if cmd == nil {
+			t.Fatal("expected non-nil cmd from check repo")
+		}
+		if m2.view != viewSSHStream {
+			t.Errorf("view = %v, want viewSSHStream", m2.view)
+		}
+		if !strings.Contains(m2.streamTitle, "rhel-9-for-x86_64-baseos-rpms") {
+			t.Errorf("streamTitle = %q, want it to include the repo id", m2.streamTitle)
+		}
+		if m2.streamReturnView != viewSubscription {
+			t.Errorf("streamReturnView = %v, want viewSubscription", m2.streamReturnView)
+		}
+	})
+
+	t.Run("c on non-Repo entry is a no-op", func(t *testing.T) {
+		m := subscriptionModel("Satellite") // only Registration entry, no Repo
+		m.subscriptionCursor = 0
+
+		result, cmd := m.handleSubscriptionKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+		m2 := result.(Model)
+
+		if cmd != nil {
+			t.Error("expected nil cmd when cursor is not on a Repo entry")
+		}
+		if m2.view == viewSSHStream {
+			t.Error("view should not switch when not on a Repo entry")
+		}
+	})
 }

--- a/internal/app/view_subscription.go
+++ b/internal/app/view_subscription.go
@@ -81,6 +81,7 @@ func (m Model) renderSubscription() string {
 		{"↑↓", "Navigate"},
 		{"u", "Unregister"},
 		{"g", regTarget},
+		{"c", "Check Repo"},
 		{"d", "Disable Repo"},
 		{"r", "Refresh"},
 		{"Esc", "Back"},


### PR DESCRIPTION
## Summary

Closes [FLE-82](https://linear.app/fleetdesk/issue/FLE-82/subscription-view-baseosappstreamcrb-flagged-error-false-positive-from).

Two related changes to the Subscription view:

1. **`fix(subscription)`** — Replace the all-repos `dnf makecache --refresh` + sed parsing with per-repo `dnf makecache --refresh --repo=<id>` (bounded parallelism = 4). The single all-repos call only emits the *first* failing repo and goes silent on the rest, so a host with three broken repos was reported as having one. Per-repo uses dnf's exit code as the source of truth and matches what the new "Check Repo" action shows.

2. **`feat(subscription)`** — New `c` (Check Repo) action: with the cursor on a `Repo: <id>` entry, press `c` to run `sudo dnf makecache --refresh --repo=<id>` against that single repo via the existing SSH stream view. The full dnf output (including 404 / GPG / cert details) streams in real time, ending with `--- exit: <n>`. Esc returns to the Subscription view.

## Real-world impact

Validated against `flxautomationctldev01` (Satellite-registered):

- **Before:** view reported only `rhel-9-for-x86_64-baseos-rpms` as ERROR.
- **After:** view correctly reports `baseos`, `appstream`, **and** `codeready-builder` as ERROR — confirmed by per-repo CLI runs and Pulp HTTP probes (404 with valid entitlement cert in Development env, 403 in other envs → distribution missing in Pulp for those three repos in Development).

A separate Satellite-side action is needed (republish CV `FLX-RHEL9-RHAAP` v61.0); that's tracked outside this PR.

## Test plan

- `make build` — passes
- `make test` — all unit tests pass, including 3 new tests for the Check Repo action and hint bar
- Manual: Subscription view shows ERROR for the three broken RHEL repos, OK for the eight working ones; pressing `c` on a broken repo streams the 404 details and `--- exit: 1`; pressing `c` on a healthy repo streams success and `--- exit: 0`

## Trade-offs

- Subscription fetch grows ~3.5s → ~6s on a 10-repo host. Acceptable for an interactive view; correctness wins.
- Bounded concurrency at 4 prevents rpmdb lock contention seen with the original unbounded-parallel approach.